### PR TITLE
Refine RouterResolver typing

### DIFF
--- a/app/Core/RouterResolver.php
+++ b/app/Core/RouterResolver.php
@@ -2,21 +2,20 @@
 namespace App\Core;
 
 use Phroute;
-use League;
+use League\Container\Container;
 
 class RouterResolver implements Phroute\Phroute\HandlerResolverInterface
 {
-    private $container;
+    private Container $container;
 
-    public function __construct(League\Container\Container $container)
+    public function __construct(Container $container)
     {
         $this->container = $container;
     }
 
-    public function resolve($handler)
+    public function resolve(array|callable $handler): array|callable
     {
-        if(is_array($handler) and is_string($handler[0]))
-        {
+        if (is_array($handler) && is_string($handler[0])) {
             $handler[0] = $this->container->get($handler[0]);
         }
 


### PR DESCRIPTION
## Summary
- declare RouterResolver container property with Container type
- type-hint resolve handler parameter and return value; replace `and` with `&&`

## Testing
- `php -l app/Core/RouterResolver.php`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689b6574c5dc83298e01868e7133474a