### PR TITLE
Typehint TokenService context and cleanup imports

### DIFF
--- a/app/Services/TokenService.php
+++ b/app/Services/TokenService.php
@@ -5,7 +5,6 @@ namespace App\Services;
 use App\Core\Context;
 use DateInterval;
 use DateTime;
-use Doctrine\DBAL\Exception;
 
 /**
  * TokenService manages persistence for both app-level tokens (app_token)
@@ -18,7 +17,8 @@ class TokenService {
 
     private Context $context;
 
-    public function __construct($context) {
+    public function __construct(Context $context)
+    {
         $this->context = $context;
     }
 


### PR DESCRIPTION
## Summary
- Typehint the TokenService constructor with `Context` for clarity and static analysis
- Remove unused Doctrine DBAL Exception import

## Testing
- `php -l app/Services/TokenService.php`
- `composer validate --no-check-publish`


------
https://chatgpt.com/codex/tasks/task_e_689b6576f2ac8329acc9a79ac97011ed