### PR TITLE
refactor: tidy service dependencies

### DIFF
--- a/app/Controllers/OAuthController.php
+++ b/app/Controllers/OAuthController.php
@@ -11,22 +11,21 @@ use App\Modules\OAuth\PlatformRegistry;
 use App\Modules\OAuth\PoyntOAuthHandler;
 use App\Services\MerchantService;
 use App\Services\SubscriptionService;
+use Doctrine\DBAL\Connection;
 use Firebase\JWT\JWT;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Exception\RequestException;
+use Monolog\Logger;
 use Ramsey\Uuid\Uuid;
 
 class OAuthController extends Controller {
 
-    private MerchantService $businessService;
-    private StoreService    $storeService;
-    private TokenService    $tokenService;
-    private Context         $context;
+    private Context $context;
 
 
-    public function __construct($api, $conn, $log) {
+    public function __construct(Api $api, Connection $conn, Logger $log) {
         parent::__construct($api, $conn, $log);
         $this->context = new Context($api, $conn, $log);
 
@@ -55,7 +54,7 @@ class OAuthController extends Controller {
      * Handles the "install" route.
      * Redirects the merchant to the OAuth authorization URL.
      */
-    public function install($platform)
+    public function install(?string $platform): array
     {
         if (!$platform) {
             return ['error' => 'Platform not specified.'];
@@ -81,7 +80,7 @@ class OAuthController extends Controller {
      * @return void
      * @throws \Exception
      */
-    public function callback()
+    public function callback(): void
     {
         $poyntOAuthHandler = new PoyntOAuthHandler($this->context);
 

--- a/app/Controllers/WebhooksController.php
+++ b/app/Controllers/WebhooksController.php
@@ -5,11 +5,13 @@ namespace App\Controllers;
 use App\Core\Api;
 use App\Core\Context;
 use App\Core\Response;
+use Doctrine\DBAL\Connection;
+use Monolog\Logger;
 
 class WebhooksController extends Controller
 {
-    private $context;
-    public function __construct($api, $conn, $log)
+    private Context $context;
+    public function __construct(Api $api, Connection $conn, Logger $log)
     {
         parent::__construct($api, $conn, $log);
         $this->context = new Context($api, $conn, $log);

--- a/app/Fetchers/MerchantFetcher.php
+++ b/app/Fetchers/MerchantFetcher.php
@@ -9,8 +9,8 @@ use Psr\Log\LoggerInterface;
 
 class MerchantFetcher
 {
-    private $httpClient;
-    private $log;
+    private Client $httpClient;
+    private LoggerInterface $log;
 
     const POYNT_ENDPOINT_API = 'https://services.poynt.net/businesses';
     const POYNT_ENDPOINT_GET_BUSINESS = 'https://services.poynt.net/businesses';

--- a/app/Modules/OAuth/CloverOAuthHandler.php
+++ b/app/Modules/OAuth/CloverOAuthHandler.php
@@ -9,9 +9,9 @@ use GuzzleHttp\Client;
 //class CloverOAuthHandler implements OAuthHandlerInterface
 class CloverOAuthHandler
 {
-    private $client;
-    private $clientId;
-    private $clientSecret;
+    private Client $client;
+    private string $clientId;
+    private string $clientSecret;
 
     public function __construct() {
         $this->client = new Client();

--- a/app/Modules/OAuth/PlatformRegistry.php
+++ b/app/Modules/OAuth/PlatformRegistry.php
@@ -5,7 +5,7 @@ namespace App\Modules\OAuth;
 use App\Core\Context;
 
 class PlatformRegistry {
-    private $context;
+    private Context $context;
 
     public function __construct(Context $context) {
         $this->context = $context;

--- a/app/Services/WebhookService.php
+++ b/app/Services/WebhookService.php
@@ -2,25 +2,26 @@
 
 namespace App\Services;
 
-use GuzzleHttp\Client;
 use App\Config\ConfigApp;
+use App\Core\Context;
+use GuzzleHttp\Client;
 use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Exception\RequestException;
 use PDO;
 
 class WebhookService
 {
-    protected $context;
-    private $businessId;
+    protected Context $context;
+    private ?string $businessId;
 
     public const POYNT_WEBHOOK_URL = 'https://services.poynt.net/hooks';
 
-        /**
+    /**
      * Constructor.
      *
-     * @param object $context An object containing dependencies (like logger, config, etc.)
+     * @param Context $context An object containing dependencies (like logger, config, etc.)
      */
-    public function __construct($context, $businessId = null)
+    public function __construct(Context $context, ?string $businessId = null)
     {
         $this->context = $context;
         $this->businessId = $businessId;


### PR DESCRIPTION
## Summary
- remove unused service placeholders and type controller dependencies
- add service imports and type hints across controllers and helpers
- ensure Context and business IDs are typed in webhook service

## Testing
- `php -l app/Controllers/OAuthController.php`
- `php -l app/Controllers/WebhooksController.php`
- `php -l app/Fetchers/MerchantFetcher.php`
- `php -l app/Modules/OAuth/CloverOAuthHandler.php`
- `php -l app/Modules/OAuth/PlatformRegistry.php`
- `php -l app/Services/WebhookService.php`
- `composer validate --no-check-all --strict`


------
https://chatgpt.com/codex/tasks/task_e_689c806b81248329a09e013e4fc3b21f