### PR TITLE
Handle pagination links separately from product sync

### DIFF
--- a/app/Services/CallbackService.php
+++ b/app/Services/CallbackService.php
@@ -162,7 +162,9 @@ class CallbackService
             return;
         }
 
-        foreach ($this->normalizeResourceItems($raw) as $item) {
+        $normalized = $this->normalizeResourceItems($raw);
+
+        foreach ($normalized['items'] as $item) {
             if (!is_array($item)) {
                 continue;
             }
@@ -179,17 +181,46 @@ class CallbackService
                 );
             }
         }
+
+        $this->recordResourceLinks($service, $businessId, $normalized['links']);
     }
 
+    /**
+     * Split a mixed resource payload into a list of entity payloads and pagination links.
+     *
+     * @param array $raw
+     * @return array{items: array<int, array<mixed>>, links: array<int, array<mixed>>}
+     */
     private function normalizeResourceItems(array $raw): array
     {
+        $items = [];
+        $links = [];
+
         if (array_is_list($raw)) {
-            return $raw;
+            foreach ($raw as $value) {
+                if (is_array($value)) {
+                    $items[] = $value;
+                }
+            }
+
+            return [
+                'items' => $items,
+                'links' => $links,
+            ];
         }
 
-        $items = [];
-        foreach ($raw as $value) {
+        foreach ($raw as $key => $value) {
             if (!is_array($value)) {
+                continue;
+            }
+
+            if ($key === 'links') {
+                foreach ($value as $link) {
+                    if (is_array($link)) {
+                        $links[] = $link;
+                    }
+                }
+
                 continue;
             }
 
@@ -205,6 +236,30 @@ class CallbackService
             $items[] = $value;
         }
 
-        return $items;
+        return [
+            'items' => $items,
+            'links' => $links,
+        ];
+    }
+
+    private function recordResourceLinks(object $service, string $businessId, array $links): void
+    {
+        if (empty($links)) {
+            return;
+        }
+
+        $resourceClass = get_class($service);
+
+        $this->context->getLog()->info(
+            sprintf(
+                'CallbackService::syncResourceCollection: captured %d pagination link(s) for %s',
+                count($links),
+                $resourceClass
+            ),
+            [
+                'businessId' => $businessId,
+                'links' => $links,
+            ]
+        );
     }
 }

--- a/tests/Services/CallbackServiceTest.php
+++ b/tests/Services/CallbackServiceTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Services;
+
+use App\Core\Context;
+use App\Modules\OAuth\PlatformRegistry;
+use App\Services\CallbackService;
+use App\Services\ServiceFactory;
+use Monolog\Logger;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use ReflectionMethod;
+
+class CallbackServiceTest extends TestCase
+{
+    private function createCallbackService(Context $context): CallbackService
+    {
+        $platformRegistry = $this->createMock(PlatformRegistry::class);
+        $serviceFactory = $this->createMock(ServiceFactory::class);
+
+        return new CallbackService($context, $platformRegistry, $serviceFactory);
+    }
+
+    public function testNormalizeResourceItemsSeparatesLinksFromItems(): void
+    {
+        $logger = $this->createMock(Logger::class);
+        $context = $this->createMock(Context::class);
+        $context->method('getLog')->willReturn($logger);
+
+        $callbackService = $this->createCallbackService($context);
+
+        $raw = [
+            'links' => [
+                [
+                    'href' => '/businesses/123/products?page=2',
+                    'rel' => 'next',
+                    'method' => 'GET',
+                ],
+            ],
+            'products' => [
+                ['id' => 'product-1', 'businessId' => '123'],
+                ['id' => 'product-2', 'businessId' => '123'],
+            ],
+        ];
+
+        $reflection = new ReflectionClass($callbackService);
+        $method = $reflection->getMethod('normalizeResourceItems');
+        $method->setAccessible(true);
+
+        $result = $method->invoke($callbackService, $raw);
+
+        $this->assertArrayHasKey('items', $result);
+        $this->assertArrayHasKey('links', $result);
+        $this->assertCount(2, $result['items']);
+        $this->assertCount(1, $result['links']);
+        $this->assertSame('product-1', $result['items'][0]['id']);
+        $this->assertSame('/businesses/123/products?page=2', $result['links'][0]['href']);
+    }
+
+    public function testSyncResourceCollectionDoesNotUpsertLinkEntries(): void
+    {
+        $logger = $this->createMock(Logger::class);
+        $logger->expects($this->once())
+            ->method('info')
+            ->with(
+                $this->stringContains('captured'),
+                $this->arrayHasKey('links')
+            );
+
+        $context = $this->createMock(Context::class);
+        $context->method('getLog')->willReturn($logger);
+
+        $service = new class {
+            public array $upserted = [];
+
+            public function fetchByBusinessId(?string $businessId = null): array
+            {
+                return [
+                    'links' => [
+                        [
+                            'href' => '/businesses/' . ($businessId ?? 'n/a') . '/products?page=2',
+                            'rel' => 'next',
+                            'method' => 'GET',
+                        ],
+                    ],
+                    'products' => [
+                        ['id' => 'product-1', 'businessId' => $businessId],
+                    ],
+                ];
+            }
+
+            public function upsert(array $payload): void
+            {
+                $this->upserted[] = $payload;
+            }
+        };
+
+        $callbackService = $this->createCallbackService($context);
+
+        $method = new ReflectionMethod($callbackService, 'syncResourceCollection');
+        $method->setAccessible(true);
+        $method->invoke($callbackService, 'business-123', $service);
+
+        $this->assertSame([
+            ['id' => 'product-1', 'businessId' => 'business-123'],
+        ], $service->upserted);
+    }
+}


### PR DESCRIPTION
## Summary
- ensure CallbackService separates pagination links from resource payloads and logs them instead of treating them as items
- add CallbackService unit tests that cover the new normalization behaviour and guard against link arrays being passed to upsert

## Testing
- composer install *(fails: GitHub API 403 for psr/cache)*

------
https://chatgpt.com/codex/tasks/task_e_68f0c872d11083298f2c850320569caa