### PR TITLE
Refactor logging to use Doctrine DBAL connection

### DIFF
--- a/app/Services/CustomPDOHandler.php
+++ b/app/Services/CustomPDOHandler.php
@@ -2,23 +2,23 @@
 
 namespace App\Services;
 
+use Doctrine\DBAL\Connection;
 use Monolog\Handler\AbstractProcessingHandler;
 use Monolog\Logger;
 
 class CustomPDOHandler extends AbstractProcessingHandler {
-    private \PDO $pdo;
+    private Connection $conn;
 
-    public function __construct(\PDO $pdo, $level = Logger::DEBUG, bool $bubble = true) {
+    public function __construct(Connection $conn, $level = Logger::DEBUG, bool $bubble = true) {
         parent::__construct($level, $bubble);
-        $this->pdo = $pdo;
+        $this->conn = $conn;
     }
 
     protected function write(array $record): void {
         $sql = "INSERT INTO log (request_id, type, level, channel, message, merchant, url, details)
                 VALUES (:request_id, :type, :level, :channel, :message, :merchant, :url, :details)";
-        $stmt = $this->pdo->prepare($sql);
 
-        $stmt->execute([
+        $this->conn->executeStatement($sql, [
             'request_id' => $record['context']['request_id'] ?? null,
             'type' => $record['context']['type'] ?? null, // Log type corresponds to the Monolog channel
             'level' => $record['level'],

--- a/public/cron.php
+++ b/public/cron.php
@@ -28,13 +28,7 @@ $conn = DriverManager::getConnection($connectionParams);
 $conn->executeStatement("SET TIME ZONE '" . ConfigApp::$timezone . "'");
 
 // Logger setup
-$pdo = new \PDO(
-    'pgsql:host=' . ConfigDatabase::$host . ';port=' . ConfigDatabase::$port . ';dbname=' . ConfigDatabase::$database,
-    ConfigDatabase::$username,
-    ConfigDatabase::$password,
-    [\PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION]
-);
-$logHandler = new CustomPDOHandler($pdo);
+$logHandler = new CustomPDOHandler($conn);
 $log = new Logger('app-poynt-log');
 $log->pushHandler($logHandler);
 $requestId = Uuid::uuid4()->toString();

--- a/public/index.php
+++ b/public/index.php
@@ -51,16 +51,7 @@ try {
 }
 
 // Logger setup
-$pdo = new \PDO(
-    'pgsql:host=' . ConfigDatabase::$host . ';port=' . ConfigDatabase::$port . ';dbname=' . ConfigDatabase::$database,
-    ConfigDatabase::$username,
-    ConfigDatabase::$password,
-    [
-        \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION,
-        \PDO::ATTR_EMULATE_PREPARES => false,
-    ]
-);
-$logHandler = new CustomPDOHandler($pdo);
+$logHandler = new CustomPDOHandler($conn);
 $log = new Logger('app-poynt-log');
 $log->pushHandler($logHandler);
 


### PR DESCRIPTION
## Summary
- replace direct PDO usage in custom log handler with Doctrine DBAL `Connection`
- wire web and cron entry points to inject DBAL connection into logger

## Testing
- ⚠️ `composer test` *(Command "test" is not defined.)*
- ⚠️ `vendor/bin/phpunit` *(No such file or directory)*
- ✅ `php -l app/Services/CustomPDOHandler.php`
- ✅ `php -l public/index.php`
- ✅ `php -l public/cron.php`


------
https://chatgpt.com/codex/tasks/task_e_68b04e746ad483299cdaa2e58278f743