### PR TITLE
Handle subscription end dates and statuses

### DIFF
--- a/SQL/poynt-v1.sql
+++ b/SQL/poynt-v1.sql
@@ -145,7 +145,7 @@ DROP TABLE IF EXISTS business CASCADE;
 
 -- 1) BUSINESS table (root of the hierarchy)
 CREATE TABLE business (
-  business_id VARCHAR(255) PRIMARY KEY,   -- Poynt’s business ID
+  business_id VARCHAR(255) PRIMARY KEY,   -- Poynts business ID
   name        VARCHAR(255) NOT NULL,
   metadata    JSONB        NOT NULL DEFAULT '{}',
   created_at  TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
@@ -158,8 +158,8 @@ select * from business;
 
 -- 2) STORE table (child of business, no foreign-key enforced)
 CREATE TABLE store (
-  store_id    VARCHAR(255) PRIMARY KEY,   -- Poynt’s store ID
-  business_id VARCHAR(255) NOT NULL,      -- “belongs to” a business, but not an FK
+  store_id    VARCHAR(255) PRIMARY KEY,   -- Poynts store ID
+  business_id VARCHAR(255) NOT NULL,      -- belongs to a business, but not an FK
   name        VARCHAR(255) NOT NULL,
   metadata    JSONB        NOT NULL DEFAULT '{}',
   created_at  TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
@@ -168,8 +168,8 @@ CREATE TABLE store (
 
 -- 3) (Optional) TERMINAL table (child of store, no FK enforced)
 CREATE TABLE terminal (
-  terminal_id VARCHAR(255) PRIMARY KEY,   -- Poynt’s terminal ID
-  store_id    VARCHAR(255) NOT NULL,      -- “belongs to” a store, but not an FK
+  terminal_id VARCHAR(255) PRIMARY KEY,   -- Poynts terminal ID
+  store_id    VARCHAR(255) NOT NULL,      -- belongs to a store, but not an FK
   metadata    JSONB        NOT NULL DEFAULT '{}',
   created_at  TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
   updated_at  TIMESTAMPTZ  NOT NULL DEFAULT NOW()
@@ -201,7 +201,7 @@ CREATE INDEX idx_merchant_token_expires_at
 
 -- 6) SUBSCRIPTION table
 CREATE TABLE subscription (
-  subscription_id     VARCHAR(255)     PRIMARY KEY,    -- Poynt’s subscription UUID or my own generated UUID
+  subscription_id     VARCHAR(255)     PRIMARY KEY,    -- Poynts subscription UUID or my own generated UUID
   business_id         VARCHAR(255)     NOT NULL,       -- which business this store belongs to
   store_id            VARCHAR(255)     NOT NULL,       -- which specific store this subscription is for
   plan_id             VARCHAR(255)     NOT NULL,       -- e.g. "free_trial", "basic_monthly", "pro_annual", etc.
@@ -211,6 +211,7 @@ CREATE TABLE subscription (
   trial_end_at        TIMESTAMPTZ,                     -- when the trial will (or did) end
   start_at            TIMESTAMPTZ     NOT NULL,       -- when this subscription record became effective
   current_period_end  TIMESTAMPTZ,                     -- when the current billing period ends
+  end_at              TIMESTAMPTZ,                     -- when the subscription fully ends (if scheduled)
   cancel_at_period_end BOOLEAN         NOT NULL DEFAULT FALSE,
   canceled_at         TIMESTAMPTZ,                     -- when (if ever) the subscription was canceled
   created_at          TIMESTAMPTZ     NOT NULL DEFAULT NOW(),
@@ -221,7 +222,7 @@ CREATE TABLE subscription (
 CREATE INDEX idx_subscription_current_period_end
   ON subscription(current_period_end);
 
--- And if you want to find all “active” subscriptions by store_id:
+-- And if you want to find all active subscriptions by store_id:
 CREATE INDEX idx_subscription_store_status
   ON subscription(store_id, status);
 

--- a/SQL/poynt-v2.sql
+++ b/SQL/poynt-v2.sql
@@ -82,6 +82,7 @@ CREATE TABLE subscription (
   trial_end_at        TIMESTAMPTZ,
   start_at            TIMESTAMPTZ      NOT NULL,
   current_period_end  TIMESTAMPTZ,
+  end_at              TIMESTAMPTZ,
   cancel_at_period_end BOOLEAN         NOT NULL DEFAULT FALSE,
   canceled_at         TIMESTAMPTZ,
   created_at          TIMESTAMPTZ      NOT NULL DEFAULT NOW(),

--- a/app/Controllers/SubscriptionController.php
+++ b/app/Controllers/SubscriptionController.php
@@ -42,8 +42,12 @@ class SubscriptionController extends Controller
         $subscriptionId = $subscription['subscriptionId'] ?? $subscription['subscription_id'] ?? null;
         $trialExpired   = $subscriptionId ? $this->subscriptionService->hasTrialExpired($subscriptionId) : false;
 
+        $normalizedStatus = is_array($subscription)
+            ? $this->subscriptionService->resolveSubscriptionStatus($subscription)
+            : null;
+
         $response = [
-            'subscriptionStatus' => $subscription['status'] ?? null,
+            'subscriptionStatus' => $normalizedStatus,
             'trialExpired'       => $trialExpired,
         ];
 

--- a/app/Services/SubscriptionService.php
+++ b/app/Services/SubscriptionService.php
@@ -223,6 +223,42 @@ class SubscriptionService
         }
     }
 
+    /**
+     * Normalises a subscription status string, taking into account the remote status
+     * payload and any "endAt" timestamp returned by Poynt. When a subscription has an
+     * end date in the past we treat it as ENDED even if the upstream status still
+     * reports ACTIVE so callers can rely on a consistent life-cycle signal.
+     *
+     * @param array $subscription Raw subscription payload from Poynt or the local DB.
+     */
+    public function resolveSubscriptionStatus(array $subscription): ?string
+    {
+        $status = $subscription['status'] ?? null;
+        if ($status === null) {
+            return null;
+        }
+
+        $normalized = strtoupper((string) $status);
+
+        $endAtRaw = $subscription['endAt'] ?? $subscription['end_at'] ?? null;
+        if ($endAtRaw === null || $endAtRaw === '') {
+            return $normalized;
+        }
+
+        try {
+            $endAt = new DateTime((string) $endAtRaw, new DateTimeZone('UTC'));
+            $now   = new DateTime('now', new DateTimeZone('UTC'));
+
+            if ($endAt <= $now && $normalized === 'ACTIVE') {
+                return 'ENDED';
+            }
+        } catch (Exception) {
+            // Ignore parsing failures and fall back to the original status.
+        }
+
+        return $normalized;
+    }
+
 
     // ────────────────────────────────────────────────────────────────────────────
     // 1) Start a local-only free trial
@@ -263,6 +299,7 @@ class SubscriptionService
           trial_end_at,
           start_at,
           current_period_end,
+          end_at,
           cancel_at_period_end,
           canceled_at,
           created_at,
@@ -272,6 +309,7 @@ class SubscriptionService
           :status, :phase,
           :tstart, :tend,
           :saat, :cpe,
+          NULL,
           FALSE, NULL,
           NOW(), NOW()
         )
@@ -519,8 +557,8 @@ class SubscriptionService
         // Remove from local subscription table
         try {
             $this->context->getConn()->executeStatement(
-                "UPDATE subscription SET status = :status, updated_at = :upat WHERE subscription_id = :sub_id",
-                ['sub_id' => $subscriptionId, 'status' => 'canceled', 'upat' => date('Y-m-d H:i:s')]
+                "UPDATE subscription SET status = :status, end_at = COALESCE(end_at, NOW()), updated_at = :upat WHERE subscription_id = :sub_id",
+                ['sub_id' => $subscriptionId, 'status' => 'CANCELED', 'upat' => date('Y-m-d H:i:s')]
             );
         } catch (\Exception $e) {
             $this->context->getLog()->error("Poynt DELETE subscription failed: " . $e->getMessage() . ". Code: " . $e->getCode() . ". Whole object: ". json_encode($e));
@@ -566,6 +604,7 @@ class SubscriptionService
         $trialEnd         = Format::optionalTimestamp($poyntSub['trialEnd']         ?? null);
         $startAt          = Format::optionalTimestamp($poyntSub['startAt']          ?? null);
         $currentPeriodEnd = Format::optionalTimestamp($poyntSub['currentPeriodEnd'] ?? null);
+        $endAt            = Format::optionalTimestamp($poyntSub['endAt']            ?? null);
         $cancelAtEnd      = $poyntSub['cancelAtPeriodEnd'] ?? false;
         $canceledAt       = Format::optionalTimestamp($poyntSub['canceledAt']       ?? null);
 
@@ -581,6 +620,7 @@ class SubscriptionService
           trial_end_at,
           start_at,
           current_period_end,
+          end_at,
           cancel_at_period_end,
           canceled_at,
           created_at,
@@ -590,6 +630,7 @@ class SubscriptionService
           :status, :phase,
           :tstart, :tend,
           :saat, :cpe,
+          :endAt,
           :cancelAtEnd, :canceledAt,
           NOW(), NOW()
         )
@@ -603,6 +644,7 @@ class SubscriptionService
           trial_end_at         = EXCLUDED.trial_end_at,
           start_at             = EXCLUDED.start_at,
           current_period_end   = EXCLUDED.current_period_end,
+          end_at               = EXCLUDED.end_at,
           cancel_at_period_end = EXCLUDED.cancel_at_period_end,
           canceled_at          = EXCLUDED.canceled_at,
           updated_at           = NOW()
@@ -620,6 +662,7 @@ class SubscriptionService
                 'tend'        => $trialEnd,
                 'saat'        => $startAt,
                 'cpe'         => $currentPeriodEnd,
+                'endAt'       => $endAt,
                 'cancelAtEnd' => $cancelAtEnd,
                 'canceledAt'  => $canceledAt,
             ]);
