### PR TITLE
Update billing API endpoints for subscription flows

### DIFF
--- a/app/Fetchers/MerchantFetcher.php
+++ b/app/Fetchers/MerchantFetcher.php
@@ -7,6 +7,7 @@ use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\GuzzleException;
 use App\Core\Context;
 use App\Services\OrderService;
+use function str_starts_with;
 
 class MerchantFetcher
 {
@@ -16,6 +17,7 @@ class MerchantFetcher
     const POYNT_ENDPOINT_API = 'https://services.poynt.net/businesses';
     const POYNT_ENDPOINT_GET_BUSINESS = 'https://services.poynt.net/businesses';
     const POYNT_ENDPOINT_GET_ORDERS = 'https://services.poynt.net/businesses';
+    private const POYNT_BILLING_BASE = 'https://billing.poynt.net/apps';
 
     public function __construct(Context $context, ?ClientInterface $httpClient = null)
     {
@@ -34,11 +36,10 @@ class MerchantFetcher
     public function fetchApplicationSubscriptionPlans(string $accessToken): ?array
     {
         try {
-            $orgId = ConfigApp::$orgId;
             $appId = ConfigApp::$appId;
 
             // Define the endpoint for fetching plans
-            $url = "https://billing.poynt.net/organizations/{$orgId}/apps/{$appId}/plans";
+            $url = $this->buildBillingUrl($appId, 'plans');
 
             // Set up request headers
             $options = [
@@ -172,7 +173,7 @@ class MerchantFetcher
             $appId = ConfigApp::$appId;
 
             // Define the endpoint
-            $url = "https://billing.poynt.net/organizations/{$orgId}/apps/{$appId}/subscriptions";
+            $url = $this->buildBillingUrl($appId, 'subscriptions');
 
             // Prepare request body
             $payload = [
@@ -226,7 +227,7 @@ class MerchantFetcher
             $appId = ConfigApp::$appId;
 
             // Define the API endpoint
-            $url = "https://billing.poynt.net/organizations/{$orgId}/apps/{$appId}/subscriptions/{$subscriptionId}";
+            $url = $this->buildBillingUrl($appId, 'subscriptions/' . $subscriptionId);
 
             // Set up request options
             $options = [
@@ -265,11 +266,10 @@ class MerchantFetcher
         ?string $status = null
     ): ?array {
         try {
-            $orgId = ConfigApp::$orgId;
             $appId = ConfigApp::$appId;
 
             // Define the base endpoint
-            $url = "https://billing.poynt.net/organizations/{$orgId}/apps/{$appId}/subscriptions";
+            $url = $this->buildBillingUrl($appId, 'subscriptions');
 
             // Prepare query parameters
             $queryParams = [
@@ -311,7 +311,6 @@ class MerchantFetcher
     }
 
 
-
     public function fetchSubscriptionStatus(string $accessToken, string $businessId): ?array
     {
         try {
@@ -334,5 +333,13 @@ class MerchantFetcher
         }
     }
 
+    private function buildBillingUrl(string $appId, string $resource = ''): string
+    {
+        $base = rtrim(self::POYNT_BILLING_BASE, '/');
+        $appUrn = str_starts_with($appId, 'urn:aid:') ? $appId : 'urn:aid:' . $appId;
+        $resourcePath = ltrim($resource, '/');
+        $suffix = $resourcePath === '' ? '' : '/' . $resourcePath;
 
+        return sprintf('%s/%s%s', $base, $appUrn, $suffix);
+    }
 }

--- a/app/Services/SubscriptionService.php
+++ b/app/Services/SubscriptionService.php
@@ -18,10 +18,11 @@ use GuzzleHttp\Exception\RequestException;
 use JsonException;
 use Ramsey\Uuid\Uuid;
 use RuntimeException;
+use function str_starts_with;
 
 class SubscriptionService
 {
-    public const POYNT_BILLING_BASE = 'https://billing.poynt.net/organizations';
+    public const POYNT_BILLING_BASE = 'https://billing.poynt.net/apps';
     private const DEFAULT_TRIAL_DAYS = 14;
     private Context $context;
     private ClientInterface $http;
@@ -59,7 +60,7 @@ class SubscriptionService
     public function fetchPlans(string $appAccessToken): ?array
     {
         try {
-            $response = $this->http->get(self::POYNT_BILLING_BASE . '/' . ConfigApp::$orgId . '/apps/urn:aid:' . ConfigApp::$appId . '/plans', [
+            $response = $this->http->get($this->buildAppResourceUrl('plans'), [
                 'headers' => [
                     'Authorization' => 'Bearer ' . $appAccessToken,
                     'Accept'        => 'application/json',
@@ -115,9 +116,7 @@ class SubscriptionService
         ?string $deviceId = null,
         ?string $status = null
     ): ?array {
-        $orgId = ConfigApp::$orgId;
-        $appId = 'urn:aid:' . ConfigApp::$appId;
-        $endpoint = "/{$orgId}/apps/{$appId}/subscriptions";
+        $endpoint = $this->buildAppResourceUrl('subscriptions');
 
         $query = ['businessId' => $businessId];
         if ($storeId) {
@@ -324,8 +323,7 @@ class SubscriptionService
         ?string     $startAt = null
     ): array {
         $orgId = ConfigApp::$orgId;
-        $appId = 'urn:aid:' . ConfigApp::$appId;
-        $endpoint = "/{$orgId}/apps/{$appId}/subscriptions";
+        $endpoint = $this->buildAppResourceUrl('subscriptions');
 
         // If startAt is not provided, use current UTC
         $timestamp = $startAt
@@ -381,8 +379,7 @@ class SubscriptionService
         string $businessId
     ): array {
         $orgId = ConfigApp::$orgId;
-        $appId = 'urn:aid:' . ConfigApp::$appId;
-        $endpoint = "/{$orgId}/apps/{$appId}/subscriptions";
+        $endpoint = $this->buildAppResourceUrl('subscriptions');
 
         $respList = [];
 
@@ -497,9 +494,7 @@ class SubscriptionService
         string $appAccessToken,
         string $subscriptionId
     ): array {
-        $orgId = ConfigApp::$orgId;
-        $appId = 'urn:aid:' . ConfigApp::$appId;
-        $endpoint = "/{$orgId}/apps/{$appId}/subscriptions/{$subscriptionId}";
+        $endpoint = $this->buildAppResourceUrl('subscriptions/' . $subscriptionId);
 
         try {
             $response = $this->http->delete($endpoint, [
@@ -692,4 +687,21 @@ class SubscriptionService
         }
     }
 
+    private function getAppUrn(): string
+    {
+        $appId = ConfigApp::$appId ?? '';
+
+        return str_starts_with($appId, 'urn:aid:') ? $appId : 'urn:aid:' . $appId;
+    }
+
+    private function buildAppResourceUrl(string $resource = ''): string
+    {
+        $appUrn = $this->getAppUrn();
+        $base = rtrim(self::POYNT_BILLING_BASE, '/');
+
+        $resourcePath = ltrim($resource, '/');
+        $suffix = $resourcePath === '' ? '' : '/' . $resourcePath;
+
+        return sprintf('%s/%s%s', $base, $appUrn, $suffix);
+    }
 }


### PR DESCRIPTION
## Summary
- update the billing base URL in `SubscriptionService` to call the apps endpoints and centralize app URN handling
- align `MerchantFetcher` to the new billing URL builder so subscription CRUD requests target the correct API

## Testing
- not run (Composer install requires GitHub token in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68f0db09b0008329ae57e954edc2613b