### PR TITLE
Delete Poynt billing subscriptions during purge

### DIFF
--- a/scripts/purge_business.php
+++ b/scripts/purge_business.php
@@ -57,6 +57,65 @@ $context = new Context($api, $conn, $log, $httpClientFactory);
 $serviceFactory = new ServiceFactory($context);
 $platformRegistry = new PlatformRegistry($context);
 
+$subscriptionIds = [];
+
+try {
+    $subscriptionIds = $conn->fetchFirstColumn(
+        'SELECT subscription_id FROM subscription WHERE business_id = :biz',
+        ['biz' => $businessId]
+    );
+} catch (\Throwable $e) {
+    $log->warning(
+        sprintf('Failed to fetch subscriptions for business %s: %s', $businessId, $e->getMessage()),
+        ['exception' => $e]
+    );
+}
+
+if (!empty($subscriptionIds)) {
+    $tokenService = $serviceFactory->token();
+    $appToken = null;
+
+    try {
+        $appToken = $tokenService->getAppToken($businessId, true);
+    } catch (\Throwable $e) {
+        $log->warning(
+            sprintf('Failed to retrieve app token for business %s: %s', $businessId, $e->getMessage()),
+            ['exception' => $e]
+        );
+    }
+
+    if (is_array($appToken) && !empty($appToken['access_token'])) {
+        $subscriptionService = $serviceFactory->subscription($businessId);
+
+        foreach ($subscriptionIds as $subscriptionId) {
+            try {
+                $subscriptionService->deleteSubscription($appToken['access_token'], $subscriptionId);
+                $log->info(
+                    sprintf(
+                        'Deleted subscription %s from Poynt billing for business %s.',
+                        $subscriptionId,
+                        $businessId
+                    )
+                );
+            } catch (\Throwable $e) {
+                $log->error(
+                    sprintf(
+                        'Failed to delete subscription %s from Poynt billing for business %s: %s',
+                        $subscriptionId,
+                        $businessId,
+                        $e->getMessage()
+                    ),
+                    ['exception' => $e]
+                );
+            }
+        }
+    } else {
+        $log->warning(
+            sprintf('No app token available for business %s; skipping Poynt subscription deletion.', $businessId)
+        );
+    }
+}
+
 $callbackService = new CallbackService($context, $platformRegistry, $serviceFactory);
 
 $callbackService->purgeBusiness($businessId, !$dropTokens);


### PR DESCRIPTION
## Summary
- look up all subscriptions associated with the business before purging local data
- use the stored app token to call the Poynt billing API and delete each subscription, logging outcomes and fallbacks

## Testing
- php -l scripts/purge_business.php

------
https://chatgpt.com/codex/tasks/task_e_68f8eb15816083298d9836dc31706140