### PR TITLE
Store catalog available discounts

### DIFF
--- a/app/Services/CatalogService.php
+++ b/app/Services/CatalogService.php
@@ -85,6 +85,10 @@ class CatalogService
             if (!empty($products)) {
                 $this->syncCatalogProducts($catalogId, $products);
             }
+            $availableDiscounts = $this->resolveCatalogAvailableDiscounts($catalogData);
+            if (!empty($availableDiscounts)) {
+                $this->syncCatalogAvailableDiscounts($catalogId, $availableDiscounts);
+            }
             return true;
         } catch (\Throwable $e) {
             $this->context->getLog()->error(
@@ -202,6 +206,22 @@ class CatalogService
         return [];
     }
 
+    private function resolveCatalogAvailableDiscounts(array $catalogData): array
+    {
+        if (isset($catalogData['availableDiscounts']) && is_array($catalogData['availableDiscounts'])) {
+            return $catalogData['availableDiscounts'];
+        }
+
+        if (isset($catalogData['catalog']) && is_array($catalogData['catalog'])) {
+            $innerCatalog = $catalogData['catalog'];
+            if (isset($innerCatalog['availableDiscounts']) && is_array($innerCatalog['availableDiscounts'])) {
+                return $innerCatalog['availableDiscounts'];
+            }
+        }
+
+        return [];
+    }
+
     private function syncCatalogProducts(string $catalogId, array $products): void
     {
         foreach ($products as $product) {
@@ -237,6 +257,51 @@ class CatalogService
             } catch (\Throwable $e) {
                 $this->context->getLog()->error(
                     sprintf('CatalogService::syncCatalogProducts: failed for catalog %s product %s: %s', $catalogId, $product['id'], $e->getMessage())
+                );
+            }
+        }
+    }
+
+    private function syncCatalogAvailableDiscounts(string $catalogId, array $availableDiscounts): void
+    {
+        foreach ($availableDiscounts as $discount) {
+            $discountId = null;
+            $payloadSource = $discount;
+
+            if (is_array($discount)) {
+                $discountId = $discount['id'] ?? $discount['discountId'] ?? null;
+            } elseif (is_string($discount) || is_int($discount)) {
+                $discountId = (string) $discount;
+                $payloadSource = ['id' => $discountId];
+            }
+
+            if ($discountId === null || $discountId === '') {
+                continue;
+            }
+
+            $payload = Format::jsonObject($payloadSource);
+
+            try {
+                $this->context->getConn()->executeStatement(
+                    'INSERT INTO catalog_available_discount (
+                        catalog_id,
+                        discount_id,
+                        payload
+                    ) VALUES (
+                        :catalogId,
+                        :discountId,
+                        :payload
+                    ) ON CONFLICT (catalog_id, discount_id) DO UPDATE SET
+                        payload  = EXCLUDED.payload',
+                    [
+                        'catalogId' => $catalogId,
+                        'discountId' => $discountId,
+                        'payload'   => $payload,
+                    ]
+                );
+            } catch (\Throwable $e) {
+                $this->context->getLog()->error(
+                    sprintf('CatalogService::syncCatalogAvailableDiscounts: failed for catalog %s discount %s: %s', $catalogId, $discountId, $e->getMessage())
                 );
             }
         }

--- a/database/migrations/20241020000000_create_catalog_available_discount_table.sql
+++ b/database/migrations/20241020000000_create_catalog_available_discount_table.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS catalog_available_discount (
+    catalog_id VARCHAR(255) NOT NULL,
+    discount_id VARCHAR(255) NOT NULL,
+    payload JSONB NOT NULL DEFAULT '{}',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (catalog_id, discount_id)
+);

--- a/tests/Services/CatalogServiceTest.php
+++ b/tests/Services/CatalogServiceTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Services {
+
+    use App\Core\Api;
+    use App\Core\Context;
+    use App\Services\CatalogService;
+    use App\Services\Support\PoyntDataFormatter as Format;
+    use Doctrine\DBAL\Connection;
+    use GuzzleHttp\ClientInterface;
+    use Monolog\Handler\TestHandler;
+    use Monolog\Logger;
+    use PHPUnit\Framework\TestCase;
+
+    /**
+     * @covers \App\Services\CatalogService
+     */
+    class CatalogServiceTest extends TestCase
+    {
+        private Context $context;
+
+        private TestHandler $testHandler;
+
+        /** @var Connection&\PHPUnit\Framework\MockObject\MockObject */
+        private Connection $connection;
+
+        protected function setUp(): void
+        {
+            parent::setUp();
+
+            $api = $this->createMock(Api::class);
+            $this->connection = $this->createMock(Connection::class);
+            $this->testHandler = new TestHandler();
+            $logger = new Logger('test');
+            $logger->pushHandler($this->testHandler);
+
+            $this->context = new Context($api, $this->connection, $logger);
+        }
+
+        public function testUpsertPersistsAvailableDiscounts(): void
+        {
+            $catalogData = [
+                'id' => 'catalog-1',
+                'businessId' => 'biz-1',
+                'availableDiscounts' => [
+                    ['id' => 'discount-1', 'name' => 'Promo'],
+                ],
+            ];
+
+            $expectedPayload = Format::jsonObject($catalogData['availableDiscounts'][0]);
+
+            $this->connection
+                ->expects($this->exactly(2))
+                ->method('executeStatement')
+                ->withConsecutive(
+                    [
+                        $this->stringContains('INSERT INTO catalog'),
+                        $this->arrayHasKey('catalogId'),
+                    ],
+                    [
+                        $this->stringContains('INSERT INTO catalog_available_discount'),
+                        $this->callback(function (array $params) use ($expectedPayload): bool {
+                            self::assertSame('catalog-1', $params['catalogId']);
+                            self::assertSame('discount-1', $params['discountId']);
+                            self::assertSame($expectedPayload, $params['payload']);
+
+                            return true;
+                        }),
+                    ],
+                )
+                ->willReturnOnConsecutiveCalls(1, 1);
+
+            $service = new CatalogService($this->context, null, $this->createMock(ClientInterface::class));
+
+            self::assertTrue($service->upsert($catalogData));
+            self::assertFalse($this->testHandler->hasErrorRecords());
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- persist available catalog discounts alongside product assignments during catalog upserts
- add a migration that introduces the catalog_available_discount table for storing discount payloads
- cover the discount persistence branch with a dedicated CatalogService unit test

## Testing
- php -l app/Services/CatalogService.php
- php -l tests/Services/CatalogServiceTest.php
- composer install *(fails: GitHub API 403 while downloading psr/cache dist archive)*

------
https://chatgpt.com/codex/tasks/task_e_68f0db32dba48329a5366cfaf41be703