### PR TITLE
refactor context initialization

### DIFF
--- a/app/Controllers/WebhooksController.php
+++ b/app/Controllers/WebhooksController.php
@@ -5,16 +5,12 @@ namespace App\Controllers;
 use App\Core\Api;
 use App\Core\Context;
 use App\Core\Response;
-use Doctrine\DBAL\Connection;
-use Monolog\Logger;
 
 class WebhooksController extends Controller
 {
-    private Context $context;
-    public function __construct(Api $api, Connection $conn, Logger $log)
+    public function __construct(Context $context)
     {
-        parent::__construct($api, $conn, $log);
-        $this->context = new Context($api, $conn, $log);
+        parent::__construct($context);
     }
 
     /**

--- a/public/index.php
+++ b/public/index.php
@@ -10,6 +10,7 @@ use League\Container\Container;
 use Monolog\Logger;
 use Phroute\Phroute\Dispatcher;
 use App\Core\Api;
+use App\Core\Context;
 use App\Core\RouterResolver;
 use App\Core\Response;
 use Doctrine\DBAL\DriverManager;
@@ -71,17 +72,16 @@ $log->pushProcessor(function ($record) use ($requestId) {
 });
 
 $api = new Api($_REQUEST['request'] ?? '', $log, $requestId);
+$context = new Context($api, $conn, $log);
 
 // Dependency injection container
 $appContainer = new Container();
-$appContainer->add('CONN', $conn);
-$appContainer->add('LOG', $log);
-$appContainer->add('API', $api);
+$appContainer->add('CONTEXT', $context);
 
 // Register controllers
-$appContainer->add('App\Controllers\OAuthController')->addArgument('API')->addArgument('CONN')->addArgument('LOG');
-$appContainer->add('App\Controllers\TokenController')->addArgument('API')->addArgument('CONN')->addArgument('LOG');
-$appContainer->add('App\Controllers\WebhooksController')->addArgument('API')->addArgument('CONN')->addArgument('LOG');
+$appContainer->add('App\Controllers\OAuthController')->addArgument('CONTEXT');
+$appContainer->add('App\Controllers\TokenController')->addArgument('CONTEXT');
+$appContainer->add('App\Controllers\WebhooksController')->addArgument('CONTEXT');
 
 $resolver = new RouterResolver($appContainer);
 


### PR DESCRIPTION
## Summary
- centralize API, DB connection, and logger into a `Context` object
- expose `Context` in DI container and inject into controllers

## Testing
- `php -l public/index.php`
- `php -l app/Controllers/OAuthController.php`
- `php -l app/Controllers/WebhooksController.php`


------
https://chatgpt.com/codex/tasks/task_e_689c8a8443848329a060312a304d0962