### PR TITLE
Fix TokenService app token message

### DIFF
--- a/app/Services/TokenService.php
+++ b/app/Services/TokenService.php
@@ -102,7 +102,7 @@ class TokenService {
             return $row === false ? null : $row['access_token'];
         } catch (\Exception $e) {
             throw new \RuntimeException(
-                "Failed to fetch merchant token for business_id={$businessId}: " . $e->getMessage(),
+                "Failed to fetch app token for business_id={$businessId}: " . $e->getMessage(),
                 (int)$e->getCode(),
                 $e
             );


### PR DESCRIPTION
## Summary
- Fix RuntimeException message in `TokenService::getAppToken` to reference app token

## Testing
- `composer test` *(fails: Command "test" is not defined.)*

------
https://chatgpt.com/codex/tasks/task_e_689dea7e06dc8329805d97f791dd4d4b