### PR TITLE
Use executeStatement for store upsert

### DIFF
--- a/app/Services/BusinessService.php
+++ b/app/Services/BusinessService.php
@@ -322,7 +322,7 @@ class BusinessService {
                     return false;
                 }
 
-                $stmt->execute([
+                $stmt->executeStatement([
                     'storeId'    => $storeId,
                     'businessId' => $businessId,
                     'name'       => $name,


### PR DESCRIPTION
## Summary
- Use `executeStatement` instead of deprecated `execute` when inserting/updating stores

## Testing
- `php -l app/Services/BusinessService.php`
- `composer test` *(fails: Command "test" is not defined.)*

------
https://chatgpt.com/codex/tasks/task_e_68b04e72728483298149b10e6aee8e53