### PR TITLE
Add catalog product timestamps and tax persistence

### DIFF
--- a/app/Services/CatalogService.php
+++ b/app/Services/CatalogService.php
@@ -229,8 +229,19 @@ class CatalogService
                 continue;
             }
 
-            $position = $product['position'] ?? $product['index'] ?? null;
+            $position = $product['position']
+                ?? $product['displayOrder']
+                ?? $product['index']
+                ?? null;
             $payload = Format::jsonObject($product);
+            $createdAtExt = Format::optionalTimestamp(
+                $product['createdAt'] ?? $product['createdAtExt'] ?? null
+            );
+            $updatedAtExt = Format::optionalTimestamp(
+                $product['updatedAt'] ?? $product['updatedAtExt'] ?? null
+            );
+
+            $now = (new \DateTimeImmutable('now'))->format('Y-m-d H:i:sP');
 
             try {
                 $this->context->getConn()->executeStatement(
@@ -238,27 +249,151 @@ class CatalogService
                         catalog_id,
                         product_id,
                         position,
-                        payload
+                        payload,
+                        created_at_ext,
+                        updated_at_ext,
+                        created_at,
+                        updated_at
                     ) VALUES (
                         :catalogId,
                         :productId,
                         :position,
-                        :payload
+                        :payload,
+                        :createdAtExt,
+                        :updatedAtExt,
+                        :createdAt,
+                        :updatedAt
                     ) ON CONFLICT (catalog_id, product_id) DO UPDATE SET
                         position = EXCLUDED.position,
-                        payload  = EXCLUDED.payload',
+                        payload  = EXCLUDED.payload,
+                        created_at_ext = EXCLUDED.created_at_ext,
+                        updated_at_ext = EXCLUDED.updated_at_ext,
+                        updated_at = EXCLUDED.updated_at',
                     [
                         'catalogId' => $catalogId,
                         'productId' => $product['id'],
                         'position'  => $position,
                         'payload'   => $payload,
+                        'createdAtExt' => $createdAtExt,
+                        'updatedAtExt' => $updatedAtExt,
+                        'createdAt' => $now,
+                        'updatedAt' => $now,
                     ]
                 );
+
+                $taxes = [];
+                if (isset($product['taxes']) && is_array($product['taxes'])) {
+                    $taxes = $product['taxes'];
+                }
+
+                if (!empty($taxes)) {
+                    $this->syncCatalogProductTaxes($catalogId, $product['id'], $taxes);
+                } else {
+                    $this->purgeCatalogProductTaxes($catalogId, $product['id']);
+                }
             } catch (\Throwable $e) {
                 $this->context->getLog()->error(
                     sprintf('CatalogService::syncCatalogProducts: failed for catalog %s product %s: %s', $catalogId, $product['id'], $e->getMessage())
                 );
             }
