### PR TITLE
refactor: split Poynt OAuth handler responsibilities

### DIFF
--- a/app/Modules/OAuth/OAuthHandlerInterface.php
+++ b/app/Modules/OAuth/OAuthHandlerInterface.php
@@ -2,13 +2,11 @@
 
 namespace App\Modules\OAuth;
 
-interface OAuthHandlerInterface {
-    public function exchangeAuthorizationCode(string $authCode): array;
-
-    public function _getTokenResponse();
-
-    public function refreshToken(string $refreshToken): array;
-//    public function fetchMerchantDetails(array $tokenResponse): array;
-    public function fetchMerchantOrders(array $tokenResponse): array;
-    public function saveMerchantData(array $merchantData): bool;
+interface OAuthHandlerInterface
+{
+    public function retrieveTokens(): array;
+    public function storeTokens($appToken, $merchantToken): void;
+    public function registerWebhooks(): void;
+    public function getBusinessId(): ?string;
+    public function getStoreId(): ?string;
 }

--- a/app/Modules/OAuth/PoyntOAuthHandler.php
+++ b/app/Modules/OAuth/PoyntOAuthHandler.php
@@ -3,54 +3,23 @@
 namespace App\Modules\OAuth;
 
 use App\Config\ConfigApp;
-use App\Core\Api;
 use App\Core\Response;
 use App\Core\Context;
-use App\Fetchers\MerchantFetcher;
-use App\Services\MerchantService;
 use App\Services\OAuthService;
 use App\Services\TokenService;
-use Doctrine\DBAL\Exception;
-use GuzzleHttp\Client;
 use GuzzleHttp\Exception\GuzzleException;
-use App\Services\HelperService;
 use App\Services\WebhookService;
 
 class PoyntOAuthHandler implements OAuthHandlerInterface
 {
 
-    private ?MerchantService $merchantService = null;
-
-    private $client;
-    private $clientId;
-    private $clientSecret;
-    private $storeId;
-    private $businessId;
-    private $tokenResponse;
-    private $context;
-    private $code;
+    private ?string $storeId = null;
+    private ?string $businessId = null;
+    private Context $context;
+    private ?string $code = null;
 
     public function __construct(Context $context) {
         $this->context = $context;
-        $this->client = new Client();
-
-        // TODO handle
-//        if ($config) {
-//            $this->clientId = $config['client_id'];
-//            $this->clientSecret = $config['client_secret'];
-//        }
-    }
-
-    public function getMerchantService(): MerchantService {
-        if ($this->merchantService === null) {
-            $this->merchantService = new MerchantService(
-                $this->context->getApi(),
-                $this->context->getConn(),
-                $this->context->getLog(),
-                new MerchantFetcher($this->context->getLog())
-            );
-        }
-        return $this->merchantService;
     }
 
     /**
@@ -280,237 +249,5 @@ class PoyntOAuthHandler implements OAuthHandlerInterface
                 'error' => 'Guzzle exception. Token exchange failed.',
             ];
         }
-    }
-
-    public function _getTokenResponse()
-    {
-        return $this->getTokenResponse();
-    }
-
-    // TODO remove along with interface definition
-    public function exchangeAuthorizationCode(string $authCode): array {
-        $response = $this->client->post('https://services.poynt.net/token', [
-            'form_params' => [
-                'client_id' => $this->clientId,
-                'client_secret' => $this->clientSecret,
-                'code' => $authCode,
-            ],
-        ]);
-
-        return json_decode($response->getBody(), true);
-    }
-
-    // TODO remove along with interface definition
-    public function refreshToken(string $refreshToken): array {
-        $response = $this->client->post('https://services.poynt.net/token', [
-            'form_params' => [
-                'client_id' => $this->clientId,
-                'client_secret' => $this->clientSecret,
-                'refresh_token' => $refreshToken,
-            ],
-        ]);
-
-        return json_decode($response->getBody(), true);
-    }
-
-    /**
-     * Business resource represents the merchant business. The Poynt system assumes the following business
-     * hierarchy. There is the parent business at the root. Each business could have 0 or more stores. Each
-     * store could have 0 or more terminals. This resource provides operations to create, update and view
-     * this entire hierarchy.
-     *
-     * @param array $tokenResponse
-     * @return array|false
-     * @throws GuzzleException
-     */
-    public function fetchMerchantBusinessById(array $tokenResponse): array|false {
-
-        if (HelperService::validateTokenResponse($tokenResponse)) {
-            // Fetch merchant business
-            if (!$merchantBusiness = $this->getMerchantService()->fetchMerchantBusinessById($tokenResponse['accessToken'], $this->businessId)) {
-//            if (!$merchantBusiness = $this->getMerchantService()->fetchMerchantBusiness($tokenResponse['accessToken'], $this->businessId)) {
-                $this->context->getLog()->error("Error: Failed to fetch merchant business");
-                Api::response(Response::STATUS_INTERNAL_SERVER_ERROR, ['error' => 'Failed to fetch merchant business.']);
-                return false;
-            } else {
-                return $merchantBusiness;
-            }
-        }
-        return false;
-    }
-
-
-    /**
-     * @param array $tokenResponse
-     * @return array|false
-     */
-    public function fetchMerchantBusiness(array $tokenResponse): array|false {
-
-        if (HelperService::validateTokenResponse($tokenResponse)) {
-            // Fetch merchant business
-            if (!$merchantBusiness = $this->getMerchantService()->fetchMerchantBusiness($tokenResponse['accessToken'])) {
-                $this->context->getLog()->error("Error: Failed to fetch merchant business");
-                Api::response(Response::STATUS_INTERNAL_SERVER_ERROR, ['error' => 'Failed to fetch merchant business.']);
-                return false;
-            } else {
-                return $merchantBusiness;
-            }
-        }
-        return false;
-    }
-
-    /**
-     *
-     *
-     * @param array $tokenResponse
-     * @return array|false
-     */
-    public function fetchMerchantSubscription(array $tokenResponse): array|false
-    {
-        if (HelperService::validateTokenResponse($tokenResponse)) {
-            $subscription = $this->getMerchantService()->fetchMerchantSubscription($tokenResponse['accessToken'], $this->businessId);
-
-            if (!$subscription) {
-                $this->context->getLog()->error("Error: Failed to fetch subscription details.");
-                return false;
-            }
-            return $subscription;
-        }
-        return false;
-    }
-
-
-    /**
-     * In order to provide GoDaddy Poynt merchants with the ability to subscribe to your app
-     * directly from your web application, you must connect with the billing system first to
-     * fetch your active billing plans
-     *
-     * @param array $tokenResponse
-     * @return array|false
-     */
-    public function fetchApplicationSubscriptionPlans(array $tokenResponse): array|false
-    {
-        if (HelperService::validateTokenResponse($tokenResponse)) {
-            $appSubscriptionPlans = $this->getMerchantService()->fetchApplicationSubscriptionPlans($tokenResponse['accessToken']);
-
-            if (!$appSubscriptionPlans) {
-                $this->context->getLog()->error("Error: Failed to fetch subscription plans.");
-                return false;
-            }
-            return $appSubscriptionPlans;
-        }
-        return false;
-    }
-
-    /**
-     * @param array $tokenResponse
-     * @param $businessId
-     * @param $planId
-     * @return array|false
-     */
-    public function createOrUpdateSubscription(array $tokenResponse, $businessId, $planId): array|false
-    {
-        $businessId = $this->businessId;
-        $planId = 'todo';
-
-        if (HelperService::validateTokenResponse($tokenResponse)) {
-            $subscription = $this->getMerchantService()->createOrUpdateSubscription($tokenResponse['accessToken'], $businessId, $planId);
-
-            if (!$subscription) {
-                $this->context->getLog()->error("Error: Failed to create or update subscription.");
-                return false;
-            }
-            return $subscription;
-        }
-        return false;
-    }
-
-
-    /**
-     * @param array $tokenResponse
-     * @param string $subscriptionId
-     * @return false
-     */
-    public function deleteSubscription(array $tokenResponse, string $subscriptionId): array|false
-    {
-        if (HelperService::validateTokenResponse($tokenResponse)) {
-            $subscriptionDeleted = $this->getMerchantService()->deleteSubscription($tokenResponse['accessToken'], $subscriptionId);
-
-            if(!$subscriptionDeleted) {
-                $this->context->getLog()->error("Error: Failed to delete subscription.");
-                return false;
-            }
-            return $subscriptionDeleted;
-        }
-        return false;
-    }
-
-
-
-//    public function fetchMerchantSubscriptions(array $tokenResponse)
-//    {
-//        if(HelperService::validateTokenResponse($tokenResponse)) {
-//            $subscriptions = $this->getMerchantService()->fetchMerchantSubscriptions($tokenResponse['accessToken'], $this->businessId);
-//        }
-//    }
-
-
-
-    // TODO refactor/move all fetch methods since this is PoyntOAuthHandler
-    // first we will check if this access token is suitable for requesting orders
-    public function fetchMerchantOrders(array $tokenResponse): array
-    {
-        if (HelperService::validateTokenResponse($tokenResponse)) {
-            if (!$merchantOrders = $this->getMerchantService()->fetchMerchantOrders($tokenResponse['accessToken'], $this->businessId)) {
-                $this->context->getLog()->error("Error: Failed to fetch merchant orders");
-                return [
-                    'success' => false,
-                    'status' => Response::STATUS_INTERNAL_SERVER_ERROR,
-                    'error' => 'Failed to fetch merchant details.',
-                ];
-            }
-            return [
-                'success' => true,
-                'data' => $merchantOrders,
-            ];
-        }
-        return [
-            'success' => false,
-            'status' => Response::STATUS_BAD_REQUEST,
-            'error' => 'Invalid token response',
-        ];
-    }
-
-
-
-
-
-    /**
-     * @param array $merchantData
-     * @return bool
-     */
-    public function saveMerchantData(array $merchantData) : bool
-    {
-        if (!$saved = $this->getMerchantService()->saveMerchant($merchantData, $this->storeId, $this->tokenResponse)) {
-            $this->context->getLog()->error("Error: Failed to save merchant details");
-            return false;
-        }
-        $this->context->getLog()->info('Merchant data saved successfully.');
-        return true;
-
-//
-//        Api::response(Response::STATUS_OK, ['message' => 'Merchant data saved successfully.']);
-//        exit;
-//
-//
-//
-//
-//        $response = $this->client->get('https://services.poynt.net/businesses/self', [
-//            'headers' => [
-//                'Authorization' => "Bearer $accessToken",
-//            ],
-//        ]);
-//
-//        return json_decode($response->getBody(), true);
     }
 }

--- a/app/Services/MerchantService.php
+++ b/app/Services/MerchantService.php
@@ -4,7 +4,6 @@ namespace App\Services;
 
 use AllowDynamicProperties;
 use App\Core\Context;
-use App\Fetchers\MerchantFetcher;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception;
 use GuzzleHttp\Client;
@@ -18,12 +17,16 @@ class MerchantService {
 
     private Context $context;
     private ?string $businessId = null;
+    private Connection $conn;
+    private Logger $log;
 
     const POYNT_ENDPOINT_API_BUSINESS = 'https://services.poynt.net/businesses';
 
     public function __construct(Context $context, ?string $businessId = null)
     {
         $this->context = $context;
+        $this->conn = $context->getConn();
+        $this->log = $context->getLog();
         if ($businessId !== null) {
             $this->businessId = $businessId;
         }
@@ -141,6 +144,62 @@ class MerchantService {
             return $data ?? false; // Assuming 'business' contains the merchant details
         } catch (GuzzleException $e) {
             $this->context->getLog()->error("Error fetching merchant details: " . $e->getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * Convenience wrapper that fetches merchant business details using the
+     * internally stored business identifier or the one supplied.
+     *
+     * @param string|null $businessId Optional business identifier
+     * @return array|false Merchant data on success, false on failure
+     */
+    public function fetchMerchantBusiness(?string $businessId = null): array|false
+    {
+        if ($businessId === null) {
+            $businessId = $this->businessId;
+        }
+
+        if (!$businessId) {
+            return false;
+        }
+
+        return $this->fetchMerchantBusinessById($businessId);
+    }
+
+    /**
+     * Retrieve orders belonging to a merchant business.
+     *
+     * @param string|null $businessId Optional business identifier
+     * @return array|false Array of orders or false on error
+     */
+    public function fetchMerchantOrders(?string $businessId = null): array|false
+    {
+        if ($businessId === null) {
+            $businessId = $this->businessId;
+        }
+
+        if (!$businessId) {
+            return false;
+        }
+
+        $tokenService = new TokenService($this->context);
+        $accessToken  = $tokenService->getMerchantToken($businessId);
+
+        $httpClient = new Client();
+
+        try {
+            $response = $httpClient->get(self::POYNT_ENDPOINT_API_BUSINESS . '/' . $businessId . '/orders', [
+                'headers' => [
+                    'Authorization' => 'Bearer ' . $accessToken,
+                ],
+            ]);
+
+            $data = json_decode($response->getBody(), true);
+            return $data ?? false;
+        } catch (GuzzleException $e) {
+            $this->context->getLog()->error('Error fetching merchant orders: ' . $e->getMessage());
             return false;
         }
     }
@@ -269,117 +328,6 @@ class MerchantService {
         }
     }
 
-
-    /**
-     * Fetch and save merchant business.
-     *
-     * @param string $accessToken OAuth access token.
-     * @return array|false Success(array) or failure(bool).
-     */
-    public function fetchMerchantBusiness(string $accessToken): array|false
-    {
-        $merchantBusiness = $this->fetchMerchantBusiness($accessToken);
-        if (!$merchantBusiness) {
-            $this->log->error("Failed to fetch merchant business.");
-            return false;
-        }
-        return $merchantBusiness;
-    }
-
-    /**
-     * Fetch merchant orders.
-     *
-     * @param string $accessToken
-     * @param string $businessId
-     * @return array|false
-     */
-    public function fetchMerchantOrders(string $accessToken, string $businessId): array|false
-    {
-        $merchantOrders = $this->merchantFetcher->fetchOrders($accessToken, $businessId);
-        if (!$merchantOrders) {
-            $this->log->error("Failed to fetch merchant orders.");
-            return false;
-        }
-        return $merchantOrders;
-    }
-
-    /**
-     * @param string $accessToken
-     * @param string $businessId
-     * @return array|false
-     */
-    public function _fetchMerchantSubscription(string $accessToken, string $businessId): array|false
-    {
-        $merchantSubscription = $this->merchantFetcher->fetchSubscriptionStatus($accessToken, $businessId);
-        if (!$merchantSubscription) {
-            $this->log->error("Failed to fetch merchant subscription.");
-            return false;
-        }
-        return $merchantSubscription;
-    }
-
-    /**
-     * @param string $accessToken
-     * @return array|false
-     */
-    public function fetchApplicationSubscriptionPlans(string $accessToken): array|false
-    {
-        $applicationPlans = $this->merchantFetcher->fetchApplicationSubscriptionPlans($accessToken);
-        if (!$applicationPlans) {
-            $this->log->error("Failed to fetch application subscription plans.");
-            return false;
-        }
-        return $applicationPlans;
-    }
-
-    /**
-     * @param $accessToken
-     * @param $businessId
-     * @param $planId
-     * @return array|false
-     */
-    public function createOrUpdateSubscription($accessToken, $businessId, $planId): array|false
-    {
-        $subscription = $this->merchantFetcher->createOrUpdateSubscription($accessToken, $businessId, $planId);
-        if (!$subscription) {
-            $this->log->error("Failed to fetch application subscription.");
-            return false;
-        }
-        return $subscription;
-    }
-
-
-    /**
-     * @param $accessToken
-     * @param $subscriptionId
-     * @return array|false
-     */
-    public function deleteSubscription($accessToken, $subscriptionId): array|false
-    {
-        $subscriptionDeleted = $this->merchantFetcher->deleteSubscription($accessToken, $subscriptionId);
-        if (!$subscriptionDeleted) {
-            $this->log->error("Failed to delete subscription.");
-            return false;
-        }
-        return $subscriptionDeleted;
-    }
-
-    /**
-     * @param $accessToken
-     * @param $businessId
-     * @param $storeId
-     * @param $deviceId
-     * @return array|false
-     */
-    public function fetchMerchantSubscription($accessToken, $businessId, $storeId = null, $deviceId = null): array|false
-    {
-        $subscriptions = $this->merchantFetcher->fetchMerchantSubscription($accessToken, $businessId, $storeId, $deviceId);
-        if (!$subscriptions) {
-            $this->log->error("Failed to fetch merchants subscriptions.");
-            return false;
-        }
-        return $subscriptions;
-    }
 
 
     /**

--- a/app/Services/SubscriptionService.php
+++ b/app/Services/SubscriptionService.php
@@ -70,6 +70,98 @@ class SubscriptionService
         }
     }
 
+    /**
+     * Legacy alias for fetching application subscription plans. Uses an
+     * app-level access token obtained via the JWT exchange.
+     *
+     * @param string $appAccessToken
+     * @return array|null
+     */
+    public function fetchApplicationSubscriptionPlans(string $appAccessToken): ?array
+    {
+        return $this->fetchPlans($appAccessToken);
+    }
+
+    /**
+     * Fetch subscriptions for a merchant using the merchant's access token.
+     *
+     * @param string $merchantAccessToken
+     * @param string $businessId
+     * @param string|null $storeId
+     * @param string|null $deviceId
+     * @param string|null $status
+     * @return array|null
+     */
+    public function fetchMerchantSubscriptions(
+        string $merchantAccessToken,
+        string $businessId,
+        ?string $storeId = null,
+        ?string $deviceId = null,
+        ?string $status = null
+    ): ?array {
+        $orgId = ConfigApp::$orgId;
+        $appId = 'urn:aid:' . ConfigApp::$appId;
+        $endpoint = "/{$orgId}/apps/{$appId}/subscriptions";
+
+        $query = ['businessId' => $businessId];
+        if ($storeId) {
+            $query['storeId'] = $storeId;
+        }
+        if ($deviceId) {
+            $query['deviceId'] = $deviceId;
+        }
+        if ($status) {
+            $query['status'] = $status;
+        }
+
+        try {
+            $response = $this->http->get($endpoint, [
+                'headers' => [
+                    'Authorization' => 'Bearer ' . $merchantAccessToken,
+                    'Accept'        => 'application/json',
+                ],
+                'query' => $query,
+            ]);
+            return json_decode((string)$response->getBody(), true);
+        } catch (RequestException $e) {
+            $msg = $e->hasResponse()
+                ? $e->getResponse()->getBody()->getContents()
+                : $e->getMessage();
+            $this->context->getLog()->error('Error fetching merchant subscriptions: ' . $msg);
+            return null;
+        } catch (GuzzleException $e) {
+            $this->context->getLog()->error('Error fetching merchant subscriptions: ' . $e->getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * Convenience wrapper around fetchMerchantSubscriptions for callers that
+     * expect a singular method name.
+     *
+     * @param string      $merchantAccessToken
+     * @param string      $businessId
+     * @param string|null $storeId
+     * @param string|null $deviceId
+     * @param string|null $status
+     * @return array|null
+     */
+    public function fetchMerchantSubscription(
+        string $merchantAccessToken,
+        string $businessId,
+        ?string $storeId = null,
+        ?string $deviceId = null,
+        ?string $status = null
+    ): ?array {
+        return $this->fetchMerchantSubscriptions(
+            $merchantAccessToken,
+            $businessId,
+            $storeId,
+            $deviceId,
+            $status
+        );
+    }
+
 
     // ────────────────────────────────────────────────────────────────────────────
     // 1) Start a local-only free trial


### PR DESCRIPTION
## Summary
- slim down `PoyntOAuthHandler` to only handle token exchange and webhook registration
- move merchant/business and subscription logic into dedicated services
- expose subscription fetch capability via `SubscriptionService`
- add helpers for merchant business/orders and plan retrieval

## Testing
- `composer validate --no-check-publish`
- `php -l app/Modules/OAuth/PoyntOAuthHandler.php`
- `php -l app/Services/MerchantService.php`
- `php -l app/Services/SubscriptionService.php`


------
https://chatgpt.com/codex/tasks/task_e_689b6de6f2e48329b81a9e4c884e55f4