### PR TITLE
Add background job for token refresh

### DIFF
--- a/app/Services/BackgroundJobService.php
+++ b/app/Services/BackgroundJobService.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace App\Services;
+
+use App\Core\Context;
+use Psr\Log\LoggerInterface;
+
+/**
+ * BackgroundJobService periodically checks for expiring tokens
+ * and refreshes them using OAuthService, persisting results
+ * via TokenService.
+ */
+class BackgroundJobService
+{
+    private Context $context;
+    private TokenService $tokenService;
+    private OAuthService $oauthService;
+    private LoggerInterface $log;
+
+    public function __construct(Context $context)
+    {
+        $this->context = $context;
+        $this->log = $context->getLog();
+        $this->tokenService = new TokenService($context);
+        $this->oauthService = new OAuthService($context);
+    }
+
+    /**
+     * Refresh both app and merchant tokens that are close to expiring.
+     */
+    public function refreshExpiringTokens(): void
+    {
+        $this->refreshAppTokens();
+        $this->refreshMerchantTokens();
+    }
+
+    /**
+     * Refresh expiring app-level tokens.
+     */
+    private function refreshAppTokens(): void
+    {
+        try {
+            $tokens = $this->tokenService->findExpiringAppTokens();
+        } catch (\Throwable $e) {
+            $this->log->error('Failed to fetch expiring app tokens: ' . $e->getMessage());
+            return;
+        }
+
+        foreach ($tokens as $token) {
+            $bizId = $token['business_id'];
+
+            try {
+                $newToken = $this->oauthService->exchangeJwtForToken();
+                if (HelperService::validateTokenResponse($newToken)) {
+                    $this->tokenService->saveAppToken($bizId, $newToken);
+                    $this->tokenService->logRefreshAttempt($bizId, 'app', true);
+                } else {
+                    $this->tokenService->logRefreshAttempt($bizId, 'app', false, 'invalid token response');
+                }
+            } catch (\Throwable $e) {
+                $this->log->error("Failed to refresh app token for business_id={$bizId}: " . $e->getMessage());
+                $this->tokenService->logRefreshAttempt($bizId, 'app', false, $e->getMessage());
+            }
+        }
+    }
+
+    /**
+     * Refresh expiring merchant-level tokens.
+     */
+    private function refreshMerchantTokens(): void
+    {
+        try {
+            $tokens = $this->tokenService->findExpiringMerchantTokens();
+        } catch (\Throwable $e) {
+            $this->log->error('Failed to fetch expiring merchant tokens: ' . $e->getMessage());
+            return;
+        }
+
+        foreach ($tokens as $token) {
+            $bizId = $token['business_id'];
+            $refreshToken = $token['refresh_token'];
+
+            try {
+                $newToken = $this->oauthService->refreshMerchantToken($refreshToken);
+                if ($newToken && HelperService::validateTokenResponse($newToken)) {
+                    $this->tokenService->saveMerchantToken($bizId, $newToken);
+                    $this->tokenService->logRefreshAttempt($bizId, 'merchant', true);
+                } else {
+                    $this->tokenService->logRefreshAttempt($bizId, 'merchant', false, 'invalid token response');
+                }
+            } catch (\Throwable $e) {
+                $this->log->error("Failed to refresh merchant token for business_id={$bizId}: " . $e->getMessage());
+                $this->tokenService->logRefreshAttempt($bizId, 'merchant', false, $e->getMessage());
+            }
+        }
+    }
+}

--- a/app/Services/OAuthService.php
+++ b/app/Services/OAuthService.php
@@ -157,5 +157,40 @@ class OAuthService {
 
         return null;
     }
+
+    /**
+     * Refresh a merchant token using a refresh token.
+     *
+     * @param string $refreshToken
+     * @return array|null
+     */
+    public function refreshMerchantToken(string $refreshToken): ?array
+    {
+        try {
+            $client = new Client();
+            $response = $client->post(self::POYNT_ENDPOINT_TOKEN, [
+                'headers' => [
+                    'Content-Type' => 'application/x-www-form-urlencoded',
+                    'api-version'  => '1.2',
+                ],
+                'form_params' => [
+                    'grant_type'    => 'refresh_token',
+                    'refresh_token' => $refreshToken,
+                    'client_id'     => ConfigApp::$appId,
+                ],
+            ]);
+
+            return json_decode($response->getBody(), true);
+        } catch (RequestException $e) {
+            if ($e->hasResponse()) {
+                $errorResponse = $e->getResponse()->getBody()->getContents();
+                $this->context->getLog()->error("Error: " . $errorResponse);
+            } else {
+                $this->context->getLog()->error("Error: " . $e->getMessage());
+            }
+        }
+
+        return null;
+    }
 }
 