+        }
+    }
+
+    private function syncCatalogProductTaxes(string $catalogId, string $productId, array $taxes): void
+    {
+        foreach ($taxes as $tax) {
+            $taxId = null;
+            $payloadSource = $tax;
+
+            if (is_array($tax)) {
+                $taxId = $tax['id'] ?? $tax['taxId'] ?? null;
+            } elseif (is_string($tax) || is_int($tax)) {
+                $taxId = (string) $tax;
+                $payloadSource = ['id' => $taxId];
+            }
+
+            if ($taxId === null || $taxId === '') {
+                continue;
+            }
+
+            $payload = Format::jsonObject($payloadSource);
+            $createdAtExt = Format::optionalTimestamp(
+                is_array($payloadSource) ? ($payloadSource['createdAt'] ?? $payloadSource['createdAtExt'] ?? null) : null
+            );
+            $updatedAtExt = Format::optionalTimestamp(
+                is_array($payloadSource) ? ($payloadSource['updatedAt'] ?? $payloadSource['updatedAtExt'] ?? null) : null
+            );
+            $now = (new \DateTimeImmutable('now'))->format('Y-m-d H:i:sP');
+
+            try {
+                $this->context->getConn()->executeStatement(
+                    'INSERT INTO catalog_product_tax (
+                        catalog_id,
+                        product_id,
+                        tax_id,
+                        payload,
+                        created_at_ext,
+                        updated_at_ext,
+                        created_at,
+                        updated_at
+                    ) VALUES (
+                        :catalogId,
+                        :productId,
+                        :taxId,
+                        :payload,
+                        :createdAtExt,
+                        :updatedAtExt,
+                        :createdAt,
+                        :updatedAt
+                    ) ON CONFLICT (catalog_id, product_id, tax_id) DO UPDATE SET
+                        payload = EXCLUDED.payload,
+                        created_at_ext = EXCLUDED.created_at_ext,
+                        updated_at_ext = EXCLUDED.updated_at_ext,
+                        updated_at = EXCLUDED.updated_at',
+                    [
+                        'catalogId' => $catalogId,
+                        'productId' => $productId,
+                        'taxId' => $taxId,
+                        'payload' => $payload,
+                        'createdAtExt' => $createdAtExt,
+                        'updatedAtExt' => $updatedAtExt,
+                        'createdAt' => $now,
+                        'updatedAt' => $now,
+                    ]
+                );
+            } catch (\Throwable $e) {
+                $this->context->getLog()->error(
+                    sprintf(
+                        'CatalogService::syncCatalogProductTaxes: failed for catalog %s product %s tax %s: %s',
+                        $catalogId,
+                        $productId,
+                        $taxId,
+                        $e->getMessage()
+                    )
+                );
+            }
+        }
+    }
+
+    private function purgeCatalogProductTaxes(string $catalogId, string $productId): void
+    {
+        try {
+            $this->context->getConn()->executeStatement(
+                'DELETE FROM catalog_product_tax WHERE catalog_id = :catalogId AND product_id = :productId',
+                [
+                    'catalogId' => $catalogId,
+                    'productId' => $productId,
+                ]
+            );
+        } catch (\Throwable $e) {
+            $this->context->getLog()->error(
+                sprintf(
+                    'CatalogService::purgeCatalogProductTaxes: failed for catalog %s product %s: %s',
+                    $catalogId,
+                    $productId,
+                    $e->getMessage()
+                )
+            );
         }
     }
 

--- a/database/migrations/20241101000000_alter_catalog_product_add_timestamps.sql
+++ b/database/migrations/20241101000000_alter_catalog_product_add_timestamps.sql
@@ -1,0 +1,21 @@
+ALTER TABLE catalog_product
+    ADD COLUMN IF NOT EXISTS created_at_ext TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS updated_at_ext TIMESTAMPTZ;
+
+ALTER TABLE catalog_product
+    ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+
+ALTER TABLE catalog_product
+    ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+
+CREATE TABLE IF NOT EXISTS catalog_product_tax (
+    catalog_id VARCHAR(255) NOT NULL,
+    product_id VARCHAR(255) NOT NULL,
+    tax_id VARCHAR(255) NOT NULL,
+    payload JSONB NOT NULL DEFAULT '{}',
+    created_at_ext TIMESTAMPTZ,
+    updated_at_ext TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (catalog_id, product_id, tax_id)
+);

--- a/tests/Services/CatalogServiceTest.php
+++ b/tests/Services/CatalogServiceTest.php
@@ -77,6 +77,97 @@ namespace Services {
             self::assertTrue($service->upsert($catalogData));
             self::assertFalse($this->testHandler->hasErrorRecords());
         }
