### PR TITLE
Expand paylink persistence with related entities

### DIFF
--- a/SQL/poynt-v2.sql
+++ b/SQL/poynt-v2.sql
@@ -486,16 +486,70 @@ CREATE INDEX idx_tax_business ON tax(business_id, active);
 CREATE TABLE paylink (
   paylink_id      VARCHAR(255) PRIMARY KEY,
   business_id     VARCHAR(255) NOT NULL,
+  url             TEXT,
+  vanity_url      TEXT,
   domain          VARCHAR(255),
+  title           TEXT,
+  description     TEXT,
   status          VARCHAR(32),
   amount_minor    BIGINT,
   currency        VARCHAR(3),
   metadata        JSONB NOT NULL DEFAULT '{}',
+  expires_at_ext  TIMESTAMPTZ,
   created_at_ext  TIMESTAMPTZ,
   updated_at_ext  TIMESTAMPTZ,
+  raw_payload     JSONB NOT NULL DEFAULT '{}',
   created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
+
+CREATE TABLE paylink_item (
+  paylink_id    VARCHAR(255) NOT NULL,
+  business_id   VARCHAR(255) NOT NULL,
+  item_ref      VARCHAR(64) NOT NULL,
+  item_id       VARCHAR(255),
+  name          VARCHAR(255),
+  description   TEXT,
+  amount_minor  BIGINT,
+  currency      VARCHAR(3),
+  quantity      NUMERIC(18,3),
+  metadata      JSONB NOT NULL DEFAULT '{}',
+  payload       JSONB NOT NULL DEFAULT '{}',
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (paylink_id, item_ref)
+);
+CREATE INDEX idx_paylink_item_business ON paylink_item(business_id);
+
+CREATE TABLE paylink_payment (
+  paylink_id       VARCHAR(255) NOT NULL,
+  business_id      VARCHAR(255) NOT NULL,
+  payment_ref      VARCHAR(64) NOT NULL,
+  payment_id       VARCHAR(255),
+  status           VARCHAR(64),
+  amount_minor     BIGINT,
+  currency         VARCHAR(3),
+  processed_at_ext TIMESTAMPTZ,
+  payload          JSONB NOT NULL DEFAULT '{}',
+  created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (paylink_id, payment_ref)
+);
+CREATE INDEX idx_paylink_payment_business ON paylink_payment(business_id);
+
+CREATE TABLE paylink_link (
+  paylink_id  VARCHAR(255) NOT NULL,
+  business_id VARCHAR(255) NOT NULL,
+  link_ref    VARCHAR(64) NOT NULL,
+  rel         VARCHAR(128),
+  href        TEXT,
+  method      VARCHAR(16),
+  payload     JSONB NOT NULL DEFAULT '{}',
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (paylink_id, link_ref)
+);
+CREATE INDEX idx_paylink_link_business ON paylink_link(business_id);
 
 -- =========================
 -- HOOKS (konfiguracija) & DELIVERIES (GET strana)

--- a/app/Services/PaylinkService.php
+++ b/app/Services/PaylinkService.php
@@ -42,7 +42,19 @@ class PaylinkService
         $paylinkId = $paylinkData['id'];
         $businessId = $paylinkData['businessId'];
 
-        $domain = $paylinkData['domain'] ?? $paylinkData['vanityUrl'] ?? null;
+        $url = Format::stringOrNull($paylinkData['url'] ?? $paylinkData['href'] ?? null);
+        $vanityUrl = Format::stringOrNull($paylinkData['vanityUrl'] ?? $paylinkData['vanityURL'] ?? null);
+        $domain = $paylinkData['domain'] ?? $vanityUrl;
+        if (!$domain && $url) {
+            $parsedHost = parse_url($url, PHP_URL_HOST);
+            if (is_string($parsedHost) && $parsedHost !== '') {
+                $domain = $parsedHost;
+            }
+        }
+        $domain = $domain !== null ? (string) $domain : null;
+
+        $title = Format::stringOrNull($paylinkData['title'] ?? $paylinkData['name'] ?? null);
+        $description = Format::stringOrNull($paylinkData['description'] ?? null);
         $status = $paylinkData['status'] ?? null;
         $amountMinor = Format::amount($paylinkData['amount'] ?? null);
         if ($amountMinor === null && isset($paylinkData['amount']['amount'])) {
@@ -50,53 +62,454 @@ class PaylinkService
         }
         $currency = $paylinkData['amount']['currency'] ?? $paylinkData['currency'] ?? null;
         $metadata = Format::jsonObject($paylinkData['metadata'] ?? []);
+        $expiresAtExt = Format::optionalTimestamp(
+            $paylinkData['expiresAt']
+                ?? $paylinkData['expireAt']
+                ?? $paylinkData['expiration']
+                ?? $paylinkData['expirationTime']
+                ?? $paylinkData['expirationDate']
+                ?? null
+        );
         $createdAtExt = Format::optionalTimestamp($paylinkData['createdAt'] ?? null);
         $updatedAtExt = Format::optionalTimestamp($paylinkData['updatedAt'] ?? null);
+        $rawPayload = Format::jsonObject($paylinkData);
+
+        $items = $this->extractItems($paylinkData);
+        $payments = $this->extractPayments($paylinkData);
+        $links = $this->extractLinks($paylinkData);
 
         $now = (new \DateTime('now'))->format('Y-m-d H:i:sP');
 
         try {
             $this->context->getConn()->executeStatement(
                 'INSERT INTO paylink (
-                    paylink_id, business_id, domain, status, amount_minor, currency,
-                    metadata, created_at_ext, updated_at_ext,
+                    paylink_id, business_id, url, vanity_url, domain, title, description,
+                    status, amount_minor, currency,
+                    metadata, expires_at_ext, created_at_ext, updated_at_ext, raw_payload,
                     created_at, updated_at
                 ) VALUES (
-                    :paylinkId, :businessId, :domain, :status, :amountMinor, :currency,
-                    :metadata, :createdAtExt, :updatedAtExt,
+                    :paylinkId, :businessId, :url, :vanityUrl, :domain, :title, :description,
+                    :status, :amountMinor, :currency,
+                    :metadata, :expiresAtExt, :createdAtExt, :updatedAtExt, :rawPayload,
                     :createdAt, :updatedAt
                 ) ON CONFLICT (paylink_id) DO UPDATE SET
                     business_id = EXCLUDED.business_id,
+                    url = EXCLUDED.url,
+                    vanity_url = EXCLUDED.vanity_url,
                     domain = EXCLUDED.domain,
+                    title = EXCLUDED.title,
+                    description = EXCLUDED.description,
                     status = EXCLUDED.status,
                     amount_minor = EXCLUDED.amount_minor,
                     currency = EXCLUDED.currency,
                     metadata = EXCLUDED.metadata,
+                    expires_at_ext = EXCLUDED.expires_at_ext,
                     created_at_ext = EXCLUDED.created_at_ext,
                     updated_at_ext = EXCLUDED.updated_at_ext,
+                    raw_payload = EXCLUDED.raw_payload,
                     updated_at = EXCLUDED.updated_at',
                 [
                     'paylinkId' => $paylinkId,
                     'businessId' => $businessId,
+                    'url' => $url,
+                    'vanityUrl' => $vanityUrl,
                     'domain' => $domain,
+                    'title' => $title,
+                    'description' => $description,
                     'status' => $status,
                     'amountMinor' => $amountMinor,
                     'currency' => $currency,
                     'metadata' => $metadata,
+                    'expiresAtExt' => $expiresAtExt,
                     'createdAtExt' => $createdAtExt,
                     'updatedAtExt' => $updatedAtExt,
+                    'rawPayload' => $rawPayload,
                     'createdAt' => $now,
                     'updatedAt' => $now,
                 ]
             );
 
             $this->context->getLog()->info("PaylinkService::upsert: upserted paylink {$paylinkId}");
+            $this->syncItems($paylinkId, $businessId, $items);
+            $this->syncPayments($paylinkId, $businessId, $payments);
+            $this->syncLinks($paylinkId, $businessId, $links);
             return true;
         } catch (\Throwable $e) {
             $this->context->getLog()->error(
                 "PaylinkService::upsert: database error for paylink_id={$paylinkId}: " . $e->getMessage()
             );
             return false;
+        }
+    }
+
+    /**
+     * @return array<int, array<mixed>>
+     */
+    private function extractItems(array $paylinkData): array
+    {
+        $items = [];
+
+        $candidates = [
+            $paylinkData['items'] ?? null,
+            $paylinkData['lineItems'] ?? null,
+            $paylinkData['order']['items'] ?? null,
+            $paylinkData['order']['lineItems'] ?? null,
+        ];
+
+        foreach ($candidates as $candidate) {
+            if (!is_array($candidate)) {
+                continue;
+            }
+
+            if (array_is_list($candidate)) {
+                foreach ($candidate as $value) {
+                    if (is_array($value)) {
+                        $items[] = $value;
+                    }
+                }
+                continue;
+            }
+
+            foreach ($candidate as $value) {
+                if (is_array($value)) {
+                    $items[] = $value;
+                }
+            }
+        }
+
+        return $items;
+    }
+
+    /**
+     * @return array<int, array<mixed>>
+     */
+    private function extractPayments(array $paylinkData): array
+    {
+        $payments = [];
+
+        $candidates = [
+            $paylinkData['payments'] ?? null,
+            $paylinkData['transactions'] ?? null,
+            $paylinkData['order']['payments'] ?? null,
+        ];
+
+        foreach ($candidates as $candidate) {
+            if (!is_array($candidate)) {
+                continue;
+            }
+
+            if (array_is_list($candidate)) {
+                foreach ($candidate as $value) {
+                    if (is_array($value)) {
+                        $payments[] = $value;
+                    }
+                }
+                continue;
+            }
+
+            foreach ($candidate as $value) {
+                if (is_array($value)) {
+                    $payments[] = $value;
+                }
+            }
+        }
+
+        return $payments;
+    }
+
+    /**
+     * @return array<int, array<mixed>>
+     */
+    private function extractLinks(array $paylinkData): array
+    {
+        $links = $paylinkData['links'] ?? $paylinkData['_links'] ?? null;
+
+        if (!is_array($links)) {
+            return [];
+        }
+
+        if (array_is_list($links)) {
+            $normalized = [];
+            foreach ($links as $link) {
+                if (is_array($link)) {
+                    $normalized[] = $link;
+                }
+            }
+
+            return $normalized;
+        }
+
+        $normalized = [];
+        foreach ($links as $key => $value) {
+            if (is_array($value)) {
+                if (!isset($value['rel']) && is_string($key)) {
+                    $value['rel'] = $key;
+                }
+                $normalized[] = $value;
+                continue;
+            }
+
+            if (is_string($value) && is_string($key)) {
+                $normalized[] = [
+                    'rel' => $key,
+                    'href' => $value,
+                ];
+            }
+        }
+
+        return $normalized;
+    }
+
+    private function syncItems(string $paylinkId, string $businessId, array $items): void
+    {
+        $conn = $this->context->getConn();
+
+        try {
+            $conn->executeStatement('DELETE FROM paylink_item WHERE paylink_id = ?', [$paylinkId]);
+        } catch (\Throwable $e) {
+            $this->context->getLog()->error(
+                sprintf('PaylinkService::syncItems: failed to prune items for %s: %s', $paylinkId, $e->getMessage())
+            );
+            return;
+        }
+
+        if (empty($items)) {
+            return;
+        }
+
+        $now = (new \DateTime('now'))->format('Y-m-d H:i:sP');
+
+        foreach ($items as $index => $item) {
+            $itemRef = sprintf('item-%d', $index + 1);
+            $itemId = $item['id'] ?? $item['itemId'] ?? $item['uuid'] ?? null;
+            $name = Format::stringOrNull($item['name'] ?? $item['title'] ?? null);
+            $description = Format::stringOrNull($item['description'] ?? null);
+
+            $amountCandidates = [
+                $item['amount'] ?? null,
+                $item['unitPrice'] ?? null,
+                $item['price'] ?? null,
+                $item['total'] ?? null,
+            ];
+            $amountMinor = null;
+            foreach ($amountCandidates as $candidate) {
+                $amountMinor = Format::amount($candidate);
+                if ($amountMinor !== null) {
+                    break;
+                }
+            }
+
+            $currencyCandidates = [
+                $item['amount']['currency'] ?? null,
+                $item['unitPrice']['currency'] ?? null,
+                $item['price']['currency'] ?? null,
+                $item['currency'] ?? null,
+            ];
+            $currency = null;
+            foreach ($currencyCandidates as $candidate) {
+                if (is_string($candidate) && $candidate !== '') {
+                    $currency = $candidate;
+                    break;
+                }
+            }
+
+            $quantityCandidate = $item['quantity'] ?? $item['qty'] ?? $item['quantityOrdered'] ?? null;
+            $quantity = Format::optionalNumericString($quantityCandidate);
+
+            $metadataPayload = $item['metadata'] ?? $item['attributes'] ?? [];
+            $metadata = Format::jsonObject($metadataPayload);
+            $payload = Format::jsonObject($item);
+
+            try {
+                $conn->executeStatement(
+                    'INSERT INTO paylink_item (
+                        paylink_id, business_id, item_ref, item_id, name, description,
+                        amount_minor, currency, quantity, metadata, payload,
+                        created_at, updated_at
+                    ) VALUES (
+                        :paylinkId, :businessId, :itemRef, :itemId, :name, :description,
+                        :amountMinor, :currency, :quantity, :metadata, :payload,
+                        :createdAt, :updatedAt
+                    )',
+                    [
+                        'paylinkId' => $paylinkId,
+                        'businessId' => $businessId,
+                        'itemRef' => $itemRef,
+                        'itemId' => $itemId,
+                        'name' => $name,
+                        'description' => $description,
+                        'amountMinor' => $amountMinor,
+                        'currency' => $currency,
+                        'quantity' => $quantity,
+                        'metadata' => $metadata,
+                        'payload' => $payload,
+                        'createdAt' => $now,
+                        'updatedAt' => $now,
+                    ]
+                );
+            } catch (\Throwable $e) {
+                $this->context->getLog()->error(
+                    sprintf('PaylinkService::syncItems: failed to upsert item %s for %s: %s', $itemRef, $paylinkId, $e->getMessage())
+                );
+            }
+        }
+    }
+
+    private function syncPayments(string $paylinkId, string $businessId, array $payments): void
+    {
+        $conn = $this->context->getConn();
+
+        try {
+            $conn->executeStatement('DELETE FROM paylink_payment WHERE paylink_id = ?', [$paylinkId]);
+        } catch (\Throwable $e) {
+            $this->context->getLog()->error(
+                sprintf('PaylinkService::syncPayments: failed to prune payments for %s: %s', $paylinkId, $e->getMessage())
+            );
+            return;
+        }
+
+        if (empty($payments)) {
+            return;
+        }
+
+        $now = (new \DateTime('now'))->format('Y-m-d H:i:sP');
+
+        foreach ($payments as $index => $payment) {
+            $paymentId = $payment['id'] ?? $payment['paymentId'] ?? $payment['transactionId'] ?? null;
+            $paymentRef = $paymentId ?? sprintf('payment-%d', $index + 1);
+            $status = $payment['status'] ?? $payment['paymentStatus'] ?? $payment['state'] ?? null;
+
+            $amountCandidates = [
+                $payment['amount'] ?? null,
+                $payment['totalAmount'] ?? null,
+                $payment['netAmount'] ?? null,
+                $payment['transactionAmount'] ?? null,
+            ];
+            $amountMinor = null;
+            foreach ($amountCandidates as $candidate) {
+                $amountMinor = Format::amount($candidate);
+                if ($amountMinor !== null) {
+                    break;
+                }
+            }
+
+            $currencyCandidates = [
+                $payment['amount']['currency'] ?? null,
+                $payment['transactionAmount']['currency'] ?? null,
+                $payment['totalAmount']['currency'] ?? null,
+                $payment['currency'] ?? null,
+            ];
+            $currency = null;
+            foreach ($currencyCandidates as $candidate) {
+                if (is_string($candidate) && $candidate !== '') {
+                    $currency = $candidate;
+                    break;
+                }
+            }
+
+            $processedAtExt = Format::optionalTimestamp(
+                $payment['processedAt']
+                    ?? $payment['createdAt']
+                    ?? $payment['updatedAt']
+                    ?? $payment['capturedAt']
+                    ?? null
+            );
+
+            $payload = Format::jsonObject($payment);
+
+            try {
+                $conn->executeStatement(
+                    'INSERT INTO paylink_payment (
+                        paylink_id, business_id, payment_ref, payment_id, status,
+                        amount_minor, currency, processed_at_ext, payload,
+                        created_at, updated_at
+                    ) VALUES (
+                        :paylinkId, :businessId, :paymentRef, :paymentId, :status,
+                        :amountMinor, :currency, :processedAtExt, :payload,
+                        :createdAt, :updatedAt
+                    )',
+                    [
+                        'paylinkId' => $paylinkId,
+                        'businessId' => $businessId,
+                        'paymentRef' => $paymentRef,
+                        'paymentId' => $paymentId,
+                        'status' => $status,
+                        'amountMinor' => $amountMinor,
+                        'currency' => $currency,
+                        'processedAtExt' => $processedAtExt,
+                        'payload' => $payload,
+                        'createdAt' => $now,
+                        'updatedAt' => $now,
+                    ]
+                );
+            } catch (\Throwable $e) {
+                $this->context->getLog()->error(
+                    sprintf('PaylinkService::syncPayments: failed to upsert payment %s for %s: %s', $paymentRef, $paylinkId, $e->getMessage())
+                );
+            }
+        }
+    }
+
+    private function syncLinks(string $paylinkId, string $businessId, array $links): void
+    {
+        $conn = $this->context->getConn();
+
+        try {
+            $conn->executeStatement('DELETE FROM paylink_link WHERE paylink_id = ?', [$paylinkId]);
+        } catch (\Throwable $e) {
+            $this->context->getLog()->error(
+                sprintf('PaylinkService::syncLinks: failed to prune links for %s: %s', $paylinkId, $e->getMessage())
+            );
+            return;
+        }
+
+        if (empty($links)) {
+            return;
+        }
+
+        $now = (new \DateTime('now'))->format('Y-m-d H:i:sP');
+
+        foreach ($links as $index => $link) {
+            if (!is_array($link)) {
+                continue;
+            }
+
+            $rel = Format::stringOrNull($link['rel'] ?? $link['relationship'] ?? null);
+            $href = Format::stringOrNull($link['href'] ?? $link['url'] ?? null);
+            $method = Format::stringOrNull($link['method'] ?? $link['httpMethod'] ?? null);
+            $linkRef = sprintf('link-%d', $index + 1);
+            if ($rel && $href) {
+                $linkRef = $rel . '-' . substr(md5($href), 0, 10);
+            }
+
+            $payload = Format::jsonObject($link);
+
+            try {
+                $conn->executeStatement(
+                    'INSERT INTO paylink_link (
+                        paylink_id, business_id, link_ref, rel, href, method, payload,
+                        created_at, updated_at
+                    ) VALUES (
+                        :paylinkId, :businessId, :linkRef, :rel, :href, :method, :payload,
+                        :createdAt, :updatedAt
+                    )',
+                    [
+                        'paylinkId' => $paylinkId,
+                        'businessId' => $businessId,
+                        'linkRef' => $linkRef,
+                        'rel' => $rel,
+                        'href' => $href,
+                        'method' => $method,
+                        'payload' => $payload,
+                        'createdAt' => $now,
+                        'updatedAt' => $now,
+                    ]
+                );
+            } catch (\Throwable $e) {
+                $this->context->getLog()->error(
+                    sprintf('PaylinkService::syncLinks: failed to upsert link %s for %s: %s', $linkRef, $paylinkId, $e->getMessage())
+                );
+            }
         }
     }
 