@@ -642,6 +685,7 @@ class SubscriptionService
         UPDATE subscription
            SET status = :status,
                start_at = COALESCE(start_at, NOW()),
+               end_at = NULL,
                updated_at = NOW()
          WHERE subscription_id = :sub_id
            AND business_id = :biz
@@ -650,7 +694,7 @@ class SubscriptionService
 
         try {
             $this->context->getConn()->executeStatement($sql, [
-                'status' => 'active',
+                'status' => 'ACTIVE',
                 'sub_id' => $subscriptionId,
                 'biz'    => $businessId,
                 'store'  => $storeId,
@@ -674,6 +718,7 @@ class SubscriptionService
         UPDATE subscription
            SET status = :status,
                canceled_at = COALESCE(canceled_at, NOW()),
+               end_at = COALESCE(end_at, NOW()),
                updated_at = NOW()
          WHERE subscription_id = :sub_id
            AND business_id = :biz
@@ -682,7 +727,7 @@ class SubscriptionService
 
         try {
             $this->context->getConn()->executeStatement($sql, [
-                'status' => 'canceled',
+                'status' => 'CANCELED',
                 'sub_id' => $subscriptionId,
                 'biz'    => $businessId,
                 'store'  => $storeId,

--- a/database/migrations/20241010000000_create_core_entities.sql
+++ b/database/migrations/20241010000000_create_core_entities.sql
@@ -55,6 +55,7 @@ CREATE TABLE IF NOT EXISTS subscription (
     trial_end_at TIMESTAMPTZ,
     start_at TIMESTAMPTZ NOT NULL,
     current_period_end TIMESTAMPTZ,
+    end_at TIMESTAMPTZ,
     cancel_at_period_end BOOLEAN NOT NULL DEFAULT FALSE,
     canceled_at TIMESTAMPTZ,
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),

--- a/tests/Controllers/ApiEndpointsTest.php
+++ b/tests/Controllers/ApiEndpointsTest.php
@@ -200,6 +200,51 @@ namespace Controllers {
             ], $last['response']);
         }
 
+        public function testSubscriptionStatusTreatsPastEndDateAsEnded(): void
+        {
+            $api = $this->createApi([
+                'merchantAccessToken' => 'token',
+                'businessId' => 'biz',
+                'storeId' => 'store',
+            ], 'GET');
+            $context = $this->createContext($api);
+
+            /** @var SubscriptionService&MockObject $service */
+            $service = $this->getMockBuilder(SubscriptionService::class)
+                ->disableOriginalConstructor()
+                ->onlyMethods(['fetchMerchantSubscription', 'hasTrialExpired'])
+                ->getMock();
+
+            $service->expects(self::once())
+                ->method('fetchMerchantSubscription')
+                ->with('token', 'biz', 'store')
+                ->willReturn([
+                    [
+                        'subscriptionId' => 'sub-123',
+                        'status' => 'ACTIVE',
+                        'endAt' => '2020-01-01T00:00:00Z',
+                    ],
+                ]);
+
+            $service->expects(self::once())
+                ->method('hasTrialExpired')
+                ->with('sub-123')
+                ->willReturn(false);
+
+            $controller = new SubscriptionController($context);
+            $controller->setSubscriptionService($service);
+
+            $controller->status();
+            $last = Api::getLastResponse();
+
+            self::assertNotNull($last);
+            self::assertSame(Response::STATUS_OK, $last['status']);
+            self::assertSame([
+                'subscriptionStatus' => 'ENDED',
+                'trialExpired' => false,
+            ], $last['response']);
+        }
+
         public function testSubscriptionStatusReturnsBadRequestWhenMissingParameters(): void
         {
             $api = $this->createApi([], 'GET');


### PR DESCRIPTION
## Summary
- persist subscription end dates in the schema and subscription upsert logic
- normalize subscription status responses using the upstream status and endAt timestamp
- ensure subscription activations/cancellations clear or stamp end dates and cover the new logic with tests

## Testing
- N/A (composer install requires GitHub credentials)

------
https://chatgpt.com/codex/tasks/task_e_68fb5ba9619c8329bfb70b66deac9f9b