### PR TITLE
Encapsulate Context dependencies with private getters

### DIFF
--- a/app/Controllers/OAuthController.php
+++ b/app/Controllers/OAuthController.php
@@ -97,7 +97,7 @@ class OAuthController extends Controller {
                 $inserted = $merchantService->upsertStores($stores);
 
                 if (!$inserted) {
-                    $this->context->log->error('Failed to insert stores for new merchant.');
+                    $this->context->getLog()->error('Failed to insert stores for new merchant.');
                     // TODO?
                     return;
                 }

--- a/app/Controllers/WebhooksController.php
+++ b/app/Controllers/WebhooksController.php
@@ -31,7 +31,7 @@ class WebhooksController extends Controller
 
         $payload = $this->api->data ?? [];
         $info = json_encode($payload, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
-        $this->context->log->info("Webhook info: " . $info);
+        $this->context->getLog()->info("Webhook info: " . $info);
 
         // Determine the event type from the payload.
         $eventType = $payload['eventType'] ?? null;

--- a/app/Core/Context.php
+++ b/app/Core/Context.php
@@ -2,16 +2,34 @@
 
 namespace App\Core;
 
+use Doctrine\DBAL\Connection;
+use Monolog\Logger;
+
 class Context
 {
-    public $api;
-    public $conn;
-    public $log;
+    private Api $api;
+    private Connection $conn;
+    private Logger $log;
 
-    public function __construct($api, $conn, $log)
+    public function __construct(Api $api, Connection $conn, Logger $log)
     {
         $this->api = $api;
         $this->conn = $conn;
         $this->log = $log;
+    }
+
+    public function getApi(): Api
+    {
+        return $this->api;
+    }
+
+    public function getConn(): Connection
+    {
+        return $this->conn;
+    }
+
+    public function getLog(): Logger
+    {
+        return $this->log;
     }
 }

--- a/app/Modules/OAuth/PoyntOAuthHandler.php
+++ b/app/Modules/OAuth/PoyntOAuthHandler.php
@@ -42,10 +42,10 @@ class PoyntOAuthHandler {
     public function getMerchantService(): MerchantService {
         if ($this->merchantService === null) {
             $this->merchantService = new MerchantService(
-                $this->context->api,
-                $this->context->conn,
-                $this->context->log,
-                new MerchantFetcher($this->context->log)
+                $this->context->getApi(),
+                $this->context->getConn(),
+                $this->context->getLog(),
+                new MerchantFetcher($this->context->getLog())
             );
         }
         return $this->merchantService;
@@ -70,12 +70,12 @@ class PoyntOAuthHandler {
     public function retrieveTokens(): array
     {
 
-        $this->businessId = $businessId = $this->context->api->getParam('businessId', null);
-        $this->storeId = $storeId = $this->context->api->getParam('store_id', null);
-        $this->code = $code = $this->context->api->getParam('code', null);
+        $this->businessId = $businessId = $this->context->getApi()->getParam('businessId', null);
+        $this->storeId = $storeId = $this->context->getApi()->getParam('store_id', null);
+        $this->code = $code = $this->context->getApi()->getParam('code', null);
 
         if (!$businessId || !$storeId || !$code) {
-            $this->context->log->error("Error: Missing required parameters");
+            $this->context->getLog()->error("Error: Missing required parameters");
             Api::response(Response::STATUS_BAD_REQUEST);
             exit;
         }
@@ -85,11 +85,11 @@ class PoyntOAuthHandler {
         try {
             $appAccessToken = $oauthService->exchangeJwtForToken();
         } catch (\Exception $e) {
-            $this->context->log->error("Error: " . $e->getMessage());
+            $this->context->getLog()->error("Error: " . $e->getMessage());
             Api::response(Response::STATUS_INTERNAL_SERVER_ERROR, ['error' => 'Token exchange failed.']);
             exit;
         } catch (GuzzleException $e) {
-            $this->context->log->error("Error: " . $e->getMessage());
+            $this->context->getLog()->error("Error: " . $e->getMessage());
             Api::response(Response::STATUS_INTERNAL_SERVER_ERROR, ['error' => 'Guzzle exception. Token exchange failed.']);
             exit;
         }
@@ -97,11 +97,11 @@ class PoyntOAuthHandler {
         try {
             $merchantAccessToken = $oauthService->exchangeAuthCodeForMerchantToken($code, ConfigApp::$redirectUri);
         } catch (\Exception $e) {
-            $this->context->log->error("Error: " . $e->getMessage());
+            $this->context->getLog()->error("Error: " . $e->getMessage());
             Api::response(Response::STATUS_INTERNAL_SERVER_ERROR, ['error' => 'Token exchange failed.']);
             exit;
         } catch (GuzzleException $e) {
-            $this->context->log->error("Error: " . $e->getMessage());
+            $this->context->getLog()->error("Error: " . $e->getMessage());
             Api::response(Response::STATUS_INTERNAL_SERVER_ERROR, ['error' => 'Guzzle exception. Token exchange failed.']);
             exit;
         }
@@ -183,11 +183,11 @@ class PoyntOAuthHandler {
      */
     public function getTokenResponse(): mixed
     {
-        $this->businessId = $businessId = $this->context->api->getParam('businessId', null);
-        $this->storeId = $storeId = $this->context->api->getParam('store_id', null);
+        $this->businessId = $businessId = $this->context->getApi()->getParam('businessId', null);
+        $this->storeId = $storeId = $this->context->getApi()->getParam('store_id', null);
 
         if (!$businessId || !$storeId) {
-            $this->context->log->error("Error: Missing required parameters");
+            $this->context->getLog()->error("Error: Missing required parameters");
             Api::response(Response::STATUS_BAD_REQUEST);
             exit;
         }
@@ -197,11 +197,11 @@ class PoyntOAuthHandler {
             $oauthService = new OAuthService($this->context);
             return $oauthService->exchangeJwtForToken();
         } catch (\Exception $e) {
-            $this->context->log->error("Error: " . $e->getMessage());
+            $this->context->getLog()->error("Error: " . $e->getMessage());
             Api::response(Response::STATUS_INTERNAL_SERVER_ERROR, ['error' => 'Token exchange failed.']);
             exit;
         } catch (GuzzleException $e) {
-            $this->context->log->error("Error: " . $e->getMessage());
+            $this->context->getLog()->error("Error: " . $e->getMessage());
             Api::response(Response::STATUS_INTERNAL_SERVER_ERROR, ['error' => 'Guzzle exception. Token exchange failed.']);
             exit;
         }
@@ -212,12 +212,12 @@ class PoyntOAuthHandler {
      */
     public function getMerchantTokenResponse(): mixed
     {
-        $this->businessId = $businessId = $this->context->api->getParam('businessId', null);
-        $this->storeId = $storeId = $this->context->api->getParam('store_id', null);
-        $this->code = $code = $this->context->api->getParam('code', null);
+        $this->businessId = $businessId = $this->context->getApi()->getParam('businessId', null);
+        $this->storeId = $storeId = $this->context->getApi()->getParam('store_id', null);
+        $this->code = $code = $this->context->getApi()->getParam('code', null);
 
         if (!$businessId || !$storeId || !$code) {
-            $this->context->log->error("Error: Missing required parameters");
+            $this->context->getLog()->error("Error: Missing required parameters");
             Api::response(Response::STATUS_BAD_REQUEST);
             exit;
         }
@@ -227,11 +227,11 @@ class PoyntOAuthHandler {
             $oauthService = new OAuthService($this->context);
             return $oauthService->exchangeAuthCodeForMerchantToken($code, ConfigApp::$redirectUri);
         } catch (\Exception $e) {
-            $this->context->log->error("Error: " . $e->getMessage());
+            $this->context->getLog()->error("Error: " . $e->getMessage());
             Api::response(Response::STATUS_INTERNAL_SERVER_ERROR, ['error' => 'Token exchange failed.']);
             exit;
         } catch (GuzzleException $e) {
-            $this->context->log->error("Error: " . $e->getMessage());
+            $this->context->getLog()->error("Error: " . $e->getMessage());
             Api::response(Response::STATUS_INTERNAL_SERVER_ERROR, ['error' => 'Guzzle exception. Token exchange failed.']);
             exit;
         }
@@ -279,7 +279,7 @@ class PoyntOAuthHandler {
             // Fetch merchant business
             if (!$merchantBusiness = $this->getMerchantService()->fetchMerchantBusinessById($tokenResponse['accessToken'], $this->businessId)) {
 //            if (!$merchantBusiness = $this->getMerchantService()->fetchMerchantBusiness($tokenResponse['accessToken'], $this->businessId)) {
-                $this->context->log->error("Error: Failed to fetch merchant business");
+                $this->context->getLog()->error("Error: Failed to fetch merchant business");
                 Api::response(Response::STATUS_INTERNAL_SERVER_ERROR, ['error' => 'Failed to fetch merchant business.']);
                 return false;
             } else {
@@ -299,7 +299,7 @@ class PoyntOAuthHandler {
         if (HelperService::validateTokenResponse($tokenResponse)) {
             // Fetch merchant business
             if (!$merchantBusiness = $this->getMerchantService()->fetchMerchantBusiness($tokenResponse['accessToken'])) {
-                $this->context->log->error("Error: Failed to fetch merchant business");
+                $this->context->getLog()->error("Error: Failed to fetch merchant business");
                 Api::response(Response::STATUS_INTERNAL_SERVER_ERROR, ['error' => 'Failed to fetch merchant business.']);
                 return false;
             } else {
@@ -321,7 +321,7 @@ class PoyntOAuthHandler {
             $subscription = $this->getMerchantService()->fetchMerchantSubscription($tokenResponse['accessToken'], $this->businessId);
 
             if (!$subscription) {
-                $this->context->log->error("Error: Failed to fetch subscription details.");
+                $this->context->getLog()->error("Error: Failed to fetch subscription details.");
                 return false;
             }
             return $subscription;
@@ -344,7 +344,7 @@ class PoyntOAuthHandler {
             $appSubscriptionPlans = $this->getMerchantService()->fetchApplicationSubscriptionPlans($tokenResponse['accessToken']);
 
             if (!$appSubscriptionPlans) {
-                $this->context->log->error("Error: Failed to fetch subscription plans.");
+                $this->context->getLog()->error("Error: Failed to fetch subscription plans.");
                 return false;
             }
             return $appSubscriptionPlans;
@@ -367,7 +367,7 @@ class PoyntOAuthHandler {
             $subscription = $this->getMerchantService()->createOrUpdateSubscription($tokenResponse['accessToken'], $businessId, $planId);
 
             if (!$subscription) {
-                $this->context->log->error("Error: Failed to create or update subscription.");
+                $this->context->getLog()->error("Error: Failed to create or update subscription.");
                 return false;
             }
             return $subscription;
@@ -387,7 +387,7 @@ class PoyntOAuthHandler {
             $subscriptionDeleted = $this->getMerchantService()->deleteSubscription($tokenResponse['accessToken'], $subscriptionId);
 
             if(!$subscriptionDeleted) {
-                $this->context->log->error("Error: Failed to delete subscription.");
+                $this->context->getLog()->error("Error: Failed to delete subscription.");
                 return false;
             }
             return $subscriptionDeleted;
@@ -412,7 +412,7 @@ class PoyntOAuthHandler {
     {
         if (HelperService::validateTokenResponse($tokenResponse)) {
             if (!$merchantOrders = $this->getMerchantService()->fetchMerchantOrders($tokenResponse['accessToken'], $this->businessId)) {
-                $this->context->log->error("Error: Failed to fetch merchant orders");
+                $this->context->getLog()->error("Error: Failed to fetch merchant orders");
                 Api::response(Response::STATUS_INTERNAL_SERVER_ERROR, ['error' => 'Failed to fetch merchant details.']);
                 exit;
             } else {
@@ -432,11 +432,11 @@ class PoyntOAuthHandler {
     public function saveMerchantData(array $merchantData) : bool
     {
         if (!$saved = $this->getMerchantService()->saveMerchant($merchantData, $this->storeId, $this->tokenResponse)) {
-            $this->context->log->error("Error: Failed to save merchant details");
+            $this->context->getLog()->error("Error: Failed to save merchant details");
             Api::response(Response::STATUS_INTERNAL_SERVER_ERROR, ['error' => 'Failed to save merchant details.']);
             return false;
         }
-        $this->context->log->info('Merchant data saved successfully.');
+        $this->context->getLog()->info('Merchant data saved successfully.');
         return true;
 
 //

--- a/app/Services/MerchantService.php
+++ b/app/Services/MerchantService.php
@@ -57,7 +57,7 @@ class MerchantService {
     {
         // 1) Validate required keys
         if (!isset($merchantData['id'], $merchantData['legalName'])) {
-            $this->context->log->error(
+            $this->context->getLog()->error(
                 'MerchantService::upsert: missing required merchantData fields (id or legalName)'
             );
             return false;
@@ -72,7 +72,7 @@ class MerchantService {
         // 2) Prepare the full payload as JSON for the metadata column
         $metadata = json_encode($merchantData);
         if ($metadata === false) {
-            $this->context->log->error(
+            $this->context->getLog()->error(
                 "MerchantService::upsert: failed to json_encode merchantData for business_id={$businessId}"
             );
             return false;
@@ -83,14 +83,14 @@ class MerchantService {
 
         try {
             // 4) See if a business row with this business_id already exists
-            $existing = $this->context->conn->fetchAssociative(
+            $existing = $this->context->getConn()->fetchAssociative(
                 'SELECT business_id FROM business WHERE business_id = ?',
                 [$businessId]
             );
 
             if ($existing) {
                 // 5a) UPDATE path (include 'active' here)
-                $this->context->conn->update(
+                $this->context->getConn()->update(
                     'business',
                     [
                         'name' => $name,
@@ -101,10 +101,10 @@ class MerchantService {
                     ['business_id' => $businessId]
                 );
 
-                $this->context->log->info("MerchantService::upsert: updated business {$businessId}");
+                $this->context->getLog()->info("MerchantService::upsert: updated business {$businessId}");
             } else {
                 // 5b) INSERT path (include 'active' here, too)
-                $this->context->conn->insert(
+                $this->context->getConn()->insert(
                     'business',
                     [
                         'business_id' => $businessId,
@@ -116,12 +116,12 @@ class MerchantService {
                     ]
                 );
 
-                $this->context->log->info("MerchantService::upsert: inserted new business {$businessId}");
+                $this->context->getLog()->info("MerchantService::upsert: inserted new business {$businessId}");
             }
 
             return true;
         } catch (\Throwable $e) {
-            $this->context->log->error(
+            $this->context->getLog()->error(
                 "MerchantService::upsert: database error for business_id={$businessId}: "
                 . $e->getMessage()
             );
@@ -154,7 +154,7 @@ class MerchantService {
             $data = json_decode($response->getBody(), true);
             return $data ?? false; // Assuming 'business' contains the merchant details
         } catch (GuzzleException $e) {
-            $this->context->log->error("Error fetching merchant details: " . $e->getMessage());
+            $this->context->getLog()->error("Error fetching merchant details: " . $e->getMessage());
             return false;
         }
 
@@ -183,7 +183,7 @@ class MerchantService {
         SELECT * FROM business WHERE business_id = ?
         SQL;
 
-        $success = $this->context->conn->fetchAssociative($sql, [$businessId]);
+        $success = $this->context->getConn()->fetchAssociative($sql, [$businessId]);
 
         if (is_array($success)) {
             return true;
@@ -219,7 +219,7 @@ class MerchantService {
             $data = json_decode($response->getBody(), true);
             return $data ?? []; // Assuming 'business' contains the merchant details
         } catch (GuzzleException $e) {
-            $this->context->log->error("Error fetching merchant details: " . $e->getMessage());
+            $this->context->getLog()->error("Error fetching merchant details: " . $e->getMessage());
             return [];
         }
     }
@@ -236,7 +236,7 @@ class MerchantService {
 
         // TODO ask GPT is there a way to upsert in this format(DBALL)
         /**
-         * $this->context->conn->insert('webhook_audit', [
+         * $this->context->getConn()->insert('webhook_audit', [
          * 'event_type'    => 'WEBHOOK_REGISTRATION',
          * 'payload'       => json_encode($payload),
          * 'headers'       => json_encode($e->hasResponse() ? $e->getResponse()->getHeaders() : []),
@@ -257,7 +257,7 @@ class MerchantService {
         SQL;
 
         try {
-            $stmt = $this->context->conn->prepare($sql);
+            $stmt = $this->context->getConn()->prepare($sql);
 
             $now = (new \DateTime('now'))->format('Y-m-d H:i:sP');
 
@@ -265,7 +265,7 @@ class MerchantService {
                 if (
                     !isset($store['id'], $store['businessId'], $store['displayName'])
                 ) {
-                    $this->context->log->error(
+                    $this->context->getLog()->error(
                         'MerchantService::insertStores: missing required store fields '
                         . '(id, businessId, or displayName)'
                     );
@@ -278,7 +278,7 @@ class MerchantService {
 
                 $metadata = json_encode($store);
                 if ($metadata === false) {
-                    $this->context->log->error(
+                    $this->context->getLog()->error(
                         "MerchantService::insertStores: failed to json_encode store for store_id={$storeId}"
                     );
                     return false;
@@ -296,7 +296,7 @@ class MerchantService {
 
             return true;
         } catch (\Throwable $e) {
-            $this->context->log->error(
+            $this->context->getLog()->error(
                 "MerchantService::insertStores: database error while inserting/updating stores: "
                 . $e->getMessage()
             );

--- a/app/Services/OAuthService.php
+++ b/app/Services/OAuthService.php
@@ -47,14 +47,14 @@ class OAuthService {
         $privateKeyPath = $basePath . DIRECTORY_SEPARATOR . 'private-key.pem';
 
         if (!file_exists($privateKeyPath)) {
-            $this->context->log->warning('Private key file not found');
+            $this->context->getLog()->warning('Private key file not found');
             exit;
         }
 
         $privateKey = file_get_contents($privateKeyPath);
 
         if ($privateKey === false) {
-            $this->context->log->warning('Failed to read private key file');
+            $this->context->getLog()->warning('Failed to read private key file');
         }
 
         // 1. Generate JWT
@@ -90,9 +90,9 @@ class OAuthService {
         } catch (RequestException $e) {
             if ($e->hasResponse()) {
                 $errorResponse = $e->getResponse()->getBody()->getContents();
-                $this->context->log->error("Error: " . $errorResponse);
+                $this->context->getLog()->error("Error: " . $errorResponse);
             } else {
-                $this->context->log->error("Error: " . $e->getMessage());
+                $this->context->getLog()->error("Error: " . $e->getMessage());
             }
         }
 
@@ -111,13 +111,13 @@ class OAuthService {
         $basePath = dirname(__DIR__, 2);
         $privateKeyPath = $basePath . DIRECTORY_SEPARATOR . 'private-key.pem';
         if (!file_exists($privateKeyPath)) {
-            $this->context->log->warning('Private key file not found');
+            $this->context->getLog()->warning('Private key file not found');
             exit;
         }
 
         $privateKey = file_get_contents($privateKeyPath);
         if ($privateKey === false) {
-            $this->context->log->warning('Failed to read private key file');
+            $this->context->getLog()->warning('Failed to read private key file');
             exit;
         }
 
@@ -160,9 +160,9 @@ class OAuthService {
         } catch (RequestException $e) {
             if ($e->hasResponse()) {
                 $errorResponse = $e->getResponse()->getBody()->getContents();
-                $this->context->log->error("Error: " . $errorResponse);
+                $this->context->getLog()->error("Error: " . $errorResponse);
             } else {
-                $this->context->log->error("Error: " . $e->getMessage());
+                $this->context->getLog()->error("Error: " . $e->getMessage());
             }
         }
 

--- a/app/Services/SubscriptionService.php
+++ b/app/Services/SubscriptionService.php
@@ -61,11 +61,11 @@ class SubscriptionService
             $msg = $e->hasResponse()
                 ? $e->getResponse()->getBody()->getContents()
                 : $e->getMessage();
-            $this->context->log->error("Error fetching plans: " . $msg);
+            $this->context->getLog()->error("Error fetching plans: " . $msg);
 
             return null;
         } catch (GuzzleException $e) {
-            $this->context->log->error("Error fetching plans: " . $e->getMessage());
+            $this->context->getLog()->error("Error fetching plans: " . $e->getMessage());
             return null;
         }
     }
@@ -125,7 +125,7 @@ class SubscriptionService
         SQL;
 
         try {
-            $this->context->conn->executeStatement($sql, [
+            $this->context->getConn()->executeStatement($sql, [
                 'sub_id' => $subscriptionId,
                 'biz'    => $businessId,
                 'store'  => $storeId,
@@ -138,7 +138,7 @@ class SubscriptionService
                 'cpe'    => $trialEnd->format('Y-m-d H:i:sP'),
             ]);
         } catch (Exception $e) {
-            $this->context->log->error("Failed to insert initial subscription for store_id={$storeId}: " . $e->getMessage() . ". " . (int)$e->getCode() . ". Exception: ". json_encode($e));
+            $this->context->getLog()->error("Failed to insert initial subscription for store_id={$storeId}: " . $e->getMessage() . ". " . (int)$e->getCode() . ". Exception: ". json_encode($e));
         }
 
         return $subscriptionId;
@@ -201,7 +201,7 @@ class SubscriptionService
             $msg = $e->hasResponse()
                 ? $e->getResponse()->getBody()->getContents()
                 : $e->getMessage();
-            $this->context->log->error("Poynt CREATE subscription failed: " . $msg . ". Code: " . $e->getCode() . ". Whole object: ". json_encode($e));
+            $this->context->getLog()->error("Poynt CREATE subscription failed: " . $msg . ". Code: " . $e->getCode() . ". Whole object: ". json_encode($e));
         }
 
         // Overwrite local row (which likely already exists as a “trial”) with Poynt’s data
@@ -246,9 +246,9 @@ class SubscriptionService
             $msg = $e->hasResponse()
                 ? $e->getResponse()->getBody()->getContents()
                 : $e->getMessage();
-            $this->context->log->error("Poynt GET subscription failed: " . $msg . ". Code: " . $e->getCode() . ". Whole object: ". json_encode($e));
+            $this->context->getLog()->error("Poynt GET subscription failed: " . $msg . ". Code: " . $e->getCode() . ". Whole object: ". json_encode($e));
         } catch (GuzzleException $e) {
-            $this->context->log->error("Poynt GET subscription failed: ". json_encode($e));
+            $this->context->getLog()->error("Poynt GET subscription failed: ". json_encode($e));
         }
 
         // Upsert each subscription into local DB
@@ -291,17 +291,17 @@ class SubscriptionService
             $msg = $e->hasResponse()
                 ? $e->getResponse()->getBody()->getContents()
                 : $e->getMessage();
-            $this->context->log->error("Poynt DELETE subscription failed: " . $msg . ". Code: " . $e->getCode() . ". Whole object: ". json_encode($e));
+            $this->context->getLog()->error("Poynt DELETE subscription failed: " . $msg . ". Code: " . $e->getCode() . ". Whole object: ". json_encode($e));
         }
 
         // Remove from local subscription table
         try {
-            $this->context->conn->executeStatement(
+            $this->context->getConn()->executeStatement(
                 "UPDATE subscription SET status = :status, updated_at = :upat WHERE subscription_id = :sub_id",
                 ['sub_id' => $subscriptionId, 'status' => 'canceled', 'upat' => date('Y-m-d H:i:s')]
             );
         } catch (\Exception $e) {
-            $this->context->log->error("Poynt DELETE subscription failed: " . $e->getMessage() . ". Code: " . $e->getCode() . ". Whole object: ". json_encode($e));
+            $this->context->getLog()->error("Poynt DELETE subscription failed: " . $e->getMessage() . ". Code: " . $e->getCode() . ". Whole object: ". json_encode($e));
         }
 
         return $respData;
@@ -387,7 +387,7 @@ class SubscriptionService
         SQL;
 
         try {
-            $this->context->conn->executeStatement($sql, [
+            $this->context->getConn()->executeStatement($sql, [
                 'sub_id'      => $subscriptionId,
                 'biz'         => $businessId,
                 'store'       => $storeId,
@@ -402,7 +402,7 @@ class SubscriptionService
                 'canceledAt'  => $canceledAt,
             ]);
         } catch (\Exception $e) {
-            $this->context->log->error("Failed to upsert local subscription {$subscriptionId}: " . $e->getMessage() . ". Code: " . $e->getCode() . ". Whole object: ". json_encode($e));
+            $this->context->getLog()->error("Failed to upsert local subscription {$subscriptionId}: " . $e->getMessage() . ". Code: " . $e->getCode() . ". Whole object: ". json_encode($e));
         }
     }
 

--- a/app/Services/TokenService.php
+++ b/app/Services/TokenService.php
@@ -11,7 +11,7 @@ use Doctrine\DBAL\Exception;
  * TokenService manages persistence for both app-level tokens (app_token)
  * and merchant-level tokens (merchant_token) in a PostgreSQL database.
  *
- * All DB operations use $this->context->conn and wrap SQL calls in try/catch,
+ * All DB operations use $this->context->getConn() and wrap SQL calls in try/catch,
  * rethrowing as RuntimeException on failure.
  */
 class TokenService {
@@ -58,7 +58,7 @@ class TokenService {
         SQL;
 
         try {
-            $stmt = $this->context->conn->prepare($sql);
+            $stmt = $this->context->getConn()->prepare($sql);
             $stmt->execute([
                 'biz'     => $businessId,
                 'access'  => $token['accessToken'],
@@ -91,7 +91,7 @@ class TokenService {
         SQL;
 
         try {
-            $row = $this->context->conn->fetchAssociative($sql, [
+            $row = $this->context->getConn()->fetchAssociative($sql, [
                 'biz' => $businessId
             ]);
 
@@ -116,7 +116,7 @@ class TokenService {
 //        SQL;
 //
 //        try {
-//            $stmt = $this->context->conn->prepare($sql);
+//            $stmt = $this->context->getConn()->prepare($sql);
 //            $stmt->execute(['biz' => $businessId]);
 //            $row = $stmt->fetch(\PDO::FETCH_ASSOC);
 //
@@ -149,7 +149,7 @@ class TokenService {
         SQL;
 
         try {
-            $stmt = $this->context->conn->prepare($sql);
+            $stmt = $this->context->getConn()->prepare($sql);
             $stmt->execute();
             return $stmt->fetchAll(\PDO::FETCH_ASSOC);
         } catch (\Exception $e) {
@@ -195,7 +195,7 @@ class TokenService {
         SQL;
 
         try {
-            $stmt = $this->context->conn->prepare($sql);
+            $stmt = $this->context->getConn()->prepare($sql);
             $stmt->execute([
                 'biz'     => $businessId,
                 'access'  => $token['accessToken'],
@@ -228,7 +228,7 @@ class TokenService {
         SQL;
 
         try {
-            $row = $this->context->conn->fetchAssociative($sql, [
+            $row = $this->context->getConn()->fetchAssociative($sql, [
                 'biz' => $businessId
             ]);
 
@@ -264,7 +264,7 @@ class TokenService {
         SQL;
 
         try {
-            $stmt = $this->context->conn->prepare($sql);
+            $stmt = $this->context->getConn()->prepare($sql);
             $stmt->execute();
             return $stmt->fetchAll(\PDO::FETCH_ASSOC);
         } catch (\Exception $e) {

--- a/app/Services/WebhookService.php
+++ b/app/Services/WebhookService.php
@@ -61,7 +61,7 @@ class WebhookService
             $responseData = json_decode($response->getBody(), true);
 
             // Insert an audit record for this outgoing registration call
-            $this->context->conn->insert('webhook_audit', [
+            $this->context->getConn()->insert('webhook_audit', [
                 'event_type'    => 'WEBHOOK_REGISTRATION',
                 'payload'       => json_encode($payload),
                 'headers'       => json_encode($response->getHeaders()),
@@ -69,7 +69,7 @@ class WebhookService
                 'error_message' => null,
             ]);
 
-            $this->context->log->info("Webhook registered successfully", $responseData);
+            $this->context->getLog()->info("Webhook registered successfully", $responseData);
             return $responseData;
 
         } catch (RequestException $e) {
@@ -78,7 +78,7 @@ class WebhookService
                 : $e->getMessage();
 
             // Insert an audit record capturing the failure
-            $this->context->conn->insert('webhook_audit', [
+            $this->context->getConn()->insert('webhook_audit', [
                 'event_type'    => 'WEBHOOK_REGISTRATION',
                 'payload'       => json_encode($payload),
                 'headers'       => json_encode($e->hasResponse() ? $e->getResponse()->getHeaders() : []),
@@ -89,7 +89,7 @@ class WebhookService
                 'processed' => PDO::PARAM_BOOL,
             ]);
 
-            $this->context->log->error(
+            $this->context->getLog()->error(
                 "Webhook registration for payload " . json_encode($payload) .
                 " failed with error: " . $errorMsg
             );
@@ -342,14 +342,14 @@ class WebhookService
             $responseData = $this->registerWebhook($merchantToken, $events);
 
             if ($responseData) {
-                $this->context->log->info('Successfully registered webhooks: ' . implode(', ', $events), $responseData);
+                $this->context->getLog()->info('Successfully registered webhooks: ' . implode(', ', $events), $responseData);
             } else if (is_null($responseData)) {
-                $this->context->log->error('Something went wrong, response data for webhooks: ' . implode(', ', $events) . ' is null.', []);
+                $this->context->getLog()->error('Something went wrong, response data for webhooks: ' . implode(', ', $events) . ' is null.', []);
             }
 
         } catch (GuzzleException $e) {
             // If the request fails, capture error details:
-            $this->context->log->error(
+            $this->context->getLog()->error(
                 'Error registering webhooks: ' . implode(', ', $events) . ' ‒ ' . $e->getMessage()
             );
             // Optionally rethrow or swallow depending on your error‐handling policy:


### PR DESCRIPTION
## Summary
- make `Context` dependencies private and expose typed getters
- refactor modules and services to use `Context` getters instead of public fields

## Testing
- `php -l app/Controllers/OAuthController.php app/Controllers/WebhooksController.php app/Core/Context.php app/Modules/OAuth/PoyntOAuthHandler.php app/Services/MerchantService.php app/Services/OAuthService.php app/Services/SubscriptionService.php app/Services/TokenService.php app/Services/WebhookService.php`

------
https://chatgpt.com/codex/tasks/task_e_689b60adfa3c8329bb98d37e5a2626cb