--- a/database/migrations/20241025000000_update_paylink_schema.sql
+++ b/database/migrations/20241025000000_update_paylink_schema.sql
@@ -1,0 +1,68 @@
+ALTER TABLE paylink
+    ADD COLUMN IF NOT EXISTS url TEXT;
+
+ALTER TABLE paylink
+    ADD COLUMN IF NOT EXISTS vanity_url TEXT;
+
+ALTER TABLE paylink
+    ADD COLUMN IF NOT EXISTS title TEXT;
+
+ALTER TABLE paylink
+    ADD COLUMN IF NOT EXISTS description TEXT;
+
+ALTER TABLE paylink
+    ADD COLUMN IF NOT EXISTS expires_at_ext TIMESTAMPTZ;
+
+ALTER TABLE paylink
+    ADD COLUMN IF NOT EXISTS raw_payload JSONB NOT NULL DEFAULT '{}';
+
+CREATE TABLE IF NOT EXISTS paylink_item (
+    paylink_id VARCHAR(255) NOT NULL,
+    business_id VARCHAR(255) NOT NULL,
+    item_ref VARCHAR(64) NOT NULL,
+    item_id VARCHAR(255),
+    name VARCHAR(255),
+    description TEXT,
+    amount_minor BIGINT,
+    currency VARCHAR(3),
+    quantity NUMERIC(18, 3),
+    metadata JSONB NOT NULL DEFAULT '{}',
+    payload JSONB NOT NULL DEFAULT '{}',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (paylink_id, item_ref)
+);
+
+CREATE INDEX IF NOT EXISTS idx_paylink_item_business ON paylink_item (business_id);
+
+CREATE TABLE IF NOT EXISTS paylink_payment (
+    paylink_id VARCHAR(255) NOT NULL,
+    business_id VARCHAR(255) NOT NULL,
+    payment_ref VARCHAR(64) NOT NULL,
+    payment_id VARCHAR(255),
+    status VARCHAR(64),
+    amount_minor BIGINT,
+    currency VARCHAR(3),
+    processed_at_ext TIMESTAMPTZ,
+    payload JSONB NOT NULL DEFAULT '{}',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (paylink_id, payment_ref)
+);
+
+CREATE INDEX IF NOT EXISTS idx_paylink_payment_business ON paylink_payment (business_id);
+
+CREATE TABLE IF NOT EXISTS paylink_link (
+    paylink_id VARCHAR(255) NOT NULL,
+    business_id VARCHAR(255) NOT NULL,
+    link_ref VARCHAR(64) NOT NULL,
+    rel VARCHAR(128),
+    href TEXT,
+    method VARCHAR(16),
+    payload JSONB NOT NULL DEFAULT '{}',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (paylink_id, link_ref)
+);
+
+CREATE INDEX IF NOT EXISTS idx_paylink_link_business ON paylink_link (business_id);


### PR DESCRIPTION
## Summary
- extend the paylink upsert routine to capture URL details and persist nested items, payments, and link metadata
- add a migration that augments the paylink table and introduces supporting tables for items, payments, and links
- refresh the SQL reference so it reflects the expanded paylink schema

## Testing
- php -l app/Services/PaylinkService.php

------
https://chatgpt.com/codex/tasks/task_e_68f0e6477cdc8329b90f80cccd13f8be