### PR TITLE
Start free trial and sync resources during OAuth callback

### DIFF
--- a/app/Services/CallbackService.php
+++ b/app/Services/CallbackService.php
@@ -5,16 +5,22 @@ namespace App\Services;
 use App\Core\Context;
 use App\Core\Response;
 use App\Modules\OAuth\PlatformRegistry;
+use Throwable;
 
 class CallbackService
 {
     private Context $context;
     private PlatformRegistry $platformRegistry;
+    private ServiceFactory $serviceFactory;
 
-    public function __construct(Context $context, PlatformRegistry $platformRegistry)
-    {
+    public function __construct(
+        Context $context,
+        PlatformRegistry $platformRegistry,
+        ?ServiceFactory $serviceFactory = null
+    ) {
         $this->context = $context;
         $this->platformRegistry = $platformRegistry;
+        $this->serviceFactory = $serviceFactory ?? new ServiceFactory($context);
     }
 
     /**
@@ -45,13 +51,23 @@ class CallbackService
         $merchantToken = $tokenResponse['data']['merchantAccessToken'] ?? [];
         $handler->storeTokens($appToken, $merchantToken);
 
-        $businessService = new BusinessService($this->context, $handler->getBusinessId());
-        if (!$businessService->businessExists()) {
-            $stores = $businessService->fetchBusinessStores();
+        $businessId = $handler->getBusinessId();
+        $storeId = $handler->getStoreId();
+
+        $businessService = $this->serviceFactory->business($businessId);
+        $this->startTrialIfMissing($businessId, $storeId);
+
+        if ($businessId) {
+            $stores = $businessService->fetchBusinessStores($businessId);
             $businessService->upsertStores($stores);
-            if ($business = $businessService->fetchBusinessById($handler->getBusinessId())) {
+
+            if ($business = $businessService->fetchBusinessById($businessId)) {
                 $businessService->upsert($business);
             }
+
+            $this->gatherInitialResources($businessId, $businessService);
+        } else {
+            $this->context->getLog()->warning('Skipping onboarding sync: missing businessId in callback response.');
         }
 
         $handler->registerWebhooks();
@@ -61,5 +77,197 @@ class CallbackService
             'status' => Response::STATUS_OK,
             'message' => 'Callback handled',
         ];
+    }
+
+    private function startTrialIfMissing(?string $businessId, ?string $storeId): void
+    {
+        if (!$businessId || !$storeId) {
+            $this->context->getLog()->warning('Unable to start trial: missing businessId or storeId.');
+            return;
+        }
+
+        try {
+            $existing = $this->context->getConn()->fetchAssociative(
+                'SELECT subscription_id FROM subscription WHERE business_id = ? AND store_id = ? LIMIT 1',
+                [$businessId, $storeId]
+            );
+        } catch (Throwable $e) {
+            $this->context->getLog()->error(
+                sprintf(
+                    'Failed to verify existing subscription for business %s store %s: %s',
+                    $businessId,
+                    $storeId,
+                    $e->getMessage()
+                )
+            );
+            return;
+        }
+
+        if ($existing) {
+            $this->context->getLog()->info(
+                sprintf(
+                    'Subscription already exists for business %s store %s, skipping free trial.',
+                    $businessId,
+                    $storeId
+                )
+            );
+            return;
+        }
+
+        try {
+            $subscriptionId = $this->serviceFactory->subscription()->startFreeTrial($businessId, $storeId);
+            $this->context->getLog()->info(
+                sprintf(
+                    'Started free trial %s for business %s store %s.',
+                    $subscriptionId,
+                    $businessId,
+                    $storeId
+                )
+            );
+        } catch (Throwable $e) {
+            $this->context->getLog()->error(
+                sprintf(
+                    'Failed to start free trial for business %s store %s: %s',
+                    $businessId,
+                    $storeId,
+                    $e->getMessage()
+                )
+            );
+        }
+    }
+
+    private function gatherInitialResources(
+        string $businessId,
+        BusinessService $businessService
+    ): void {
+        foreach ($this->serviceFactory->onboardingResources($businessId) as $service) {
+            $this->syncResourceCollection($businessId, $service);
+        }
+
+        $orders = $businessService->fetchBusinessOrders($businessId);
+        if (is_array($orders) && !empty($orders)) {
+            $orderService = $this->serviceFactory->order();
+            foreach ($orders as $order) {
+                if (!is_array($order)) {
+                    continue;
+                }
+
+                try {
+                    $orderService->upsert($order);
+                } catch (Throwable $e) {
+                    $this->context->getLog()->error(
+                        sprintf(
+                            'Failed to persist order %s for business %s: %s',
+                            $order['id'] ?? 'unknown',
+                            $businessId,
+                            $e->getMessage()
+                        )
+                    );
+                }
+            }
+        }
+
+        try {
+            $merchantToken = $this->serviceFactory->token()->getMerchantToken($businessId);
+        } catch (Throwable $e) {
+            $this->context->getLog()->error(
+                sprintf(
+                    'Failed to load merchant token for transaction sync (business %s): %s',
+                    $businessId,
+                    $e->getMessage()
+                )
+            );
+            return;
+        }
+
+        if (is_string($merchantToken) && $merchantToken !== '') {
+            try {
+                $this->serviceFactory->transaction()->fetchAndStore($merchantToken, $businessId);
+            } catch (Throwable $e) {
+                $this->context->getLog()->error(
+                    sprintf(
+                        'Failed to sync transactions for business %s: %s',
+                        $businessId,
+                        $e->getMessage()
+                    )
+                );
+            }
+        } else {
+            $this->context->getLog()->warning(
+                sprintf('No merchant token available for transaction sync (business %s).', $businessId)
+            );
+        }
+    }
+
+    /**
+     * @param object $service
+     */
+    private function syncResourceCollection(string $businessId, object $service): void
+    {
+        if (!method_exists($service, 'fetchByBusinessId') || !method_exists($service, 'upsert')) {
+            return;
+        }
+
+        try {
+            $raw = $service->fetchByBusinessId($businessId);
+        } catch (Throwable $e) {
+            $this->context->getLog()->error(
+                sprintf(
+                    'Failed to fetch onboarding resources for business %s: %s',
+                    $businessId,
+                    $e->getMessage()
+                )
+            );
+            return;
+        }
+
+        if (!is_array($raw) || empty($raw)) {
+            return;
+        }
+
+        foreach ($this->normalizeResourceItems($raw) as $item) {
+            if (!is_array($item)) {
+                continue;
+            }
+
+            try {
+                $service->upsert($item);
+            } catch (Throwable $e) {
+                $this->context->getLog()->error(
+                    sprintf(
+                        'Failed to persist onboarding resource for business %s: %s',
+                        $businessId,
+                        $e->getMessage()
+                    )
+                );
+            }
+        }
+    }
+
+    private function normalizeResourceItems(array $raw): array
+    {
+        if (array_is_list($raw)) {
+            return $raw;
+        }
+
+        $items = [];
+        foreach ($raw as $value) {
+            if (!is_array($value)) {
+                continue;
+            }
+
+            if (array_is_list($value)) {
+                foreach ($value as $nested) {
+                    if (is_array($nested)) {
+                        $items[] = $nested;
+                    }
+                }
+                continue;
+            }
+
+            $items[] = $value;
+        }
+
+        return $items;
     }
 }

--- a/app/Services/ServiceFactory.php
+++ b/app/Services/ServiceFactory.php
@@ -52,4 +52,49 @@ class ServiceFactory
     {
         return new HookService($this->context, $businessId);
     }
+
+    public function business(?string $businessId = null): BusinessService
+    {
+        return new BusinessService($this->context, $businessId);
+    }
+
+    public function subscription(?string $storeId = null): SubscriptionService
+    {
+        return new SubscriptionService($this->context, $storeId);
+    }
+
+    public function order(): OrderService
+    {
+        return new OrderService($this->context);
+    }
+
+    public function token(): TokenService
+    {
+        return new TokenService($this->context);
+    }
+
+    public function transaction(): TransactionService
+    {
+        return new TransactionService($this->context);
+    }
+
+    /**
+     * Return the list of resource services that should be synchronized during onboarding.
+     *
+     * @param string $businessId
+     * @return array
+     */
+    public function onboardingResources(string $businessId): array
+    {
+        return [
+            $this->businessUser($businessId),
+            $this->catalog($businessId),
+            $this->customer($businessId),
+            $this->inventorySummary($businessId),
+            $this->paylink($businessId),
+            $this->product($businessId),
+            $this->tax($businessId),
+            $this->hook($businessId),
+        ];
+    }
 }


### PR DESCRIPTION
## Summary
- start a merchant free trial automatically after completing the OAuth callback
- bootstrap the newly onboarded business by syncing stores, subscriptions, and related resources
- extend the service factory with helpers used during onboarding data collection

## Testing
- ./vendor/bin/phpunit *(fails: command not found because Composer dependencies could not be fully installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ef73bcdc808329b21f3a00c821c06f