+
+        public function testUpsertPersistsCatalogProductsWithTimestampsAndTaxes(): void
+        {
+            $productCreated = '2024-03-01T12:00:00Z';
+            $productUpdated = '2024-03-02T12:00:00Z';
+            $taxCreated = '2024-03-05T09:15:00Z';
+            $taxUpdated = '2024-03-06T18:45:00Z';
+
+            $catalogData = [
+                'id' => 'catalog-1',
+                'businessId' => 'biz-1',
+                'products' => [
+                    [
+                        'id' => 'product-1',
+                        'displayOrder' => 7,
+                        'createdAt' => $productCreated,
+                        'updatedAt' => $productUpdated,
+                        'taxes' => [
+                            [
+                                'id' => 'tax-1',
+                                'createdAt' => $taxCreated,
+                                'updatedAt' => $taxUpdated,
+                                'amount' => 50,
+                            ],
+                        ],
+                    ],
+                ],
+            ];
+
+            $expectedProductPayload = Format::jsonObject($catalogData['products'][0]);
+            $expectedProductCreatedAtExt = Format::optionalTimestamp($productCreated);
+            $expectedProductUpdatedAtExt = Format::optionalTimestamp($productUpdated);
+
+            $expectedTaxPayload = Format::jsonObject($catalogData['products'][0]['taxes'][0]);
+            $expectedTaxCreatedAtExt = Format::optionalTimestamp($taxCreated);
+            $expectedTaxUpdatedAtExt = Format::optionalTimestamp($taxUpdated);
+
+            $this->connection
+                ->expects($this->exactly(3))
+                ->method('executeStatement')
+                ->withConsecutive(
+                    [
+                        $this->stringContains('INSERT INTO catalog'),
+                        $this->arrayHasKey('catalogId'),
+                    ],
+                    [
+                        $this->stringContains('INSERT INTO catalog_product'),
+                        $this->callback(function (array $params) use (
+                            $expectedProductPayload,
+                            $expectedProductCreatedAtExt,
+                            $expectedProductUpdatedAtExt
+                        ): bool {
+                            self::assertSame('catalog-1', $params['catalogId']);
+                            self::assertSame('product-1', $params['productId']);
+                            self::assertSame(7, $params['position']);
+                            self::assertSame($expectedProductPayload, $params['payload']);
+                            self::assertSame($expectedProductCreatedAtExt, $params['createdAtExt']);
+                            self::assertSame($expectedProductUpdatedAtExt, $params['updatedAtExt']);
+                            self::assertArrayHasKey('createdAt', $params);
+                            self::assertArrayHasKey('updatedAt', $params);
+
+                            return true;
+                        }),
+                    ],
+                    [
+                        $this->stringContains('INSERT INTO catalog_product_tax'),
+                        $this->callback(function (array $params) use (
+                            $expectedTaxPayload,
+                            $expectedTaxCreatedAtExt,
+                            $expectedTaxUpdatedAtExt
+                        ): bool {
+                            self::assertSame('catalog-1', $params['catalogId']);
+                            self::assertSame('product-1', $params['productId']);
+                            self::assertSame('tax-1', $params['taxId']);
+                            self::assertSame($expectedTaxPayload, $params['payload']);
+                            self::assertSame($expectedTaxCreatedAtExt, $params['createdAtExt']);
+                            self::assertSame($expectedTaxUpdatedAtExt, $params['updatedAtExt']);
+                            self::assertArrayHasKey('createdAt', $params);
+                            self::assertArrayHasKey('updatedAt', $params);
+
+                            return true;
+                        }),
+                    ]
+                )
+                ->willReturnOnConsecutiveCalls(1, 1, 1);
+
+            $service = new CatalogService($this->context, null, $this->createMock(ClientInterface::class));
+
+            self::assertTrue($service->upsert($catalogData));
+            self::assertFalse($this->testHandler->hasErrorRecords());
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- add a migration that enriches catalog_product with timestamp columns and introduces catalog_product_tax for product-level tax payloads
- extend CatalogService to persist product timestamps, normalise display order, and sync related tax records
- cover the new behaviour with a unit test that asserts product and tax payload persistence

## Testing
- not run (composer install requires GitHub authentication token)


------
https://chatgpt.com/codex/tasks/task_e_68f7572075788329904d21442cac259b