### PR TITLE
Upsert terminals from store devices

### DIFF
--- a/app/Services/MerchantService.php
+++ b/app/Services/MerchantService.php
@@ -248,11 +248,36 @@ class MerchantService {
             ]);
 
             $data = json_decode($response->getBody(), true);
+
+            // Persist terminals for each store if present
+            if (is_array($data)) {
+                $terminalService = new TerminalService($this->context);
+                foreach ($data as $store) {
+                    $devices = $store['storeDevices'] ?? [];
+                    $storeId = $store['id'] ?? null;
+                    if ($storeId && !empty($devices)) {
+                        $terminalService->upsertTerminals($devices, $storeId);
+                    }
+                }
+            }
+
             return $data ?? []; // Assuming 'business' contains the merchant details
         } catch (GuzzleException $e) {
             $this->context->getLog()->error("Error fetching merchant details: " . $e->getMessage());
             return [];
         }
+    }
+
+    /**
+     * Fetch terminals already stored for a given store.
+     *
+     * @param string $storeId
+     * @return array
+     */
+    public function fetchStoreTerminals(string $storeId): array
+    {
+        $terminalService = new TerminalService($this->context);
+        return $terminalService->fetchByStoreId($storeId);
     }
 
     /**

--- a/app/Services/TerminalService.php
+++ b/app/Services/TerminalService.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace App\Services;
+
+use App\Core\Context;
+
+class TerminalService
+{
+    private Context $context;
+
+    public function __construct(Context $context)
+    {
+        $this->context = $context;
+    }
+
+    /**
+     * Upsert a set of terminals for a store.
+     *
+     * @param array $devices  Array of device payloads from the API
+     * @param string $storeId Store identifier
+     *
+     * @return bool True on success, false on failure
+     */
+    public function upsertTerminals(array $devices, string $storeId): bool
+    {
+        if (empty($devices)) {
+            return true;
+        }
+
+        $sql = <<<SQL
+        INSERT INTO terminal
+            (terminal_id, store_id, metadata, created_at, updated_at)
+        VALUES
+            (:terminalId, :storeId, :metadata, :createdAt, :updatedAt)
+        ON CONFLICT (terminal_id) DO UPDATE SET
+            store_id  = EXCLUDED.store_id,
+            metadata  = EXCLUDED.metadata,
+            updated_at = NOW()
+        SQL;
+
+        try {
+            $stmt = $this->context->getConn()->prepare($sql);
+            $now = (new \DateTime('now'))->format('Y-m-d H:i:sP');
+
+            foreach ($devices as $device) {
+                if (!isset($device['id'])) {
+                    $this->context->getLog()->error(
+                        'TerminalService::upsertTerminals: missing device id'
+                    );
+                    return false;
+                }
+
+                $terminalId = $device['id'];
+                $metadata   = json_encode($device);
+                if ($metadata === false) {
+                    $this->context->getLog()->error(
+                        "TerminalService::upsertTerminals: failed to json_encode device for terminal_id={$terminalId}"
+                    );
+                    return false;
+                }
+
+                $stmt->execute([
+                    'terminalId' => $terminalId,
+                    'storeId'    => $storeId,
+                    'metadata'   => $metadata,
+                    'createdAt'  => $now,
+                    'updatedAt'  => $now,
+                ]);
+            }
+
+            return true;
+        } catch (\Throwable $e) {
+            $this->context->getLog()->error(
+                'TerminalService::upsertTerminals: database error: ' . $e->getMessage()
+            );
+            return false;
+        }
+    }
+
+    /**
+     * Retrieve all terminals belonging to a store.
+     *
+     * @param string $storeId
+     *
+     * @return array
+     */
+    public function fetchByStoreId(string $storeId): array
+    {
+        try {
+            $rows = $this->context->getConn()->fetchAllAssociative(
+                'SELECT * FROM terminal WHERE store_id = ?',
+                [$storeId]
+            );
+            return $rows ?: [];
+        } catch (\Throwable $e) {
+            $this->context->getLog()->error(
+                'TerminalService::fetchByStoreId: database error: ' . $e->getMessage()
+            );
+            return [];
+        }
+    }
+
+    /**
+     * Retrieve a single terminal by its identifier.
+     *
+     * @param string $terminalId
+     *
+     * @return array|false
+     */
+    public function fetchById(string $terminalId): array|false
+    {
+        try {
+            $row = $this->context->getConn()->fetchAssociative(
+                'SELECT * FROM terminal WHERE terminal_id = ?',
+                [$terminalId]
+            );
+            return $row ?: false;
+        } catch (\Throwable $e) {
+            $this->context->getLog()->error(
+                'TerminalService::fetchById: database error: ' . $e->getMessage()
+            );
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- upsert terminals when fetching business stores
- add TerminalService for terminal persistence and retrieval helpers

## Testing
- `php -l app/Services/TerminalService.php`
- `php -l app/Services/MerchantService.php`
- `composer test` *(fails: Command "test" is not defined.)*


------
https://chatgpt.com/codex/tasks/task_e_689dea81aff0832986d64e9701f3b5d2