### PR TITLE
Add comprehensive API endpoint tests

### DIFF
--- a/app/Controllers/OAuthController.php
+++ b/app/Controllers/OAuthController.php
@@ -11,11 +11,11 @@ class OAuthController extends Controller {
     private PlatformRegistry $platformRegistry;
     private CallbackService $callbackService;
 
-    public function __construct(Context $context) {
+    public function __construct(Context $context, ?PlatformRegistry $platformRegistry = null, ?CallbackService $callbackService = null) {
         parent::__construct($context);
 
-        $this->platformRegistry = new PlatformRegistry($this->context);
-        $this->callbackService = new CallbackService($this->context, $this->platformRegistry);
+        $this->platformRegistry = $platformRegistry ?? new PlatformRegistry($this->context);
+        $this->callbackService = $callbackService ?? new CallbackService($this->context, $this->platformRegistry);
     }
 
     /**
@@ -63,7 +63,9 @@ class OAuthController extends Controller {
             \App\Core\Api::response($result['status'], ['error' => $result['error']]);
         }
 
-        exit;
+        if (!\App\Core\Api::isExitDisabled()) {
+            exit;
+        }
     }
 
 

--- a/app/Controllers/SubscriptionController.php
+++ b/app/Controllers/SubscriptionController.php
@@ -69,4 +69,9 @@ class SubscriptionController extends Controller
             'status' => 'trialing',
         ];
     }
+
+    public function setSubscriptionService(SubscriptionService $subscriptionService): void
+    {
+        $this->subscriptionService = $subscriptionService;
+    }
 }

--- a/app/Controllers/TokenController.php
+++ b/app/Controllers/TokenController.php
@@ -7,15 +7,22 @@ use App\Services\BackgroundJobService;
 
 class TokenController extends Controller
 {
+    private BackgroundJobService $backgroundJobService;
+
     public function __construct(Context $context)
     {
         parent::__construct($context);
+        $this->backgroundJobService = new BackgroundJobService($this->context);
     }
 
     public function refreshTokens(): array
     {
-        $jobService = new BackgroundJobService($this->context);
-        $jobService->refreshExpiringTokens();
+        $this->backgroundJobService->refreshExpiringTokens();
         return ['status' => 'success'];
+    }
+
+    public function setBackgroundJobService(BackgroundJobService $backgroundJobService): void
+    {
+        $this->backgroundJobService = $backgroundJobService;
     }
 }

--- a/app/Controllers/WebhooksController.php
+++ b/app/Controllers/WebhooksController.php
@@ -10,9 +10,12 @@ use PDO;
 
 class WebhooksController extends Controller
 {
+    private SubscriptionService $subscriptionService;
+
     public function __construct(Context $context)
     {
         parent::__construct($context);
+        $this->subscriptionService = new SubscriptionService($context);
     }
 
     /**
@@ -37,7 +40,7 @@ class WebhooksController extends Controller
         $eventType = $payload['eventType'] ?? null;
 
         // Insert audit record with default processed=false
-        $headers = getallheaders();
+        $headers = $this->getAllHeaders();
         $conn = $this->context->getConn();
         $conn->insert('webhook_audit', [
             'event_type' => $eventType,
@@ -111,8 +114,7 @@ class WebhooksController extends Controller
             throw new \InvalidArgumentException('Missing subscription data');
         }
 
-        $service = new SubscriptionService($this->context);
-        $service->activateSubscription($subscriptionId, $businessId, $storeId);
+        $this->subscriptionService->activateSubscription($subscriptionId, $businessId, $storeId);
     }
 
     /**
@@ -130,8 +132,29 @@ class WebhooksController extends Controller
             throw new \InvalidArgumentException('Missing subscription data');
         }
 
-        $service = new SubscriptionService($this->context);
-        $service->cancelSubscription($subscriptionId, $businessId, $storeId);
+        $this->subscriptionService->cancelSubscription($subscriptionId, $businessId, $storeId);
+    }
+
+    private function getAllHeaders(): array
+    {
+        if (function_exists('getallheaders')) {
+            return getallheaders();
+        }
+
+        $headers = [];
+        foreach ($_SERVER as $name => $value) {
+            if (str_starts_with($name, 'HTTP_')) {
+                $headerName = str_replace(' ', '-', ucwords(strtolower(str_replace('_', ' ', substr($name, 5)))));
+                $headers[$headerName] = $value;
+            }
+        }
+
+        return $headers;
+    }
+
+    public function setSubscriptionService(SubscriptionService $subscriptionService): void
+    {
+        $this->subscriptionService = $subscriptionService;
     }
 
 }

--- a/app/Core/Api.php
+++ b/app/Core/Api.php
@@ -10,6 +10,16 @@ class Api
     private static ?LoggerInterface $log = null;
 
     /**
+     * @var bool
+     */
+    private static bool $exitDisabled = false;
+
+    /**
+     * @var array|null
+     */
+    private static ?array $lastResponse = null;
+
+    /**
      * @var string
      */
     private string $requestId;
@@ -142,7 +152,13 @@ class Api
         } else {
             $return = !$returnRaw ? json_encode(new Response($response)) : json_encode($response);
 
-            if ($exit) {
+            self::$lastResponse = [
+                'status' => $status,
+                'response' => $response,
+                'raw' => $return,
+            ];
+
+            if ($exit && !self::$exitDisabled) {
                 if (isset($response)) {
                     echo $return;
                 }
@@ -153,10 +169,35 @@ class Api
                     self::$log->debug(basename(__FILE__) . ' (' . __LINE__ . "): Data sent with error status '{$status}' and response '{$responseJSON}'.", self::getLogContext());
                 }
                 exit;
-            } else {
-                return $return;
             }
+
+            return $return;
         }
+    }
+
+    public static function disableExit(): void
+    {
+        self::$exitDisabled = true;
+    }
+
+    public static function enableExit(): void
+    {
+        self::$exitDisabled = false;
+    }
+
+    public static function getLastResponse(): ?array
+    {
+        return self::$lastResponse;
+    }
+
+    public static function clearLastResponse(): void
+    {
+        self::$lastResponse = null;
+    }
+
+    public static function isExitDisabled(): bool
+    {
+        return self::$exitDisabled;
     }
 
     /**

--- a/tests/Controllers/ApiEndpointsTest.php
+++ b/tests/Controllers/ApiEndpointsTest.php
@@ -1,0 +1,335 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Config {
+    if (!class_exists(__NAMESPACE__ . '\\ConfigApp')) {
+        class ConfigApp
+        {
+            public static string $platform = '';
+            public static string $orgId = '';
+            public static string $appId = '';
+        }
+    }
+}
+
+namespace Controllers {
+
+    use App\Controllers\OAuthController;
+    use App\Controllers\SubscriptionController;
+    use App\Controllers\TokenController;
+    use App\Controllers\WebhooksController;
+    use App\Core\Api;
+    use App\Core\Context;
+    use App\Core\Response;
+    use App\Core\RouterResolver;
+    use App\Modules\OAuth\PlatformRegistry;
+    use App\Services\BackgroundJobService;
+    use App\Services\CallbackService;
+    use App\Services\SubscriptionService;
+    use Doctrine\DBAL\Connection;
+    use League\Container\Container;
+    use Monolog\Handler\TestHandler;
+    use Monolog\Logger;
+    use Phroute\Phroute\Dispatcher;
+    use PHPUnit\Framework\MockObject\MockObject;
+    use PHPUnit\Framework\TestCase;
+
+    class ApiEndpointsTest extends TestCase
+    {
+        private TestHandler $testHandler;
+        private Logger $logger;
+
+        protected function setUp(): void
+        {
+            parent::setUp();
+            $this->testHandler = new TestHandler();
+            $this->logger = new Logger('test');
+            $this->logger->pushHandler($this->testHandler);
+            Api::disableExit();
+            Api::clearLastResponse();
+        }
+
+        protected function tearDown(): void
+        {
+            Api::enableExit();
+            Api::clearLastResponse();
+            parent::tearDown();
+        }
+
+        public function testInstallRouteReturnsStaticMessage(): void
+        {
+            $api = $this->createApi(method: 'GET');
+            $container = new Container();
+            $container->add('CONTEXT', $this->createContext($api));
+            $dispatcher = new Dispatcher($api->loadRouteData(), new RouterResolver($container));
+
+            $result = $dispatcher->dispatch('GET', '/install');
+
+            self::assertSame('Install endpoint reached!', $result);
+        }
+
+        public function testCallbackEndpointReturnsSuccessMessage(): void
+        {
+            $api = $this->createApi(['platform' => 'poynt'], 'GET');
+            $context = $this->createContext($api);
+
+            /** @var PlatformRegistry&MockObject $platformRegistry */
+            $platformRegistry = $this->getMockBuilder(PlatformRegistry::class)
+                ->disableOriginalConstructor()
+                ->getMock();
+
+            /** @var CallbackService&MockObject $callbackService */
+            $callbackService = $this->getMockBuilder(CallbackService::class)
+                ->disableOriginalConstructor()
+                ->onlyMethods(['handle'])
+                ->getMock();
+
+            $callbackService->expects(self::once())
+                ->method('handle')
+                ->with('poynt')
+                ->willReturn([
+                    'success' => true,
+                    'status' => Response::STATUS_OK,
+                    'message' => 'Callback handled',
+                ]);
+
+            $controller = new OAuthController($context, $platformRegistry, $callbackService);
+            $controller->callback();
+
+            $last = Api::getLastResponse();
+            self::assertNotNull($last);
+            self::assertSame(Response::STATUS_OK, $last['status']);
+            self::assertSame(['message' => 'Callback handled'], $last['response']);
+        }
+
+        public function testCallbackEndpointLogsErrorWhenFailureOccurs(): void
+        {
+            $api = $this->createApi(['platform' => 'poynt'], 'GET');
+            $context = $this->createContext($api);
+
+            $platformRegistry = $this->getMockBuilder(PlatformRegistry::class)
+                ->disableOriginalConstructor()
+                ->getMock();
+
+            $callbackService = $this->getMockBuilder(CallbackService::class)
+                ->disableOriginalConstructor()
+                ->onlyMethods(['handle'])
+                ->getMock();
+
+            $callbackService->expects(self::once())
+                ->method('handle')
+                ->with('poynt')
+                ->willReturn([
+                    'success' => false,
+                    'status' => Response::STATUS_BAD_REQUEST,
+                    'error' => 'Bad request',
+                ]);
+
+            $controller = new OAuthController($context, $platformRegistry, $callbackService);
+            $controller->callback();
+
+            $last = Api::getLastResponse();
+            self::assertNotNull($last);
+            self::assertSame(Response::STATUS_BAD_REQUEST, $last['status']);
+            self::assertSame(['error' => 'Bad request'], $last['response']);
+        }
+
+        public function testRefreshTokensEndpointRunsBackgroundJob(): void
+        {
+            $api = $this->createApi([], 'POST');
+            $context = $this->createContext($api);
+
+            /** @var BackgroundJobService&MockObject $jobService */
+            $jobService = $this->getMockBuilder(BackgroundJobService::class)
+                ->disableOriginalConstructor()
+                ->onlyMethods(['refreshExpiringTokens'])
+                ->getMock();
+
+            $jobService->expects(self::once())->method('refreshExpiringTokens');
+
+            $controller = new TokenController($context);
+            $controller->setBackgroundJobService($jobService);
+
+            $result = $controller->refreshTokens();
+
+            self::assertSame(['status' => 'success'], $result);
+        }
+
+        public function testSubscriptionStatusReturnsCurrentStatus(): void
+        {
+            $api = $this->createApi([
+                'merchantAccessToken' => 'token',
+                'businessId' => 'biz',
+                'storeId' => 'store',
+            ], 'GET');
+            $context = $this->createContext($api);
+
+            /** @var SubscriptionService&MockObject $service */
+            $service = $this->getMockBuilder(SubscriptionService::class)
+                ->disableOriginalConstructor()
+                ->onlyMethods(['fetchMerchantSubscription', 'hasTrialExpired'])
+                ->getMock();
+
+            $service->expects(self::once())
+                ->method('fetchMerchantSubscription')
+                ->with('token', 'biz', 'store')
+                ->willReturn([
+                    [
+                        'subscriptionId' => 'sub-123',
+                        'status' => 'ACTIVE',
+                    ],
+                ]);
+
+            $service->expects(self::once())
+                ->method('hasTrialExpired')
+                ->with('sub-123')
+                ->willReturn(false);
+
+            $controller = new SubscriptionController($context);
+            $controller->setSubscriptionService($service);
+
+            $controller->status();
+            $last = Api::getLastResponse();
+
+            self::assertNotNull($last);
+            self::assertSame(Response::STATUS_OK, $last['status']);
+            self::assertSame([
+                'subscriptionStatus' => 'ACTIVE',
+                'trialExpired' => false,
+            ], $last['response']);
+        }
+
+        public function testSubscriptionStatusReturnsBadRequestWhenMissingParameters(): void
+        {
+            $api = $this->createApi([], 'GET');
+            $context = $this->createContext($api);
+
+            $controller = new SubscriptionController($context);
+            $controller->status();
+
+            $last = Api::getLastResponse();
+            self::assertNotNull($last);
+            self::assertSame(Response::STATUS_BAD_REQUEST, $last['status']);
+            self::assertSame(['error' => 'Missing required parameters'], $last['response']);
+        }
+
+        public function testStartTrialEndpointReturnsNewSubscriptionId(): void
+        {
+            $api = $this->createApi([
+                'businessId' => 'biz',
+                'storeId' => 'store',
+                'trialPlanId' => 'trial-plan',
+            ], 'POST');
+            $context = $this->createContext($api);
+
+            $service = $this->getMockBuilder(SubscriptionService::class)
+                ->disableOriginalConstructor()
+                ->onlyMethods(['startFreeTrial'])
+                ->getMock();
+
+            $service->expects(self::once())
+                ->method('startFreeTrial')
+                ->with('biz', 'store', 'trial-plan')
+                ->willReturn('sub-456');
+
+            $controller = new SubscriptionController($context);
+            $controller->setSubscriptionService($service);
+
+            $result = $controller->startTrial();
+
+            self::assertSame([
+                'subscriptionId' => 'sub-456',
+                'status' => 'trialing',
+            ], $result);
+        }
+
+        public function testWebhookEndpointProcessesSubscriptionStartEvent(): void
+        {
+            $payload = [
+                'eventType' => 'APPLICATION_SUBSCRIPTION_START',
+                'subscriptionId' => 'sub-1',
+                'businessId' => 'biz-1',
+                'storeId' => 'store-1',
+            ];
+
+            $api = $this->createApi($payload, 'POST');
+            $connection = $this->createMock(Connection::class);
+
+            $connection->expects(self::once())
+                ->method('insert')
+                ->with('webhook_audit', self::callback(static function (array $data) use ($payload): bool {
+                    return $data['event_type'] === $payload['eventType'];
+                }), self::anything());
+
+            $connection->expects(self::once())
+                ->method('lastInsertId')
+                ->willReturn('1');
+
+            $connection->expects(self::once())
+                ->method('update')
+                ->with('webhook_audit', self::arrayHasKey('processed'), ['id' => '1'], self::anything());
+
+            $context = $this->createContext($api, $connection);
+
+            $service = $this->getMockBuilder(SubscriptionService::class)
+                ->disableOriginalConstructor()
+                ->onlyMethods(['activateSubscription', 'cancelSubscription'])
+                ->getMock();
+
+            $service->expects(self::once())
+                ->method('activateSubscription')
+                ->with('sub-1', 'biz-1', 'store-1');
+
+            $controller = new WebhooksController($context);
+            $controller->setSubscriptionService($service);
+
+            $controller->eventListener();
+
+            $last = Api::getLastResponse();
+            self::assertNotNull($last);
+            self::assertSame(Response::STATUS_OK, $last['status']);
+            self::assertSame(['status' => 'ok'], $last['response']);
+        }
+
+        public function testWebhookEndpointReturnsBadRequestForUnknownEvent(): void
+        {
+            $payload = ['eventType' => 'UNKNOWN_EVENT'];
+            $api = $this->createApi($payload, 'POST');
+
+            $connection = $this->createMock(Connection::class);
+            $connection->expects(self::once())->method('insert')->willReturn(1);
+            $connection->expects(self::once())->method('lastInsertId')->willReturn('1');
+            $connection->expects(self::once())->method('update');
+
+            $context = $this->createContext($api, $connection);
+
+            $controller = new WebhooksController($context);
+            $controller->eventListener();
+
+            $last = Api::getLastResponse();
+            self::assertNotNull($last);
+            self::assertSame(Response::STATUS_BAD_REQUEST, $last['status']);
+            self::assertSame(['error' => 'Unrecognized event'], $last['response']);
+        }
+
+        private function createApi(array $data = [], string $method = 'GET'): Api
+        {
+            $_SERVER['REQUEST_METHOD'] = $method;
+            $_SERVER['REMOTE_ADDR'] = '127.0.0.1';
+            $_SERVER['REQUEST_URI'] = '/';
+
+            $api = new Api('', $this->logger, 'test-request');
+            $api->data = $data;
+
+            return $api;
+        }
+
+        private function createContext(Api $api, ?Connection $connection = null): Context
+        {
+            $connection ??= $this->createMock(Connection::class);
+
+            return new Context($api, $connection, $this->logger);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add testing helpers to the API core so responses can be inspected without terminating execution
- allow controllers to receive mocked dependencies and harden webhook header handling
- introduce PHPUnit coverage that exercises every exposed API endpoint

## Testing
- composer install *(fails: GitHub 403 when downloading dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68e8e0c959e88329a0cebafdb79c3115