### PR TITLE
Ensure active business lookup and fallback store subscriptions

### DIFF
--- a/app/Services/BusinessService.php
+++ b/app/Services/BusinessService.php
@@ -59,7 +59,7 @@ class BusinessService {
         try {
             // 4) See if a business row with this business_id already exists
             $existing = $this->context->getConn()->fetchAssociative(
-                'SELECT business_id FROM business WHERE business_id = ?',
+                'SELECT business_id FROM business WHERE business_id = ? AND active = TRUE ORDER BY updated_at DESC LIMIT 1',
                 [$businessId]
             );
 
@@ -221,7 +221,12 @@ class BusinessService {
         }
 
         $sql = <<<SQL
-        SELECT * FROM business WHERE business_id = ?
+        SELECT *
+          FROM business
+         WHERE business_id = ?
+           AND active = TRUE
+         ORDER BY updated_at DESC
+         LIMIT 1
         SQL;
 
         $success = $this->context->getConn()->fetchAssociative($sql, [$businessId]);

--- a/app/Services/CallbackService.php
+++ b/app/Services/CallbackService.php
@@ -208,7 +208,7 @@ class CallbackService
     {
         try {
             $existing = $this->context->getConn()->fetchOne(
-                'SELECT 1 FROM business WHERE business_id = ? LIMIT 1',
+                'SELECT 1 FROM business WHERE business_id = ? AND active = TRUE ORDER BY updated_at DESC LIMIT 1',
                 [$businessId]
             );
         } catch (Throwable $e) {
@@ -418,7 +418,32 @@ class CallbackService
                 )
             );
 
-            return false;
+            try {
+                $fallbackSubscriptionId = $subscriptionService->startFreeTrial($businessId, $storeId);
+                $this->context->getLog()->info(
+                    sprintf(
+                        'Started local free trial %s for business %s store %s as a fallback.',
+                        $fallbackSubscriptionId,
+                        $businessId,
+                        $storeId
+                    )
+                );
+            } catch (Throwable $e) {
+                $this->context->getLog()->error(
+                    sprintf(
+                        'Failed to create fallback trial subscription for business %s store %s: %s',
+                        $businessId,
+                        $storeId,
+                        $e->getMessage()
+                    )
+                );
+
+                return false;
+            }
+
+            $hasSubscription = $this->storeHasSubscription($businessId, $storeId);
+
+            return $hasSubscription === true;
         }
 
         $created = $subscriptionService->createSubscription(


### PR DESCRIPTION
## Summary
- restrict business installation checks to active records and prefer the most recently updated entry
- fall back to starting a local free trial when a store subscription cannot be created remotely so every store retains coverage

## Testing
- composer install *(fails: GitHub authentication required for api.github.com)*

------
https://chatgpt.com/codex/tasks/task_e_68f8c0b154348329bc4d2861972356d5