### PR TITLE
Add centralized Guzzle client factory for shared HTTP configuration

### DIFF
--- a/app/Core/Context.php
+++ b/app/Core/Context.php
@@ -2,7 +2,9 @@
 
 namespace App\Core;
 
+use App\Http\GuzzleClientFactory;
 use Doctrine\DBAL\Connection;
+use GuzzleHttp\ClientInterface;
 use Monolog\Logger;
 
 class Context
@@ -10,12 +12,14 @@ class Context
     private Api $api;
     private Connection $conn;
     private Logger $log;
+    private GuzzleClientFactory $httpClientFactory;
 
-    public function __construct(Api $api, Connection $conn, Logger $log)
+    public function __construct(Api $api, Connection $conn, Logger $log, ?GuzzleClientFactory $httpClientFactory = null)
     {
         $this->api = $api;
         $this->conn = $conn;
         $this->log = $log;
+        $this->httpClientFactory = $httpClientFactory ?? new GuzzleClientFactory();
     }
 
     public function getApi(): Api
@@ -31,5 +35,15 @@ class Context
     public function getLog(): Logger
     {
         return $this->log;
+    }
+
+    public function getHttpClient(): ClientInterface
+    {
+        return $this->httpClientFactory->getDefaultClient();
+    }
+
+    public function getHttpClientFactory(): GuzzleClientFactory
+    {
+        return $this->httpClientFactory;
     }
 }

--- a/app/Fetchers/MerchantFetcher.php
+++ b/app/Fetchers/MerchantFetcher.php
@@ -3,24 +3,24 @@ namespace App\Fetchers;
 
 use App\Config\ConfigApp;
 use Doctrine\DBAL\Driver\IBMDB2\Result;
