### PR TITLE
Prefer merchant token when fetching subscriptions

### DIFF
--- a/app/Services/SubscriptionService.php
+++ b/app/Services/SubscriptionService.php
@@ -411,9 +411,10 @@ class SubscriptionService
 
     /**
      * Fetches all subscriptions for a given businessId from Poynt,
-     * upserts each into the local `subscription` table, and returns the list.
+     * preferring a stored merchant access token when available, then upserts
+     * each into the local `subscription` table, and returns the list.
      *
-     * @param string $appAccessToken  App-level OAuth token (will fall back to a stored merchant token if required)
+     * @param string $appAccessToken  App-level OAuth token (used when no merchant token is available or authorized)
      * @param string $businessId      Poynt business ID
      * @return array<int, array<string, mixed>>|null  List of subscription objects (decoded JSON) or null when request fails
      * @throws RuntimeException on HTTP/decoding error
@@ -436,24 +437,65 @@ class SubscriptionService
             'status'     => $status,
         ], static fn($value) => $value !== null && $value !== '');
 
-        try {
-            $decoded = $this->performSubscriptionFetch($appAccessToken, $query);
-        } catch (RequestException $e) {
-            $decoded = $this->retryFetchSubscriptionsWithMerchantToken($businessId, $query, $e);
+        $decoded = null;
+        $attemptedMerchantFetch = false;
 
-            if ($decoded === null) {
-                $this->logSubscriptionRequestException($e, 'Poynt GET subscription failed');
+        $merchantToken = $this->getStoredMerchantToken($businessId);
+        if ($merchantToken !== null) {
+            $attemptedMerchantFetch = true;
+
+            try {
+                $decoded = $this->performSubscriptionFetch($merchantToken, $query);
+            } catch (RequestException $merchantException) {
+                $response = $merchantException->getResponse();
+                if ($response !== null && $response->getStatusCode() === 401) {
+                    $this->context->getLog()->info(
+                        sprintf(
+                            'Merchant token unauthorized for business %s; retrying subscription fetch with app token',
+                            $businessId
+                        )
+                    );
+                } else {
+                    $this->logSubscriptionRequestException(
+                        $merchantException,
+                        'Poynt GET subscription with merchant token failed'
+                    );
+                }
+            } catch (JsonException $merchantException) {
+                $this->context->getLog()->error(
+                    'Poynt GET subscription with merchant token returned invalid JSON: ' .
+                    $merchantException->getMessage()
+                );
+            } catch (GuzzleException $merchantException) {
+                $this->context->getLog()->error(
+                    'Poynt GET subscription with merchant token failed: ' .
+                    $merchantException->getMessage()
+                );
+            }
+        }
+
+        if ($decoded === null) {
+            try {
+                $decoded = $this->performSubscriptionFetch($appAccessToken, $query);
+            } catch (RequestException $e) {
+                if (!$attemptedMerchantFetch) {
+                    $decoded = $this->retryFetchSubscriptionsWithMerchantToken($businessId, $query, $e);
+                }
+
+                if ($decoded === null) {
+                    $this->logSubscriptionRequestException($e, 'Poynt GET subscription failed');
+
+                    return null;
+                }
+            } catch (JsonException $e) {
+                $this->context->getLog()->error('Poynt GET subscription returned invalid JSON: ' . $e->getMessage());
+
+                return null;
+            } catch (GuzzleException $e) {
+                $this->context->getLog()->error('Poynt GET subscription failed: ' . $e->getMessage());
 
                 return null;
             }
-        } catch (JsonException $e) {
-            $this->context->getLog()->error('Poynt GET subscription returned invalid JSON: ' . $e->getMessage());
-
-            return null;
-        } catch (GuzzleException $e) {
-            $this->context->getLog()->error('Poynt GET subscription failed: ' . $e->getMessage());
-
-            return null;
         }
 
         $respList = $this->normalizeSubscriptionList($decoded);
@@ -507,6 +549,30 @@ class SubscriptionService
             return null;
         }
 
+        $merchantToken = $this->getStoredMerchantToken($businessId);
+        if ($merchantToken === null) {
+            return null;
+        }
+
+        $this->context->getLog()->info(
+            sprintf('Retrying subscription fetch with merchant token for business %s', $businessId)
+        );
+
+        try {
+            return $this->performSubscriptionFetch($merchantToken, $query);
+        } catch (RequestException $retryException) {
+            $this->logSubscriptionRequestException($retryException, 'Poynt GET subscription retry failed');
+        } catch (JsonException $retryException) {
+            $this->context->getLog()->error('Poynt GET subscription retry returned invalid JSON: ' . $retryException->getMessage());
+        } catch (GuzzleException $retryException) {
+            $this->context->getLog()->error('Poynt GET subscription retry failed: ' . $retryException->getMessage());
+        }
+
+        return null;
+    }
+
+    private function getStoredMerchantToken(string $businessId): ?string
+    {
         $tokenService = new TokenService($this->context);
 
         try {
@@ -534,21 +600,7 @@ class SubscriptionService
             return null;
         }
 
-        $this->context->getLog()->info(
-            sprintf('Retrying subscription fetch with merchant token for business %s', $businessId)
-        );
-
-        try {
-            return $this->performSubscriptionFetch($merchantToken, $query);
-        } catch (RequestException $retryException) {
-            $this->logSubscriptionRequestException($retryException, 'Poynt GET subscription retry failed');
-        } catch (JsonException $retryException) {
-            $this->context->getLog()->error('Poynt GET subscription retry returned invalid JSON: ' . $retryException->getMessage());
-        } catch (GuzzleException $retryException) {
-            $this->context->getLog()->error('Poynt GET subscription retry failed: ' . $retryException->getMessage());
-        }
-
-        return null;
+        return $merchantToken;
     }
 
     private function shouldRetryWithMerchantToken(RequestException $exception): bool

--- a/tests/Services/SubscriptionServiceTest.php
+++ b/tests/Services/SubscriptionServiceTest.php
@@ -87,9 +87,9 @@ namespace Services {
                 ->willReturn(1);
 
             $this->connection
-                ->expects(self::never())
-                ->method('fetchAssociative');
-
+                ->expects(self::once())
+                ->method('fetchAssociative')
+                ->willReturn(false);
             $service = $this->createServiceWithQueue([
                 new Response(
                     200,
@@ -140,6 +140,11 @@ namespace Services {
                 ->with(self::stringContains('INSERT INTO subscription'), self::isType('array'))
                 ->willReturn(1);
 
+            $this->connection
+                ->expects(self::once())
+                ->method('fetchAssociative')
+                ->willReturn(false);
+
             $service = $this->createServiceWithQueue([
                 new Response(
                     200,
@@ -166,6 +171,11 @@ namespace Services {
 
         public function testFetchSubscriptionsAllowsOptionalQueryParameters(): void
         {
+            $this->connection
+                ->expects(self::once())
+                ->method('fetchAssociative')
+                ->willReturn(false);
+
             $service = $this->createServiceWithQueue([
                 new Response(
                     200,
@@ -285,9 +295,12 @@ namespace Services {
                 ->willReturn(1);
 
             $this->connection
-                ->expects(self::once())
+                ->expects(self::exactly(2))
                 ->method('fetchAssociative')
-                ->willReturn(['access_token' => 'merchant-token']);
+                ->willReturnOnConsecutiveCalls(
+                    false,
+                    ['access_token' => 'merchant-token']
+                );
 
             $errorBody = json_encode([
                 'code' => 'UNAUTHORIZED_ACCESS',
@@ -317,6 +330,64 @@ namespace Services {
             self::assertSame(['businessId' => 'biz-1'], $firstQuery);
             self::assertSame($firstQuery, $secondQuery);
             self::assertTrue($this->testHandler->hasInfoThatContains('Retrying subscription fetch with merchant token'));
+        }
+
+        public function testFetchSubscriptionsRetriesWithAppTokenWhenMerchantUnauthorized(): void
+        {
+            $subscription = [
+                'subscriptionId' => 'sub-2',
+                'businessId' => 'biz-2',
+                'storeId' => 'store-2',
+                'planId' => 'plan-premium',
+                'status' => 'active',
+                'phase' => 'active',
+                'trialStart' => null,
+                'trialEnd' => null,
+                'startAt' => '2024-05-01T00:00:00Z',
+                'currentPeriodEnd' => null,
+                'cancelAtPeriodEnd' => false,
+                'canceledAt' => null,
+            ];
+
+            $this->connection
+                ->expects(self::once())
+                ->method('executeStatement')
+                ->with(self::stringContains('INSERT INTO subscription'), self::isType('array'))
+                ->willReturn(1);
+
+            $this->connection
+                ->expects(self::once())
+                ->method('fetchAssociative')
+                ->willReturn(['access_token' => 'merchant-token']);
+
+            $errorBody = json_encode([
+                'code' => 'UNAUTHORIZED_ACCESS',
+                'httpStatus' => 401,
+                'message' => 'Access not authorized for the requested resource.',
+                'developerMessage' => 'The access token does not have permission for this resource.',
+                'requestId' => 'test-request-merchant',
+            ], JSON_THROW_ON_ERROR);
+
+            $service = $this->createServiceWithQueue([
+                new Response(401, ['Content-Type' => 'application/json'], $errorBody),
+                new Response(
+                    200,
+                    ['Content-Type' => 'application/json'],
+                    json_encode(['subscriptions' => [$subscription]], JSON_THROW_ON_ERROR)
+                ),
+            ]);
+
+            $result = $service->fetchSubscriptions('app-token', 'biz-2');
+
+            self::assertSame([$subscription], $result);
+            self::assertCount(2, $this->history);
+            self::assertSame('Bearer merchant-token', $this->history[0]['request']->getHeaderLine('Authorization'));
+            self::assertSame('Bearer app-token', $this->history[1]['request']->getHeaderLine('Authorization'));
+            parse_str($this->history[0]['request']->getUri()->getQuery(), $firstQuery);
+            parse_str($this->history[1]['request']->getUri()->getQuery(), $secondQuery);
+            self::assertSame(['businessId' => 'biz-2'], $firstQuery);
+            self::assertSame($firstQuery, $secondQuery);
+            self::assertTrue($this->testHandler->hasInfoThatContains('Merchant token unauthorized for business biz-2; retrying subscription fetch with app token'));
         }
 
         public function testFetchPlansReturnsDecodedResponseAndDoesNotLogErrors(): void


### PR DESCRIPTION
## Summary
- try a stored merchant token before using the app token when fetching subscriptions
- centralize merchant token loading and reuse it during retry logic
- update SubscriptionService tests to reflect merchant-first fetching and add coverage for the new fallback path

## Testing
- Unable to run tests (composer install requires a GitHub token in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68f8d21638b0832989494a97ed069cb8