### PR TITLE
Add token refresh API endpoint

### DIFF
--- a/app/Controllers/TokenController.php
+++ b/app/Controllers/TokenController.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Controllers;
+
+use App\Core\Context;
+use App\Services\BackgroundJobService;
+
+class TokenController extends Controller
+{
+    public function __construct(Context $context)
+    {
+        parent::__construct($context);
+    }
+
+    public function refreshTokens(): array
+    {
+        $jobService = new BackgroundJobService($this->context);
+        $jobService->refreshExpiringTokens();
+        return ['status' => 'success'];
+    }
+}

--- a/app/Core/Api.php
+++ b/app/Core/Api.php
@@ -227,8 +227,8 @@ class Api
 //        $router->post('/webhooks/event-listener', ['App\Controllers\WebhooksController', 'eventListener']);
         $router->post('/webhooks/event-listener', ['App\Controllers\WebhooksController', 'eventListener']);
 
-        // Refresh token route
-        $router->post('/api/token/refresh', ['YourApp\Controllers\TokenController', 'refreshToken']);
+        // Internal route to trigger token refreshes
+        $router->post('/internal/refresh-tokens', ['App\Controllers\TokenController', 'refreshTokens']);
 
         return $router->getData();
     }


### PR DESCRIPTION
## Summary
- expose `/internal/refresh-tokens` route for triggering token refreshes
- implement `TokenController::refreshTokens` invoking `BackgroundJobService`

## Testing
- `composer test` (fails: Command "test" is not defined)
- `vendor/bin/phpunit` (fails: No such file or directory)


------
https://chatgpt.com/codex/tasks/task_e_689ca92abef083299745f255ad207182