-use GuzzleHttp\Client;
+use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\GuzzleException;
 use App\Core\Context;
 use App\Services\OrderService;
 
 class MerchantFetcher
 {
-    private Client $httpClient;
+    private ClientInterface $httpClient;
     private Context $context;
 
     const POYNT_ENDPOINT_API = 'https://services.poynt.net/businesses';
     const POYNT_ENDPOINT_GET_BUSINESS = 'https://services.poynt.net/businesses';
     const POYNT_ENDPOINT_GET_ORDERS = 'https://services.poynt.net/businesses';
 
-    public function __construct(Context $context)
+    public function __construct(Context $context, ?ClientInterface $httpClient = null)
     {
         $this->context = $context;
-        $this->httpClient = new Client();
+        $this->httpClient = $httpClient ?? $context->getHttpClient();
     }
 
     /**

--- a/app/Http/GuzzleClientFactory.php
+++ b/app/Http/GuzzleClientFactory.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Http;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\ClientInterface;
+
+class GuzzleClientFactory
+{
+    /**
+     * @var array<string, mixed>
+     */
+    private array $defaultConfig;
+
+    private ?ClientInterface $defaultClient = null;
+
+    /**
+     * @param array<string, mixed> $defaultConfig
+     */
+    public function __construct(array $defaultConfig = [])
+    {
+        $this->defaultConfig = array_merge([
+            'base_uri' => 'https://services.poynt.net',
+            'timeout' => 10.0,
+            'headers' => [
+                'Accept' => 'application/json',
+            ],
+        ], $defaultConfig);
+    }
+
+    public function getDefaultClient(): ClientInterface
+    {
+        if ($this->defaultClient === null) {
+            $this->defaultClient = $this->create();
+        }
+
+        return $this->defaultClient;
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     */
+    public function create(array $config = []): ClientInterface
+    {
+        $mergedConfig = $this->mergeConfig($config);
+
+        return new Client($mergedConfig);
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     * @return array<string, mixed>
+     */
+    private function mergeConfig(array $config): array
+    {
+        $merged = array_merge($this->defaultConfig, $config);
+
+        if (isset($this->defaultConfig['headers']) || isset($config['headers'])) {
+            $merged['headers'] = array_merge(
+                $this->defaultConfig['headers'] ?? [],
+                $config['headers'] ?? []
+            );
+        }
+
+        return $merged;
+    }
+}
+

--- a/app/Services/BusinessService.php
+++ b/app/Services/BusinessService.php
@@ -3,19 +3,21 @@
 namespace App\Services;
 
 use App\Core\Context;
-use GuzzleHttp\Client;
+use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\GuzzleException;
 
 class BusinessService {
 
     private Context $context;
+    private ClientInterface $httpClient;
     private ?string $businessId = null;
 
     const POYNT_ENDPOINT_API_BUSINESS = 'https://services.poynt.net/businesses';
 
-    public function __construct(Context $context, ?string $businessId = null)
+    public function __construct(Context $context, ?string $businessId = null, ?ClientInterface $httpClient = null)
     {
         $this->context = $context;
+        $this->httpClient = $httpClient ?? $context->getHttpClient();
         if ($businessId !== null) {
             $this->businessId = $businessId;
         }
@@ -120,10 +122,8 @@ class BusinessService {
 
         // TODO remove all Guzzle things into separated class?
 
-        $httpClient = new Client();
-
         try {
-            $response = $httpClient->get(self::POYNT_ENDPOINT_API_BUSINESS . '/' . $businessId, [
+            $response = $this->httpClient->get(self::POYNT_ENDPOINT_API_BUSINESS . '/' . $businessId, [
                 'headers' => [
                     'Authorization' => 'Bearer ' . $accessToken,
                 ],
@@ -176,10 +176,8 @@ class BusinessService {
         $tokenService = new TokenService($this->context);
         $accessToken  = $tokenService->getMerchantToken($businessId);
 
-        $httpClient = new Client();
-
         try {
-            $response = $httpClient->get(self::POYNT_ENDPOINT_API_BUSINESS . '/' . $businessId . '/orders', [
+            $response = $this->httpClient->get(self::POYNT_ENDPOINT_API_BUSINESS . '/' . $businessId . '/orders', [
                 'headers' => [
                     'Authorization' => 'Bearer ' . $accessToken,
                 ],
@@ -231,10 +229,8 @@ class BusinessService {
         $tokenService = new TokenService($this->context);
         $accessToken = $tokenService->getMerchantToken($businessId);
 
-        $httpClient = new Client();
-
         try {
-            $response = $httpClient->get(self::POYNT_ENDPOINT_API_BUSINESS . '/' . $businessId . '/stores', [
+            $response = $this->httpClient->get(self::POYNT_ENDPOINT_API_BUSINESS . '/' . $businessId . '/stores', [
                 'headers' => [
                     'Authorization' => 'Bearer ' . $accessToken,
                 ],

--- a/app/Services/BusinessUserService.php
+++ b/app/Services/BusinessUserService.php
@@ -3,21 +3,21 @@
 namespace App\Services;
 
 use App\Core\Context;
-use GuzzleHttp\Client;
+use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\GuzzleException;
 
 class BusinessUserService
 {
     private Context $context;
-    private Client $httpClient;
+    private ClientInterface $httpClient;
     private ?string $businessId = null;
 
     const POYNT_ENDPOINT = 'https://services.poynt.net/businesses';
 
-    public function __construct(Context $context, ?string $businessId = null)
+    public function __construct(Context $context, ?string $businessId = null, ?ClientInterface $httpClient = null)
     {
         $this->context = $context;
-        $this->httpClient = new Client();
+        $this->httpClient = $httpClient ?? $context->getHttpClient();
         if ($businessId !== null) {
             $this->businessId = $businessId;
         }

--- a/app/Services/CatalogService.php
+++ b/app/Services/CatalogService.php
@@ -3,21 +3,21 @@
 namespace App\Services;
 
 use App\Core\Context;
-use GuzzleHttp\Client;
+use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\GuzzleException;
 
 class CatalogService
 {
     private Context $context;
-    private Client $httpClient;
+    private ClientInterface $httpClient;
     private ?string $businessId = null;
 
     const POYNT_ENDPOINT = 'https://services.poynt.net/businesses';
 
-    public function __construct(Context $context, ?string $businessId = null)
+    public function __construct(Context $context, ?string $businessId = null, ?ClientInterface $httpClient = null)
     {
         $this->context = $context;
-        $this->httpClient = new Client();
+        $this->httpClient = $httpClient ?? $context->getHttpClient();
         if ($businessId !== null) {
             $this->businessId = $businessId;
         }

--- a/app/Services/CustomerService.php
+++ b/app/Services/CustomerService.php
@@ -3,21 +3,21 @@
 namespace App\Services;
 
 use App\Core\Context;
-use GuzzleHttp\Client;
+use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\GuzzleException;
 
 class CustomerService
 {
     private Context $context;
-    private Client $httpClient;
+    private ClientInterface $httpClient;
     private ?string $businessId = null;
 
     const POYNT_ENDPOINT = 'https://services.poynt.net/businesses';
 
-    public function __construct(Context $context, ?string $businessId = null)
+    public function __construct(Context $context, ?string $businessId = null, ?ClientInterface $httpClient = null)
     {
         $this->context = $context;
-        $this->httpClient = new Client();
+        $this->httpClient = $httpClient ?? $context->getHttpClient();
         if ($businessId !== null) {
             $this->businessId = $businessId;
         }

--- a/app/Services/HookService.php
+++ b/app/Services/HookService.php
@@ -3,21 +3,21 @@
 namespace App\Services;
 
 use App\Core\Context;
-use GuzzleHttp\Client;
+use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\GuzzleException;
 
 class HookService
 {
     private Context $context;
-    private Client $httpClient;
+    private ClientInterface $httpClient;
     private ?string $businessId = null;
 
     const POYNT_ENDPOINT = 'https://services.poynt.net/businesses';
 
-    public function __construct(Context $context, ?string $businessId = null)
+    public function __construct(Context $context, ?string $businessId = null, ?ClientInterface $httpClient = null)
     {
         $this->context = $context;
-        $this->httpClient = new Client();
+        $this->httpClient = $httpClient ?? $context->getHttpClient();
         if ($businessId !== null) {
             $this->businessId = $businessId;
         }

--- a/app/Services/InventorySummaryService.php
+++ b/app/Services/InventorySummaryService.php
@@ -3,21 +3,21 @@
 namespace App\Services;
 
 use App\Core\Context;
-use GuzzleHttp\Client;
+use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\GuzzleException;
 
 class InventorySummaryService
 {
     private Context $context;
-    private Client $httpClient;
+    private ClientInterface $httpClient;
     private ?string $businessId = null;
 
     const POYNT_ENDPOINT = 'https://services.poynt.net/businesses';
 
-    public function __construct(Context $context, ?string $businessId = null)
+    public function __construct(Context $context, ?string $businessId = null, ?ClientInterface $httpClient = null)
     {
         $this->context = $context;
-        $this->httpClient = new Client();
+        $this->httpClient = $httpClient ?? $context->getHttpClient();
         if ($businessId !== null) {
             $this->businessId = $businessId;
         }

--- a/app/Services/OAuthService.php
+++ b/app/Services/OAuthService.php
@@ -5,7 +5,7 @@ namespace App\Services;
 use App\Config\ConfigApp;
 use App\Core\Context;
 use Firebase\JWT\JWT;
-use GuzzleHttp\Client;
+use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Exception\RequestException;
 use Ramsey\Uuid\Uuid;
@@ -18,10 +18,12 @@ class OAuthService {
     const JWT_EXPIRATION_TIME = 30; // 3600
 
     private Context $context;
+    private ClientInterface $httpClient;
 
-    public function __construct(Context $context)
+    public function __construct(Context $context, ?ClientInterface $httpClient = null)
     {
         $this->context = $context;
+        $this->httpClient = $httpClient ?? $context->getHttpClient();
     }
 
 
@@ -62,8 +64,7 @@ class OAuthService {
         // 2. Send token exchange request
         try {
             $responseData = [];
-            $client = new Client();
-            $response = $client->post(self::POYNT_ENDPOINT_TOKEN, [
+            $response = $this->httpClient->post(self::POYNT_ENDPOINT_TOKEN, [
                 'headers' => [
                     'Accept' => 'application/json',
                     'api-version' => '1.2',
@@ -127,8 +128,7 @@ class OAuthService {
 
         // 3. Send POST request to exchange code for Merchant Access Token
         try {
-            $client = new Client();
-            $response = $client->post(self::POYNT_ENDPOINT_TOKEN, [
+            $response = $this->httpClient->post(self::POYNT_ENDPOINT_TOKEN, [
                 'headers' => [
                     'Content-Type'  => 'application/x-www-form-urlencoded',
                     'api-version'   => '1.2',
@@ -167,8 +167,7 @@ class OAuthService {
     public function refreshMerchantToken(string $refreshToken): ?array
     {
         try {
-            $client = new Client();
-            $response = $client->post(self::POYNT_ENDPOINT_TOKEN, [
+            $response = $this->httpClient->post(self::POYNT_ENDPOINT_TOKEN, [
                 'headers' => [
                     'Content-Type' => 'application/x-www-form-urlencoded',
                     'api-version'  => '1.2',

--- a/app/Services/PaylinkService.php
+++ b/app/Services/PaylinkService.php
@@ -3,21 +3,21 @@
 namespace App\Services;
 
 use App\Core\Context;
-use GuzzleHttp\Client;
+use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\GuzzleException;
 
 class PaylinkService
 {
     private Context $context;
-    private Client $httpClient;
+    private ClientInterface $httpClient;
     private ?string $businessId = null;
 
     const POYNT_ENDPOINT = 'https://services.poynt.net/businesses';
 
-    public function __construct(Context $context, ?string $businessId = null)
+    public function __construct(Context $context, ?string $businessId = null, ?ClientInterface $httpClient = null)
     {
         $this->context = $context;
-        $this->httpClient = new Client();
+        $this->httpClient = $httpClient ?? $context->getHttpClient();
         if ($businessId !== null) {
             $this->businessId = $businessId;
         }

--- a/app/Services/ProductService.php
+++ b/app/Services/ProductService.php
@@ -3,21 +3,21 @@
 namespace App\Services;
 
 use App\Core\Context;
-use GuzzleHttp\Client;
+use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\GuzzleException;
 
 class ProductService
 {
     private Context $context;
-    private Client $httpClient;
+    private ClientInterface $httpClient;
     private ?string $businessId = null;
 
     const POYNT_ENDPOINT = 'https://services.poynt.net/businesses';
 
-    public function __construct(Context $context, ?string $businessId = null)
+    public function __construct(Context $context, ?string $businessId = null, ?ClientInterface $httpClient = null)
     {
         $this->context = $context;
-        $this->httpClient = new Client();
+        $this->httpClient = $httpClient ?? $context->getHttpClient();
         if ($businessId !== null) {
             $this->businessId = $businessId;
         }

--- a/app/Services/SubscriptionService.php
+++ b/app/Services/SubscriptionService.php
@@ -11,7 +11,7 @@ use DateInterval;
 use DateTime;
 use DateTimeZone;
 use Exception;
-use GuzzleHttp\Client;
+use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Exception\RequestException;
 use JsonException;
@@ -23,20 +23,22 @@ class SubscriptionService
     public const POYNT_BILLING_BASE = 'https://billing.poynt.net/organizations';
     private const DEFAULT_TRIAL_DAYS = 14;
     private Context $context;
-    private Client $http;
+    private ClientInterface $http;
     private mixed $storeId;
 
-    public function __construct(Context $context, $storeId = null)
+    public function __construct(Context $context, $storeId = null, ?ClientInterface $httpClient = null)
     {
         $this->context = $context;
-        // A shared Guzzle client for all Poynt HTTP calls
-        $this->http = new Client([
-            'base_uri' => self::POYNT_BILLING_BASE,
-            'timeout'  => 10.0,
-        ]);
+        if ($httpClient !== null) {
+            $this->http = $httpClient;
+        } else {
+            $this->http = $context->getHttpClientFactory()->create([
+                'base_uri' => self::POYNT_BILLING_BASE,
+                'timeout' => 10.0,
+            ]);
+        }
 
-        if (!is_null($storeId))
-        {
+        if (!is_null($storeId)) {
             $this->storeId = $storeId;
         }
     }

--- a/app/Services/TaxService.php
+++ b/app/Services/TaxService.php
@@ -3,21 +3,21 @@
 namespace App\Services;
 
 use App\Core\Context;
-use GuzzleHttp\Client;
+use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\GuzzleException;
 
 class TaxService
 {
     private Context $context;
-    private Client $httpClient;
+    private ClientInterface $httpClient;
     private ?string $businessId = null;
 
     const POYNT_ENDPOINT = 'https://services.poynt.net/businesses';
 
-    public function __construct(Context $context, ?string $businessId = null)
+    public function __construct(Context $context, ?string $businessId = null, ?ClientInterface $httpClient = null)
     {
         $this->context = $context;
-        $this->httpClient = new Client();
+        $this->httpClient = $httpClient ?? $context->getHttpClient();
         if ($businessId !== null) {
             $this->businessId = $businessId;
         }

--- a/app/Services/TransactionService.php
+++ b/app/Services/TransactionService.php
@@ -3,7 +3,7 @@
 namespace App\Services;
 
 use App\Core\Context;
-use GuzzleHttp\Client;
+use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\GuzzleException;
 
 class TransactionService
@@ -11,12 +11,12 @@ class TransactionService
     private const POYNT_ENDPOINT = 'https://services.poynt.net/businesses';
 
     private Context $context;
-    private Client $httpClient;
+    private ClientInterface $httpClient;
 
-    public function __construct(Context $context)
+    public function __construct(Context $context, ?ClientInterface $httpClient = null)
     {
         $this->context = $context;
-        $this->httpClient = new Client();
+        $this->httpClient = $httpClient ?? $context->getHttpClient();
     }
 
     /**

--- a/app/Services/WebhookService.php
+++ b/app/Services/WebhookService.php
@@ -4,7 +4,7 @@ namespace App\Services;
 
 use App\Config\ConfigApp;
 use App\Core\Context;
-use GuzzleHttp\Client;
+use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Exception\RequestException;
 use PDO;
@@ -13,6 +13,7 @@ class WebhookService
 {
     protected Context $context;
     private ?string $businessId;
+    private ClientInterface $httpClient;
 
     public const POYNT_WEBHOOK_URL = 'https://services.poynt.net/hooks';
 
@@ -21,10 +22,11 @@ class WebhookService
      *
      * @param Context $context An object containing dependencies (like logger, config, etc.)
      */
-    public function __construct(Context $context, ?string $businessId = null)
+    public function __construct(Context $context, ?string $businessId = null, ?ClientInterface $httpClient = null)
     {
         $this->context = $context;
         $this->businessId = $businessId;
+        $this->httpClient = $httpClient ?? $context->getHttpClient();
     }
 
     /**
@@ -40,8 +42,6 @@ class WebhookService
      */
     public function registerWebhook(string $merchantAccessToken, array $events): mixed
     {
-        $client = new Client();
-
         // Build the payload
         $payload = [
             'applicationId' => 'urn:aid:' . ConfigApp::$appId,
@@ -51,7 +51,7 @@ class WebhookService
         ];
 
         try {
-            $response = $client->post(self::POYNT_WEBHOOK_URL, [
+            $response = $this->httpClient->post(self::POYNT_WEBHOOK_URL, [
                 'headers' => [
                     'Content-Type'  => 'application/json',
                     'Authorization' => 'Bearer ' . $merchantAccessToken,

--- a/public/cron.php
+++ b/public/cron.php
@@ -7,6 +7,7 @@ use App\Config\ConfigApp;
 use App\Config\ConfigDatabase;
 use App\Core\Api;
 use App\Core\Context;
+use App\Http\GuzzleClientFactory;
 use App\Services\BackgroundJobService;
 use App\Services\CustomPDOHandler;
 use Doctrine\DBAL\DriverManager;
@@ -38,7 +39,8 @@ $log->pushProcessor(function ($record) use ($requestId) {
 });
 
 $api = new Api('', $log, $requestId);
-$context = new Context($api, $conn, $log);
+$httpClientFactory = new GuzzleClientFactory();
+$context = new Context($api, $conn, $log, $httpClientFactory);
 
 $service = new BackgroundJobService($context);
 $service->refreshExpiringTokens();

--- a/public/index.php
+++ b/public/index.php
@@ -14,6 +14,7 @@ use App\Core\Context;
 use App\Core\RouterResolver;
 use App\Core\Response;
 use Doctrine\DBAL\DriverManager;
+use App\Http\GuzzleClientFactory;
 use App\Services\CustomPDOHandler;
 use Ramsey\Uuid\Uuid;
 
@@ -63,7 +64,8 @@ $log->pushProcessor(function ($record) use ($requestId) {
 });
 
 $api = new Api($_REQUEST['request'] ?? '', $log, $requestId);
-$context = new Context($api, $conn, $log);
+$httpClientFactory = new GuzzleClientFactory();
+$context = new Context($api, $conn, $log, $httpClientFactory);
 
 // Dependency injection container
 $appContainer = new Container();

--- a/tests/Services/SubscriptionServiceTest.php
+++ b/tests/Services/SubscriptionServiceTest.php
@@ -102,8 +102,6 @@ namespace Services {
          */
         private function createServiceWithQueue(array $queue): SubscriptionService
         {
-            $service = new SubscriptionService($this->context);
-
             $mockHandler = new MockHandler($queue);
             $handlerStack = HandlerStack::create($mockHandler);
             $client = new Client([
@@ -111,11 +109,7 @@ namespace Services {
                 'base_uri' => SubscriptionService::POYNT_BILLING_BASE,
             ]);
 
-            $property = new \ReflectionProperty(SubscriptionService::class, 'http');
-            $property->setAccessible(true);
-            $property->setValue($service, $client);
-
-            return $service;
+            return new SubscriptionService($this->context, null, $client);
         }
 
     }


### PR DESCRIPTION
## Summary
- add a reusable `GuzzleClientFactory` that provides shared defaults for outbound HTTP requests
- inject the factory into `Context` and update fetchers/services to depend on `ClientInterface` instances instead of instantiating clients directly
- refresh the subscription service test to supply a mock client through the new constructor signature

## Testing
- `php -l app/Core/Context.php app/Http/GuzzleClientFactory.php app/Fetchers/MerchantFetcher.php app/Services/BusinessService.php app/Services/BusinessUserService.php app/Services/CatalogService.php app/Services/CustomerService.php app/Services/HookService.php app/Services/InventorySummaryService.php app/Services/OAuthService.php app/Services/PaylinkService.php app/Services/ProductService.php app/Services/SubscriptionService.php app/Services/TaxService.php app/Services/TransactionService.php app/Services/WebhookService.php public/cron.php public/index.php tests/Services/SubscriptionServiceTest.php`
- `composer install` *(fails: unable to download firebase/php-jwt due to GitHub 403 tunnel requirement)*
- `./vendor/bin/phpunit` *(fails: binary missing because composer install could not complete)*

------
https://chatgpt.com/codex/tasks/task_e_68e8d7ee853c83299af2a9c638e14acf