### PR TITLE
Ensure default plan selection uses store scope

### DIFF
--- a/app/Services/CallbackService.php
+++ b/app/Services/CallbackService.php
@@ -586,11 +586,17 @@ class CallbackService
 
     private function selectDefaultPlanId(?array $plans): ?string
     {
-        $candidates = $this->collectPlanCandidates($plans);
+        $allCandidates = $this->collectPlanCandidates($plans);
 
-        if ($candidates === []) {
+        if ($allCandidates === []) {
             return null;
         }
+
+        $storeScoped = array_filter($allCandidates, function (array $plan): bool {
+            return $this->isStoreScopedPlan($plan);
+        });
+
+        $candidates = $storeScoped !== [] ? array_values($storeScoped) : $allCandidates;
 
         foreach ($candidates as $plan) {
             $planId = $this->extractPlanId($plan);
@@ -612,6 +618,28 @@ class CallbackService
         }
 
         return null;
+    }
+
+    private function isStoreScopedPlan(array $plan): bool
+    {
+        $rawScope = null;
+
+        foreach (['scope', 'scopeType', 'scope_type'] as $key) {
+            $value = $plan[$key] ?? null;
+
+            if ($value === null) {
+                continue;
+            }
+
+            if (is_string($value) || is_numeric($value)) {
+                $rawScope = strtolower(trim((string) $value));
+                if ($rawScope !== '') {
+                    break;
+                }
+            }
+        }
+
+        return $rawScope === 'store';
     }
 
     private function startTrialIfMissing(?string $businessId, ?string $storeId): void

--- a/tests/Services/CallbackServiceTest.php
+++ b/tests/Services/CallbackServiceTest.php
@@ -215,10 +215,12 @@ class CallbackServiceTest extends TestCase
                 [
                     'planId' => 'plan-basic',
                     'status' => 'ACTIVE',
+                    'scope' => 'STORE',
                 ],
                 [
                     'planId' => 'plan-pro',
                     'status' => 'inactive',
+                    'scope' => 'BUSINESS',
                 ],
             ],
             'links' => [],
@@ -228,6 +230,64 @@ class CallbackServiceTest extends TestCase
         $method->setAccessible(true);
 
         $this->assertSame('plan-basic', $method->invoke($callbackService, $plans));
+    }
+
+    public function testSelectDefaultPlanIdPrefersStoreScopedPlans(): void
+    {
+        $logger = $this->createMock(Logger::class);
+        $context = $this->createMock(Context::class);
+        $context->method('getLog')->willReturn($logger);
+
+        $callbackService = $this->createCallbackService($context);
+
+        $plans = [
+            'items' => [
+                [
+                    'planId' => 'plan-business',
+                    'status' => 'ACTIVE',
+                    'scope' => 'BUSINESS',
+                ],
+                [
+                    'planId' => 'plan-store',
+                    'status' => 'ACTIVE',
+                    'scopeType' => 'STORE',
+                ],
+            ],
+        ];
+
+        $method = new ReflectionMethod($callbackService, 'selectDefaultPlanId');
+        $method->setAccessible(true);
+
+        $this->assertSame('plan-store', $method->invoke($callbackService, $plans));
+    }
+
+    public function testSelectDefaultPlanIdFallsBackWhenNoStoreScopedPlans(): void
+    {
+        $logger = $this->createMock(Logger::class);
+        $context = $this->createMock(Context::class);
+        $context->method('getLog')->willReturn($logger);
+
+        $callbackService = $this->createCallbackService($context);
+
+        $plans = [
+            'items' => [
+                [
+                    'planId' => 'plan-business-active',
+                    'status' => 'ACTIVE',
+                    'scope' => 'BUSINESS',
+                ],
+                [
+                    'planId' => 'plan-business-disabled',
+                    'status' => 'disabled',
+                    'scope' => 'BUSINESS',
+                ],
+            ],
+        ];
+
+        $method = new ReflectionMethod($callbackService, 'selectDefaultPlanId');
+        $method->setAccessible(true);
+
+        $this->assertSame('plan-business-active', $method->invoke($callbackService, $plans));
     }
 
     public function testFindPlanIdByNameMatchesCaseInsensitive(): void


### PR DESCRIPTION
## Summary
- prioritize store-scoped plans when selecting a default plan
- add a helper to recognize store scope metadata variants
- extend CallbackService tests to cover scope filtering and fallback behavior

## Testing
- not run (composer install requires GitHub credentials in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68fb6b241f248329b6ba6233eec879fc