### PR TITLE
Add method to check subscription trial expiration

### DIFF
--- a/app/Services/SubscriptionService.php
+++ b/app/Services/SubscriptionService.php
@@ -4,6 +4,7 @@ namespace App\Services;
 
 use App\Config\ConfigApp;
 use App\Core\Context;
+use App\Core\Response;
 use DateInterval;
 //use DateMalformedIntervalStringException;
 //use DateMalformedStringException;
@@ -498,5 +499,43 @@ class SubscriptionService
         }
     }
 
+    /**
+     * Determines if a subscription's free-trial period has expired.
+     *
+     * Queries the local `subscription` table for the `trial_end_at` timestamp and
+     * compares it with the current time in UTC.
+     *
+     * When the trial has elapsed callers may respond with
+     * {@see Response::STATUS_FREE_TRIAL_FINISHED} to enforce limits.
+     *
+     * @param string $subscriptionId
+     * @return bool Returns true (or \App\Core\Response::STATUS_FREE_TRIAL_FINISHED)
+     *              if the trial has expired; otherwise false.
+     */
+    public function hasTrialExpired(string $subscriptionId): bool
+    {
+        try {
+            $trialEndAt = $this->context->getConn()->fetchOne(
+                'SELECT trial_end_at FROM subscription WHERE subscription_id = :sub_id',
+                ['sub_id' => $subscriptionId]
+            );
+        } catch (Exception $e) {
+            $this->context->getLog()->error(
+                'Failed to fetch trial_end_at for subscription ' . $subscriptionId . ': ' . $e->getMessage()
+            );
+            return false;
+        }
+
+        if (!$trialEndAt) {
+            return false;
+        }
+
+        $nowUtc      = new DateTime('now', new DateTimeZone('UTC'));
+        $trialEndUtc = new DateTime($trialEndAt, new DateTimeZone('UTC'));
+
+        return $nowUtc > $trialEndUtc
+            ? Response::STATUS_FREE_TRIAL_FINISHED
+            : false;
+    }
 
 }


### PR DESCRIPTION
## Summary
- Add `hasTrialExpired` to `SubscriptionService` to compare the trial end time with current UTC and optionally signal free trial status

## Testing
- `php -l app/Services/SubscriptionService.php`
- `composer test` *(fails: Command "test" is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_689cb0fc3a208329a78a09e8a92efbb1