--- a/app/Services/TokenService.php
+++ b/app/Services/TokenService.php
@@ -300,4 +300,35 @@ class TokenService {
             );
         }
     }
+
+    /**
+     * Persist an attempt to refresh a token.
+     *
+     * @param string      $businessId
+     * @param string      $type     'app' or 'merchant'
+     * @param bool        $success
+     * @param string|null $message
+     * @return void
+     */
+    public function logRefreshAttempt(string $businessId, string $type, bool $success, ?string $message = null): void
+    {
+        $sql = <<<SQL
+        INSERT INTO token_refresh_log (business_id, token_type, attempted_at, success, message)
+        VALUES (:biz, :type, NOW(), :success, :message)
+        SQL;
+
+        try {
+            $stmt = $this->context->getConn()->prepare($sql);
+            $stmt->execute([
+                'biz'     => $businessId,
+                'type'    => $type,
+                'success' => $success,
+                'message' => $message,
+            ]);
+        } catch (\Exception $e) {
+            $this->context->getLog()->error(
+                "Failed to log token refresh attempt for business_id={$businessId}: " . $e->getMessage()
+            );
+        }
+    }
 }

--- a/public/cron.php
+++ b/public/cron.php
@@ -1,0 +1,50 @@
+<?php
+namespace App;
+
+require_once __DIR__ . '/bootstrap.php';
+
+use App\Config\ConfigApp;
+use App\Config\ConfigDatabase;
+use App\Core\Api;
+use App\Core\Context;
+use App\Services\BackgroundJobService;
+use App\Services\CustomPDOHandler;
+use Doctrine\DBAL\DriverManager;
+use Monolog\Logger;
+use Ramsey\Uuid\Uuid;
+
+// Setup database connection
+$connectionParams = [
+    'driver' => 'pdo_pgsql',
+    'host' => ConfigDatabase::$host,
+    'port' => ConfigDatabase::$port,
+    'dbname' => ConfigDatabase::$database,
+    'user' => ConfigDatabase::$username,
+    'password' => ConfigDatabase::$password,
+    'charset' => ConfigDatabase::$charset,
+];
+
+$conn = DriverManager::getConnection($connectionParams);
+$conn->executeStatement("SET TIME ZONE '" . ConfigApp::$timezone . "'");
+
+// Logger setup
+$pdo = new \PDO(
+    'pgsql:host=' . ConfigDatabase::$host . ';port=' . ConfigDatabase::$port . ';dbname=' . ConfigDatabase::$database,
+    ConfigDatabase::$username,
+    ConfigDatabase::$password,
+    [\PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION]
+);
+$logHandler = new CustomPDOHandler($pdo);
+$log = new Logger('app-poynt-log');
+$log->pushHandler($logHandler);
+$requestId = Uuid::uuid4()->toString();
+$log->pushProcessor(function ($record) use ($requestId) {
+    $record['context']['request_id'] = $requestId;
+    return $record;
+});
+
+$api = new Api('', $log, $requestId);
+$context = new Context($api, $conn, $log);
+
+$service = new BackgroundJobService($context);
+$service->refreshExpiringTokens();


### PR DESCRIPTION
## Summary
- Create `BackgroundJobService` to refresh expiring app and merchant tokens and log attempts
- Support merchant token refresh in `OAuthService`
- Persist token refresh attempts in `TokenService`
- Add cron entry to invoke the background job

## Testing
- `php -l app/Services/BackgroundJobService.php`
- `php -l app/Services/OAuthService.php`
- `php -l app/Services/TokenService.php`
- `php -l public/cron.php`


------
https://chatgpt.com/codex/tasks/task_e_689c9f0154c08329998b86b98169ae89