### PR TITLE
Handle business-scope subscriptions without store IDs

### DIFF
--- a/SQL/poynt-v1.sql
+++ b/SQL/poynt-v1.sql
@@ -145,7 +145,7 @@ DROP TABLE IF EXISTS business CASCADE;
 
 -- 1) BUSINESS table (root of the hierarchy)
 CREATE TABLE business (
-  business_id VARCHAR(255) PRIMARY KEY,   -- Poyntís business ID
+  business_id VARCHAR(255) PRIMARY KEY,   -- Poynt‚Äôs business ID
   name        VARCHAR(255) NOT NULL,
   metadata    JSONB        NOT NULL DEFAULT '{}',
   created_at  TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
@@ -158,8 +158,8 @@ select * from business;
 
 -- 2) STORE table (child of business, no foreign-key enforced)
 CREATE TABLE store (
-  store_id    VARCHAR(255) PRIMARY KEY,   -- Poyntís store ID
-  business_id VARCHAR(255) NOT NULL,      -- ìbelongs toî a business, but not an FK
+  store_id    VARCHAR(255) PRIMARY KEY,   -- Poynt‚Äôs store ID
+  business_id VARCHAR(255) NOT NULL,      -- ‚Äúbelongs to‚Äù a business, but not an FK
   name        VARCHAR(255) NOT NULL,
   metadata    JSONB        NOT NULL DEFAULT '{}',
   created_at  TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
@@ -168,8 +168,8 @@ CREATE TABLE store (
 
 -- 3) (Optional) TERMINAL table (child of store, no FK enforced)
 CREATE TABLE terminal (
-  terminal_id VARCHAR(255) PRIMARY KEY,   -- Poyntís terminal ID
-  store_id    VARCHAR(255) NOT NULL,      -- ìbelongs toî a store, but not an FK
+  terminal_id VARCHAR(255) PRIMARY KEY,   -- Poynt‚Äôs terminal ID
+  store_id    VARCHAR(255) NOT NULL,      -- ‚Äúbelongs to‚Äù a store, but not an FK
   metadata    JSONB        NOT NULL DEFAULT '{}',
   created_at  TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
   updated_at  TIMESTAMPTZ  NOT NULL DEFAULT NOW()
@@ -201,7 +201,7 @@ CREATE INDEX idx_merchant_token_expires_at
 
 -- 6) SUBSCRIPTION table
 CREATE TABLE subscription (
-  subscription_id     VARCHAR(255)     PRIMARY KEY,    -- Poyntís subscription UUID or my own generated UUID
+  store_id            VARCHAR(255),                  -- null when subscription scope is BUSINESS
   business_id         VARCHAR(255)     NOT NULL,       -- which business this store belongs to
   store_id            VARCHAR(255)     NOT NULL,       -- which specific store this subscription is for
   plan_id             VARCHAR(255)     NOT NULL,       -- e.g. "free_trial", "basic_monthly", "pro_annual", etc.
@@ -221,7 +221,7 @@ CREATE TABLE subscription (
 CREATE INDEX idx_subscription_current_period_end
   ON subscription(current_period_end);
 
--- And if you want to find all ìactiveî subscriptions by store_id:
+-- And if you want to find all ‚Äúactive‚Äù subscriptions by store_id:
 CREATE INDEX idx_subscription_store_status
   ON subscription(store_id, status);
 

--- a/SQL/poynt-v2.sql
+++ b/SQL/poynt-v2.sql
@@ -74,7 +74,7 @@ CREATE INDEX idx_merchant_token_expires_at ON merchant_token(expires_at);
 CREATE TABLE subscription (
   subscription_id     VARCHAR(255)     PRIMARY KEY,
   business_id         VARCHAR(255)     NOT NULL,
-  store_id            VARCHAR(255)     NOT NULL,
+  store_id            VARCHAR(255),
   plan_id             VARCHAR(255)     NOT NULL,
   status              VARCHAR(50)      NOT NULL,
   phase               VARCHAR(50)      NOT NULL,

--- a/app/Controllers/WebhooksController.php
+++ b/app/Controllers/WebhooksController.php
@@ -109,9 +109,22 @@ class WebhooksController extends Controller
         $subscriptionId = $payload['subscriptionId'] ?? null;
         $businessId     = $payload['businessId']     ?? null;
         $storeId        = $payload['storeId']        ?? null;
+        $scope          = isset($payload['scope']) && is_string($payload['scope'])
+            ? strtoupper($payload['scope'])
+            : null;
 
-        if (!$subscriptionId || !$businessId || !$storeId) {
+        if (!$subscriptionId || !$businessId) {
             throw new \InvalidArgumentException('Missing subscription data');
+        }
+
+        if ($scope === 'BUSINESS') {
+            $this->subscriptionService->activateSubscription($subscriptionId, $businessId, null);
+
+            return;
+        }
+
+        if (!$storeId) {
+            throw new \InvalidArgumentException('Missing store identifier for subscription start event');
         }
 
         $this->subscriptionService->activateSubscription($subscriptionId, $businessId, $storeId);
@@ -127,9 +140,22 @@ class WebhooksController extends Controller
         $subscriptionId = $payload['subscriptionId'] ?? null;
         $businessId     = $payload['businessId']     ?? null;
         $storeId        = $payload['storeId']        ?? null;
+        $scope          = isset($payload['scope']) && is_string($payload['scope'])
+            ? strtoupper($payload['scope'])
+            : null;
 
-        if (!$subscriptionId || !$businessId || !$storeId) {
+        if (!$subscriptionId || !$businessId) {
             throw new \InvalidArgumentException('Missing subscription data');
+        }
+
+        if ($scope === 'BUSINESS') {
+            $this->subscriptionService->cancelSubscription($subscriptionId, $businessId, null);
+
+            return;
+        }
+
+        if (!$storeId) {
+            throw new \InvalidArgumentException('Missing store identifier for subscription end event');
         }
 
         $this->subscriptionService->cancelSubscription($subscriptionId, $businessId, $storeId);

--- a/app/Services/CallbackService.php
+++ b/app/Services/CallbackService.php
@@ -286,11 +286,13 @@ class CallbackService
             $subscriptionId = $subscription['subscription_id'] ?? null;
             $storeId = $subscription['store_id'] ?? null;
 
-            if (!$subscriptionId || !$storeId) {
+            if (!$subscriptionId) {
                 continue;
             }
 
-            $subscriptionService->activateSubscription($subscriptionId, $businessId, $storeId);
+            $normalizedStoreId = is_string($storeId) && $storeId !== '' ? $storeId : null;
+
+            $subscriptionService->activateSubscription($subscriptionId, $businessId, $normalizedStoreId);
         }
     }
 

--- a/app/Services/SubscriptionService.php
+++ b/app/Services/SubscriptionService.php
@@ -517,7 +517,7 @@ class SubscriptionService
                 continue;
             }
 
-            $resolvedStoreId = $sub['storeId'] ?? $storeId ?? $this->storeId;
+            $resolvedStoreId = $this->resolveStoreIdFromPayload($sub, $storeId);
             $this->upsertLocalSubscription($sub, $resolvedStoreId);
         }
 
@@ -682,6 +682,43 @@ class SubscriptionService
         return [];
     }
 
+    /**
+     * Resolve the most appropriate store identifier for a subscription payload.
+     *
+     * When the subscription scope is BUSINESS the store identifier is omitted
+     * entirely and we persist the row without a store reference.
+     *
+     * @param array $payload          Subscription payload from Poynt.
+     * @param string|null $fallbackId Optional store identifier supplied by the caller.
+     * @return string|null
+     */
+    private function resolveStoreIdFromPayload(array $payload, ?string $fallbackId = null): ?string
+    {
+        $scope = $payload['scope'] ?? null;
+        if (is_string($scope) && strtoupper($scope) === 'BUSINESS') {
+            return null;
+        }
+
+        $candidates = [
+            $payload['storeId'] ?? null,
+            $fallbackId,
+            $this->storeId,
+        ];
+
+        foreach ($candidates as $candidate) {
+            if (!is_string($candidate)) {
+                continue;
+            }
+
+            $trimmed = trim($candidate);
+            if ($trimmed !== '') {
+                return $trimmed;
+            }
+        }
+
+        return null;
+    }
+
     private function logSubscriptionRequestException(RequestException $exception, string $prefix): void
     {
         $msg = $exception->hasResponse()
@@ -748,7 +785,7 @@ class SubscriptionService
     public function upsert(array $subscriptionData): bool
     {
         try {
-            $resolvedStoreId = $subscriptionData['storeId'] ?? $this->storeId;
+            $resolvedStoreId = $this->resolveStoreIdFromPayload($subscriptionData, $this->storeId);
             $this->upsertLocalSubscription($subscriptionData, $resolvedStoreId);
             return true;
         } catch (\Throwable $e) {
@@ -854,7 +891,7 @@ class SubscriptionService
     {
         $subscriptionId   = $poyntSub['subscriptionId'];
         $businessId       = $poyntSub['businessId'];
-        $storeId          = $storeId ?? ($poyntSub['storeId'] ?? $this->storeId);
+        $storeId          = $this->resolveStoreIdFromPayload($poyntSub, $storeId);
         $planId           = $poyntSub['planId'];
         $status           = $poyntSub['status'];
         $phase            = $poyntSub['phase'];
@@ -988,10 +1025,10 @@ class SubscriptionService
      *
      * @param string $subscriptionId
      * @param string $businessId
-     * @param string $storeId
+     * @param string|null $storeId
      * @return void
      */
-    public function activateSubscription(string $subscriptionId, string $businessId, string $storeId): void
+    public function activateSubscription(string $subscriptionId, string $businessId, ?string $storeId): void
     {
         $sql = <<<SQL
         UPDATE subscription
@@ -1000,7 +1037,10 @@ class SubscriptionService
                updated_at = NOW()
          WHERE subscription_id = :sub_id
            AND business_id = :biz
-           AND store_id = :store
+           AND (
+                (store_id = :store)
+                OR (:store IS NULL AND store_id IS NULL)
+            )
         SQL;
 
         try {
@@ -1020,10 +1060,10 @@ class SubscriptionService
      *
      * @param string $subscriptionId
      * @param string $businessId
-     * @param string $storeId
+     * @param string|null $storeId
      * @return void
      */
-    public function cancelSubscription(string $subscriptionId, string $businessId, string $storeId): void
+    public function cancelSubscription(string $subscriptionId, string $businessId, ?string $storeId): void
     {
         $sql = <<<SQL
         UPDATE subscription
@@ -1032,7 +1072,10 @@ class SubscriptionService
                updated_at = NOW()
          WHERE subscription_id = :sub_id
            AND business_id = :biz
-           AND store_id = :store
+           AND (
+                (store_id = :store)
+                OR (:store IS NULL AND store_id IS NULL)
+            )
         SQL;
 
         try {

--- a/database/migrations/20241010000000_create_core_entities.sql
+++ b/database/migrations/20241010000000_create_core_entities.sql
@@ -47,7 +47,7 @@ CREATE INDEX IF NOT EXISTS idx_merchant_token_expires_at ON merchant_token (expi
 CREATE TABLE IF NOT EXISTS subscription (
     subscription_id VARCHAR(255) PRIMARY KEY,
     business_id VARCHAR(255) NOT NULL,
-    store_id VARCHAR(255) NOT NULL,
+    store_id VARCHAR(255),
     plan_id VARCHAR(255) NOT NULL,
     status VARCHAR(50) NOT NULL,
     phase VARCHAR(50) NOT NULL,

--- a/database/migrations/20241101000000_alter_subscription_store_nullable.sql
+++ b/database/migrations/20241101000000_alter_subscription_store_nullable.sql
@@ -1,0 +1,2 @@
+ALTER TABLE subscription
+    ALTER COLUMN store_id DROP NOT NULL;


### PR DESCRIPTION
## Summary
- resolve store identifiers from subscription payloads and allow business-scope records without a store reference
- update webhook and callback flows to activate/cancel subscriptions even when no store ID is present
- make `subscription.store_id` nullable in schema definitions and add a migration to drop the NOT NULL constraint

## Testing
- composer test *(fails: Command "test" is not defined.)*

------
https://chatgpt.com/codex/tasks/task_e_6900a912e5a08329a256112911b208fd