### PR TITLE
refactor: normalize response status constants

### DIFF
--- a/app/Core/Api.php
+++ b/app/Core/Api.php
@@ -68,7 +68,7 @@ use App\Core\Response;
             $this->method = match ($_SERVER['HTTP_X_HTTP_METHOD']) {
                 'DELETE' => 'DELETE',
                 'PUT' => 'PUT',
-                default => self::response(Response::StatusMethodNotAllowed),
+                default => self::response(Response::STATUS_METHOD_NOT_ALLOWED),
             };
         }
 
@@ -138,7 +138,7 @@ use App\Core\Response;
             $this->method = match ($_SERVER['HTTP_X_HTTP_METHOD']) {
                 'DELETE' => 'DELETE',
                 'PUT' => 'PUT',
-                default => self::response(Response::StatusMethodNotAllowed),
+                default => self::response(Response::STATUS_METHOD_NOT_ALLOWED),
             };
         }
 

--- a/app/Core/Response.php
+++ b/app/Core/Response.php
@@ -6,19 +6,19 @@ class Response
     const STATUS_OK = 200;
 
     const STATUS_BAD_REQUEST = 400;
-    const StatusUnauthorized = 401;
-    const StatusForbidden = 403;
-    const StatusNotFound = 404;
+    const STATUS_UNAUTHORIZED = 401;
+    const STATUS_FORBIDDEN = 403;
+    const STATUS_NOT_FOUND = 404;
     const STATUS_METHOD_NOT_ALLOWED = 405;
-    const StatusConflict = 409;
-    const StatusRequestEntityTooLarge = 413;
-    const StatusSubscriptionPlanLimit = 441;
-    const StatusEmailAlreadyExists = 442;
-    const StatusFreeTrialFinished = 443;
-    const StatusModelCreationLimit = 445;
-    const StatusApiRateLimitExceeded = 429;
+    const STATUS_CONFLICT = 409;
+    const STATUS_REQUEST_ENTITY_TOO_LARGE = 413;
+    const STATUS_SUBSCRIPTION_PLAN_LIMIT = 441;
+    const STATUS_EMAIL_ALREADY_EXISTS = 442;
+    const STATUS_FREE_TRIAL_FINISHED = 443;
+    const STATUS_MODEL_CREATION_LIMIT = 445;
+    const STATUS_API_RATE_LIMIT_EXCEEDED = 429;
     const STATUS_INTERNAL_SERVER_ERROR = 500;
-    const StatusNotImplemented = 501;
+    const STATUS_NOT_IMPLEMENTED = 501;
 
     public static $imageTypes = [
         'image/jpeg',


### PR DESCRIPTION
## Summary
- rename Response status constants to uppercase snake case
- update API references to new constant names

## Testing
- `php -l app/Core/Response.php`
- `php -l app/Core/Api.php`
- `composer test` *(fails: Command "test" is not defined.)*

------
https://chatgpt.com/codex/tasks/task_e_689b5a32144c83298fd898ea43ce2100