### PR TITLE
Refactor webhook responses to use Api::response

### DIFF
--- a/app/Controllers/WebhooksController.php
+++ b/app/Controllers/WebhooksController.php
@@ -54,14 +54,11 @@ class WebhooksController extends Controller
                 break;
 
             default:
-                header("Content-Type: application/json", true, 400);
-                echo json_encode(['error' => 'Unrecognized event']);
-                return;
+                Api::response(Response::STATUS_BAD_REQUEST, ['error' => 'Unrecognized event']);
         }
 
         // Respond to acknowledge the event has been processed.
-        header("Content-Type: application/json", true, 200);
-        echo json_encode(['status' => 'ok']);
+        Api::response(Response::STATUS_OK, ['status' => 'ok']);
     }
 
     /**


### PR DESCRIPTION
## Summary
- Refactor WebhooksController event listener to rely on Api::response for all replies
- Remove direct header and echo calls for cleaner response handling

## Testing
- `php -l app/Controllers/WebhooksController.php`


------
https://chatgpt.com/codex/tasks/task_e_689b648ab6f88329ab3c252908a5cfde