### PR TITLE
Refactor OAuth platform registry for dynamic handler resolution

### DIFF
--- a/app/Modules/OAuth/PlatformRegistry.php
+++ b/app/Modules/OAuth/PlatformRegistry.php
@@ -5,48 +5,18 @@ namespace App\Modules\OAuth;
 use App\Core\Context;
 
 class PlatformRegistry {
-    private $platforms = [];
     private $context;
 
     public function __construct(Context $context) {
         $this->context = $context;
-//        $this->platforms[$platform] = $this->createHandler($platform);
     }
 
     public function getHandler(string $platform): OAuthHandlerInterface {
         $handlerClass = "\\App\\Modules\\OAuth\\" . ucfirst($platform) . "OAuthHandler";
         if (!class_exists($handlerClass)) {
-            throw new \Exception("Handler for platform $platform not found.");
+            throw new \InvalidArgumentException("Unsupported platform: $platform");
         }
 
         return new $handlerClass($this->context);
     }
-
-    public function _getHandler(string $platform): OAuthHandlerInterface {
-        if (!isset($this->platforms[$platform])) {
-            throw new \Exception("Platform $platform not supported.");
-        }
-        return $this->platforms[$platform];
-    }
-
-    private function createHandler(string $platform): OAuthHandlerInterface {
-        switch ($platform) {
-            case 'clover':
-                return new CloverOAuthHandler();
-            case 'poynt':
-                return new PoyntOAuthHandler($this->context);
-            default:
-                throw new \Exception("Handler for $platform not implemented.");
-        }
-    }
-//    private function _createHandler(string $platform, array $config): OAuthHandlerInterface {
-//        switch ($platform) {
-//            case 'clover':
-//                return new CloverOAuthHandler($config);
-//            case 'poynt':
-//                return new PoyntOAuthHandler($config);
-//            default:
-//                throw new \Exception("Handler for $platform not implemented.");
-//        }
-//    }
 }


### PR DESCRIPTION
## Summary
- Simplify PlatformRegistry by relying on dynamic handler resolution
- Remove unused platform cache and helper methods
- Throw InvalidArgumentException when platform handler is missing

## Testing
- `php -l app/Modules/OAuth/PlatformRegistry.php`
- `composer validate --no-check-publish`


------
https://chatgpt.com/codex/tasks/task_e_689b6dff2bd48329a57b43cf3c5679e0