### PR TITLE
Use merchant token when creating subscriptions

### DIFF
--- a/app/Services/CallbackService.php
+++ b/app/Services/CallbackService.php
@@ -432,10 +432,10 @@ class CallbackService
             return true;
         }
 
-        if (!$appAccessToken || !$defaultPlanId) {
+        if (!$appAccessToken || !$merchantAccessToken || !$defaultPlanId) {
             $this->context->getLog()->warning(
                 sprintf(
-                    'Unable to create subscription for business %s store %s: missing app token or plan.',
+                    'Unable to create subscription for business %s store %s: missing app token, merchant token, or plan.',
                     $businessId,
                     $storeId
                 )
@@ -470,7 +470,7 @@ class CallbackService
         }
 
         $created = $subscriptionService->createSubscription(
-            $appAccessToken,
+            $merchantAccessToken,
             $businessId,
             $storeId,
             $defaultPlanId

--- a/app/Services/SubscriptionService.php
+++ b/app/Services/SubscriptionService.php
@@ -328,7 +328,7 @@ class SubscriptionService
     /**
      * Creates a new paid subscription on Poynt (POST) and upserts the result into local DB.
      *
-     * @param string $appAccessToken App-level OAuth token
+     * @param string $merchantAccessToken Merchant-level OAuth token
      * @param string $businessId Poynt business ID
      * @param string $storeId Poynt store ID
      * @param string $planId Poynt plan ID (e.g. "plan_basic_monthly")
@@ -340,7 +340,7 @@ class SubscriptionService
      * @throws GuzzleException
      */
     public function createSubscription(
-        string      $accessToken,
+        string      $merchantAccessToken,
         string      $businessId,
         string      $storeId,
         string      $planId,
@@ -351,6 +351,12 @@ class SubscriptionService
         if ($orgId === '') {
             throw new RuntimeException('ConfigApp::$orgId must be configured to create subscriptions.');
         }
+        if ($merchantAccessToken === '') {
+            $this->context->getLog()->error('Cannot create subscription without a merchant access token.');
+
+            return [];
+        }
+
         $endpoint = $this->buildAppResourceUrl('subscriptions');
 
         // If startAt is not provided, use current UTC
@@ -369,7 +375,7 @@ class SubscriptionService
         try {
             $response = $this->http->post($endpoint, [
                 'headers' => [
-                    'Authorization' => 'Bearer ' . $accessToken,
+                    'Authorization' => 'Bearer ' . $merchantAccessToken,
                     'Accept'        => 'application/json',
                     'Content-Type'  => 'application/json',
                 ],

--- a/tests/Services/SubscriptionServiceTest.php
+++ b/tests/Services/SubscriptionServiceTest.php
@@ -240,7 +240,7 @@ namespace Services {
             ]);
 
             $result = $service->createSubscription(
-                'token',
+                'merchant-token',
                 $responsePayload['businessId'],
                 $responsePayload['storeId'],
                 $responsePayload['planId'],
@@ -253,7 +253,7 @@ namespace Services {
 
             $request = $this->history[0]['request'];
             self::assertSame('POST', $request->getMethod());
-            self::assertSame('Bearer token', $request->getHeaderLine('Authorization'));
+            self::assertSame('Bearer merchant-token', $request->getHeaderLine('Authorization'));
             self::assertSame(
                 'https://billing.poynt.net/organizations/test-org/apps/urn:aid:test-app/subscriptions',
                 (string) $request->getUri()


### PR DESCRIPTION
## Summary
- require a merchant access token when issuing subscription creation requests to the Poynt billing API
- gate callback subscription creation on the presence of both app and merchant tokens and update the fallback message
- refresh subscription service tests to expect the merchant token in authorization headers

## Testing
- php -l app/Services/SubscriptionService.php
- php -l app/Services/CallbackService.php
- php -l tests/Services/SubscriptionServiceTest.php

------
https://chatgpt.com/codex/tasks/task_e_68f8e90f3a588329804e28dddfafcb8b