### PR TITLE
Handle Guzzle HTTP errors during OAuth callback

### DIFF
--- a/app/Controllers/OAuthController.php
+++ b/app/Controllers/OAuthController.php
@@ -137,10 +137,12 @@ class OAuthController extends Controller {
                 $this->log->error("Failed to save merchant data.");
                 Api::response(Response::STATUS_INTERNAL_SERVER_ERROR, ['error' => 'Failed to save merchant data.']);
             }
+        } catch (GuzzleException $e) {
+            $this->log->error("HTTP request error during callback: " . $e->getMessage());
+            Api::response(Response::STATUS_INTERNAL_SERVER_ERROR, ['error' => $e->getMessage()]);
         } catch (\Exception $e) {
             $this->log->error("Error during callback: " . $e->getMessage());
             Api::response(Response::STATUS_INTERNAL_SERVER_ERROR, ['error' => $e->getMessage()]);
-        } catch (GuzzleException $e) {
         }
 
         exit;


### PR DESCRIPTION
## Summary
- log and handle Guzzle exceptions during OAuth callback

## Testing
- `php -l app/Controllers/OAuthController.php`


------
https://chatgpt.com/codex/tasks/task_e_689b62d86bf48329a72f63784524a16b