### PR TITLE
Use executeStatement for terminal upsert

### DIFF
--- a/app/Services/TerminalService.php
+++ b/app/Services/TerminalService.php
@@ -59,13 +59,20 @@ class TerminalService
                     return false;
                 }
 
-                $stmt->execute([
+                $affected = $stmt->executeStatement([
                     'terminalId' => $terminalId,
                     'storeId'    => $storeId,
                     'metadata'   => $metadata,
                     'createdAt'  => $now,
                     'updatedAt'  => $now,
                 ]);
+
+                if ($affected < 1) {
+                    $this->context->getLog()->error(
+                        "TerminalService::upsertTerminals: failed to upsert terminal_id={$terminalId}"
+                    );
+                    return false;
+                }
             }
 
             return true;


### PR DESCRIPTION
## Summary
- use executeStatement instead of deprecated execute for terminal upserts
- ensure upsert succeeds for each terminal before returning

## Testing
- `composer test` *(fails: Command "test" is not defined)*
- `php -l app/Services/TerminalService.php`


------
https://chatgpt.com/codex/tasks/task_e_68b04e73817c8329bc04f89ca1347f7b