### PR TITLE
refactor controller to use context

### DIFF
--- a/app/Controllers/Controller.php
+++ b/app/Controllers/Controller.php
@@ -3,11 +3,17 @@
 namespace App\Controllers;
 
 use App\Core\Api;
+use App\Core\Context;
 use Doctrine\DBAL\Connection;
 use Monolog\Logger;
 
 abstract class Controller
 {
+    /**
+     * @var Context
+     */
+    protected Context $context;
+
     /**
      * @var Api
      */
@@ -24,15 +30,14 @@ abstract class Controller
     protected Logger $log;
 
     /**
-     * @param Api $api
-     * @param Connection $conn
-     * @param Logger $log
+     * @param Context $context
      */
-    public function __construct(Api $api, Connection $conn, Logger $log)
+    public function __construct(Context $context)
     {
-        $this->api = $api;
-        $this->conn = $conn;
-        $this->log = $log;
+        $this->context = $context;
+        $this->api = $context->getApi();
+        $this->conn = $context->getConn();
+        $this->log = $context->getLog();
     }
 
     public function startSession() {


### PR DESCRIPTION
## Summary
- refactor Controller base class to accept a Context object
- expose injected Api, Connection, and Logger from the Context

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `composer test` *(fails: Command "test" is not defined)*
- `composer validate --no-check-publish`
- `php -l app/Controllers/Controller.php`


------
https://chatgpt.com/codex/tasks/task_e_689c858d147c8329b8b481605cf0864f