### PR TITLE
Handle subscription start and end webhooks

### DIFF
--- a/app/Controllers/WebhooksController.php
+++ b/app/Controllers/WebhooksController.php
@@ -5,6 +5,7 @@ namespace App\Controllers;
 use App\Core\Api;
 use App\Core\Context;
 use App\Core\Response;
+use App\Services\SubscriptionService;
 use PDO;
 
 class WebhooksController extends Controller
@@ -102,7 +103,16 @@ class WebhooksController extends Controller
      */
     private function handleSubscriptionStart(array $payload)
     {
-        // Todo
+        $subscriptionId = $payload['subscriptionId'] ?? null;
+        $businessId     = $payload['businessId']     ?? null;
+        $storeId        = $payload['storeId']        ?? null;
+
+        if (!$subscriptionId || !$businessId || !$storeId) {
+            throw new \InvalidArgumentException('Missing subscription data');
+        }
+
+        $service = new SubscriptionService($this->context);
+        $service->activateSubscription($subscriptionId, $businessId, $storeId);
     }
 
     /**
@@ -112,7 +122,16 @@ class WebhooksController extends Controller
      */
     private function handleSubscriptionEnd(array $payload)
     {
-        // Todo
+        $subscriptionId = $payload['subscriptionId'] ?? null;
+        $businessId     = $payload['businessId']     ?? null;
+        $storeId        = $payload['storeId']        ?? null;
+
+        if (!$subscriptionId || !$businessId || !$storeId) {
+            throw new \InvalidArgumentException('Missing subscription data');
+        }
+
+        $service = new SubscriptionService($this->context);
+        $service->cancelSubscription($subscriptionId, $businessId, $storeId);
     }
 
 }

--- a/app/Services/SubscriptionService.php
+++ b/app/Services/SubscriptionService.php
@@ -544,4 +544,68 @@ class SubscriptionService
         }
     }
 
+    /**
+     * Marks an existing subscription row as active.
+     *
+     * @param string $subscriptionId
+     * @param string $businessId
+     * @param string $storeId
+     * @return void
+     */
+    public function activateSubscription(string $subscriptionId, string $businessId, string $storeId): void
+    {
+        $sql = <<<SQL
+        UPDATE subscription
+           SET status = :status,
+               start_at = COALESCE(start_at, NOW()),
+               updated_at = NOW()
+         WHERE subscription_id = :sub_id
+           AND business_id = :biz
+           AND store_id = :store
+        SQL;
+
+        try {
+            $this->context->getConn()->executeStatement($sql, [
+                'status' => 'active',
+                'sub_id' => $subscriptionId,
+                'biz'    => $businessId,
+                'store'  => $storeId,
+            ]);
+        } catch (Exception $e) {
+            $this->context->getLog()->error('Failed to activate subscription ' . $subscriptionId . ': ' . $e->getMessage());
+        }
+    }
+
+    /**
+     * Cancels an existing subscription row.
+     *
+     * @param string $subscriptionId
+     * @param string $businessId
+     * @param string $storeId
+     * @return void
+     */
+    public function cancelSubscription(string $subscriptionId, string $businessId, string $storeId): void
+    {
+        $sql = <<<SQL
+        UPDATE subscription
+           SET status = :status,
+               canceled_at = COALESCE(canceled_at, NOW()),
+               updated_at = NOW()
+         WHERE subscription_id = :sub_id
+           AND business_id = :biz
+           AND store_id = :store
+        SQL;
+
+        try {
+            $this->context->getConn()->executeStatement($sql, [
+                'status' => 'canceled',
+                'sub_id' => $subscriptionId,
+                'biz'    => $businessId,
+                'store'  => $storeId,
+            ]);
+        } catch (Exception $e) {
+            $this->context->getLog()->error('Failed to cancel subscription ' . $subscriptionId . ': ' . $e->getMessage());
+        }
+    }
+
 }


### PR DESCRIPTION
## Summary
- Activate subscriptions when APPLICATION_SUBSCRIPTION_START webhooks arrive
- Cancel subscriptions on APPLICATION_SUBSCRIPTION_END events
- Add service methods to update subscription table status and timestamps

## Testing
- `php -l app/Controllers/WebhooksController.php`
- `php -l app/Services/SubscriptionService.php`


------
https://chatgpt.com/codex/tasks/task_e_68b03f1cffc88329b0937d117de0bc44