### PR TITLE
Fetch subscriptions per store in purge script

### DIFF
--- a/scripts/purge_business.php
+++ b/scripts/purge_business.php
@@ -15,8 +15,67 @@ use App\Services\ServiceFactory;
 use Doctrine\DBAL\DriverManager;
 use Monolog\Logger;
 use Ramsey\Uuid\Uuid;
-
 require_once __DIR__ . '/../public/bootstrap.php';
+
+/**
+ * @param mixed $payload
+ * @return array<int, string>
+ */
+function extractStoreIdsFromPayload(mixed $payload): array
+{
+    if (!is_array($payload)) {
+        return [];
+    }
+
+    $collections = [];
+
+    if (\array_is_list($payload)) {
+        $collections[] = $payload;
+    } else {
+        foreach (['items', 'stores', 'data'] as $key) {
+            if (isset($payload[$key]) && is_array($payload[$key])) {
+                $collections[] = $payload[$key];
+            }
+        }
+
+        if ($collections === []) {
+            $collections[] = array_values(array_filter($payload, 'is_array'));
+        }
+    }
+
+    $ids = [];
+
+    foreach ($collections as $collection) {
+        if (!is_array($collection)) {
+            continue;
+        }
+
+        foreach ($collection as $storeData) {
+            if (!is_array($storeData)) {
+                continue;
+            }
+
+            $candidateId = $storeData['id'] ?? $storeData['storeId'] ?? null;
+            if (is_string($candidateId) && $candidateId !== '') {
+                $ids[] = $candidateId;
+                continue;
+            }
+
+            if (isset($storeData['store']) && is_array($storeData['store'])) {
+                $nestedId = $storeData['store']['id'] ?? $storeData['store']['storeId'] ?? null;
+                if (is_string($nestedId) && $nestedId !== '') {
+                    $ids[] = $nestedId;
+                }
+            }
+        }
+    }
+
+    if ($ids === []) {
+        return [];
+    }
+
+    return array_values(array_unique($ids));
+}
 
 $options = getopt('', ['business:', 'drop-tokens']);
 
@@ -96,24 +155,76 @@ try {
 
 $subscriptionService = $serviceFactory->subscription($businessId);
 
+$storeIds = [];
+
+try {
+    $storeIds = $conn->fetchFirstColumn(
+        'SELECT store_id FROM store WHERE business_id = :biz',
+        ['biz' => $businessId]
+    );
+} catch (\Throwable $e) {
+    $log->warning(
+        sprintf('Failed to fetch local stores for business %s: %s', $businessId, $e->getMessage()),
+        ['exception' => $e]
+    );
+}
+
+$storeIds = array_values(array_filter(
+    array_map(static fn($value) => is_string($value) ? trim($value) : null, $storeIds),
+    static fn($value) => is_string($value) && $value !== ''
+));
+
+if (is_string($merchantToken) && $merchantToken !== '') {
+    $storeService = $serviceFactory->store($businessId);
+    $remoteStores = $storeService->fetchByBusinessId($businessId);
+
+    if (is_array($remoteStores)) {
+        $storeIds = array_values(array_unique(array_merge(
+            $storeIds,
+            extractStoreIdsFromPayload($remoteStores)
+        )));
+    } elseif ($remoteStores === false) {
+        $log->warning(
+            sprintf('Failed to fetch remote stores for business %s; continuing with local store list only.', $businessId)
+        );
+    }
+}
+
 if (is_array($appToken) && !empty($appToken['access_token'])) {
-    try {
-        $remoteSubscriptions = $subscriptionService->fetchSubscriptions($appToken['access_token'], $businessId);
+    $storesForLookup = $storeIds;
 
-        if (is_array($remoteSubscriptions)) {
-            foreach ($remoteSubscriptions as $subscription) {
-                $remoteId = $subscription['subscriptionId'] ?? null;
+    if ($storesForLookup === []) {
+        $storesForLookup[] = null;
+    }
 
-                if (is_string($remoteId) && $remoteId !== '') {
-                    $remoteSubscriptionIds[] = $remoteId;
+    foreach ($storesForLookup as $storeId) {
+        try {
+            $remoteSubscriptions = $subscriptionService->fetchSubscriptions(
+                $appToken['access_token'],
+                $businessId,
+                $storeId
+            );
+
+            if (is_array($remoteSubscriptions)) {
+                foreach ($remoteSubscriptions as $subscription) {
+                    $remoteId = $subscription['subscriptionId'] ?? null;
+
+                    if (is_string($remoteId) && $remoteId !== '') {
+                        $remoteSubscriptionIds[] = $remoteId;
+                    }
                 }
             }
+        } catch (\Throwable $e) {
+            $log->error(
+                sprintf(
+                    'Failed to fetch remote subscriptions for business %s%s: %s',
+                    $businessId,
+                    $storeId !== null ? sprintf(' (store %s)', $storeId) : '',
+                    $e->getMessage()
+                ),
+                ['exception' => $e]
+            );
         }
-    } catch (\Throwable $e) {
-        $log->error(
-            sprintf('Failed to fetch remote subscriptions for business %s: %s', $businessId, $e->getMessage()),
-            ['exception' => $e]
-        );
     }
 }
 


### PR DESCRIPTION
## Summary
- add helper to extract store identifiers from store payloads
- fetch store IDs locally and remotely when available before purging
- delete subscriptions after querying Poynt for each store individually

## Testing
- php -l scripts/purge_business.php

------
https://chatgpt.com/codex/tasks/task_e_68fb46173f5c8329a02091f35bbb5b8d