### PR TITLE
Add transaction storage service and migrations

### DIFF
--- a/app/Fetchers/TransactionFetcher.php
+++ b/app/Fetchers/TransactionFetcher.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Fetchers;
+
+use App\Core\Context;
+use App\Services\TransactionService;
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\GuzzleException;
+
+class TransactionFetcher
+{
+    private Client $httpClient;
+    private Context $context;
+
+    const POYNT_ENDPOINT = 'https://services.poynt.net/businesses';
+
+    public function __construct(Context $context)
+    {
+        $this->context = $context;
+        $this->httpClient = new Client();
+    }
+
+    /**
+     * Fetch transactions for a business and store them via the service.
+     *
+     * @param string $accessToken OAuth token.
+     * @param string $businessId Business identifier.
+     * @return bool True on success, false otherwise.
+     */
+    public function fetchAndStore(string $accessToken, string $businessId): bool
+    {
+        try {
+            $url = self::POYNT_ENDPOINT . '/' . $businessId . '/transactions';
+            $response = $this->httpClient->get($url, [
+                'headers' => [
+                    'Authorization' => 'Bearer ' . $accessToken,
+                ],
+            ]);
+
+            $data = json_decode($response->getBody(), true);
+            if (!$data || !isset($data['transactions'])) {
+                return false;
+            }
+
+            $service = new TransactionService($this->context);
+            foreach ($data['transactions'] as $transaction) {
+                $service->upsert($transaction, $transaction['receipt'] ?? null);
+            }
+
+            return true;
+        } catch (GuzzleException $e) {
+            $this->context->getLog()->error('TransactionFetcher::fetchAndStore: ' . $e->getMessage());
+            return false;
+        }
+    }
+}
+

--- a/app/Services/TransactionService.php
+++ b/app/Services/TransactionService.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace App\Services;
+
+use App\Core\Context;
+
+class TransactionService
+{
+    private Context $context;
+
+    public function __construct(Context $context)
+    {
+        $this->context = $context;
+    }
+
+    /**
+     * Upsert a transaction and optionally its receipt.
+     *
+     * @param array $transactionData Data for the transaction.
+     * @param array|null $receiptData Optional receipt data.
+     * @return bool True on success, false on failure.
+     */
+    public function upsert(array $transactionData, ?array $receiptData = null): bool
+    {
+        // Require transaction id and business id
+        if (!isset($transactionData['id'], $transactionData['businessId'])) {
+            $this->context->getLog()->error(
+                'TransactionService::upsert: missing required fields id or businessId'
+            );
+            return false;
+        }
+
+        $transactionId = $transactionData['id'];
+        $businessId = $transactionData['businessId'];
+
+        $metadata = json_encode($transactionData);
+        if ($metadata === false) {
+            $this->context->getLog()->error(
+                "TransactionService::upsert: failed to encode metadata for transaction_id={$transactionId}"
+            );
+            return false;
+        }
+
+        $now = (new \DateTime('now'))->format('Y-m-d H:i:sP');
+
+        try {
+            $existing = $this->context->getConn()->fetchAssociative(
+                'SELECT transaction_id FROM transaction WHERE transaction_id = ?',
+                [$transactionId]
+            );
+
+            if ($existing) {
+                $this->context->getConn()->update(
+                    'transaction',
+                    [
+                        'business_id' => $businessId,
+                        'metadata' => $metadata,
+                        'updated_at' => $now,
+                    ],
+                    ['transaction_id' => $transactionId]
+                );
+            } else {
+                $this->context->getConn()->insert(
+                    'transaction',
+                    [
+                        'transaction_id' => $transactionId,
+                        'business_id' => $businessId,
+                        'metadata' => $metadata,
+                        'created_at' => $now,
+                        'updated_at' => $now,
+                    ]
+                );
+            }
+
+            if ($receiptData !== null) {
+                $receiptJson = json_encode($receiptData);
+                if ($receiptJson === false) {
+                    $this->context->getLog()->error(
+                        "TransactionService::upsert: failed to encode receipt for transaction_id={$transactionId}"
+                    );
+                    return false;
+                }
+
+                $receiptExisting = $this->context->getConn()->fetchAssociative(
+                    'SELECT transaction_id FROM transaction_receipt WHERE transaction_id = ?',
+                    [$transactionId]
+                );
+
+                if ($receiptExisting) {
+                    $this->context->getConn()->update(
+                        'transaction_receipt',
+                        [
+                            'data' => $receiptJson,
+                            'updated_at' => $now,
+                        ],
+                        ['transaction_id' => $transactionId]
+                    );
+                } else {
+                    $this->context->getConn()->insert(
+                        'transaction_receipt',
+                        [
+                            'transaction_id' => $transactionId,
+                            'data' => $receiptJson,
+                            'created_at' => $now,
+                            'updated_at' => $now,
+                        ]
+                    );
+                }
+            }
+
+            return true;
+        } catch (\Throwable $e) {
+            $this->context->getLog()->error(
+                'TransactionService::upsert: database error: ' . $e->getMessage()
+            );
+            return false;
+        }
+    }
+}
+

--- a/database/migrations/20240901000000_create_transaction_table.sql
+++ b/database/migrations/20240901000000_create_transaction_table.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS transaction (
+    id SERIAL PRIMARY KEY,
+    transaction_id VARCHAR(255) UNIQUE NOT NULL,
+    business_id VARCHAR(255) NOT NULL,
+    metadata JSON NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);

--- a/database/migrations/20240901000001_create_transaction_receipt_table.sql
+++ b/database/migrations/20240901000001_create_transaction_receipt_table.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS transaction_receipt (
+    id SERIAL PRIMARY KEY,
+    transaction_id VARCHAR(255) NOT NULL REFERENCES transaction(transaction_id) ON DELETE CASCADE,
+    data JSON NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);


### PR DESCRIPTION
## Summary
- add migrations for transaction and transaction_receipt tables
- implement TransactionService for upserting transactions and receipts
- add TransactionFetcher to retrieve transactions from Poynt API and store them

## Testing
- `php -l app/Services/TransactionService.php`
- `php -l app/Fetchers/TransactionFetcher.php`
- `composer dump-autoload`

------
https://chatgpt.com/codex/tasks/task_e_68b058576a0883298280510341ba0b19