### PR TITLE
Backfill transaction schema changes for new payload

### DIFF
--- a/SQL/poynt-v2.sql
+++ b/SQL/poynt-v2.sql
@@ -248,51 +248,70 @@ CREATE TABLE order_shipment (
 -- Source (GET): /businesses/{businessId}/transactions
 --               /businesses/{businessId}/transactions/{transactionId}
 CREATE TABLE transaction (
-  transaction_id     VARCHAR(255) PRIMARY KEY,
-  business_id        VARCHAR(255) NOT NULL,
-  store_id           VARCHAR(255),
-  order_id           VARCHAR(255),     -- iz references[type='POYNT_ORDER']
-  action             VARCHAR(32),      -- SALE/AUTHORIZE/CAPTURE/REFUND/VOID...
-  status             VARCHAR(32),      -- APPROVED/DECLINED/VOIDED/...
-  settlement_status  VARCHAR(32),
-  settled            BOOLEAN,
-  partially_approved BOOLEAN,
+  transaction_id           VARCHAR(255) PRIMARY KEY,
+  business_id              VARCHAR(255) NOT NULL,
+  store_id                 VARCHAR(255),
+  store_device_id          VARCHAR(255),
+  employee_user_id         BIGINT,
+  signature_required       BOOLEAN,
+  signature_captured       BOOLEAN,
+  pin_captured             BOOLEAN,
+  adjusted                 BOOLEAN,
+  amounts_adjusted         BOOLEAN,
+  auth_only                BOOLEAN,
+  partially_approved       BOOLEAN,
+  action_void              BOOLEAN,
+  voided                   BOOLEAN,
+  settled                  BOOLEAN,
+  reversal_void            BOOLEAN,
+
+  action                   VARCHAR(32),      -- AUTHORIZE/SALE/REFUND/...
+  status                   VARCHAR(32),      -- AUTHORIZED/CAPTURED/VOIDED/...
+  settlement_status        VARCHAR(32),
+  transaction_instruction  VARCHAR(64),
+  source                   VARCHAR(32),
+  source_app               VARCHAR(255),
+  mcc                      VARCHAR(16),
+
+  customer_user_id         BIGINT,
+  customer_language        VARCHAR(16),
+  customer_opted_no_tip    BOOLEAN,
 
   -- amounts (minor units)
-  txn_amount_minor       BIGINT,
-  order_amount_minor     BIGINT,
-  tip_amount_minor       BIGINT,
-  cashback_amount_minor  BIGINT,
-  currency               VARCHAR(3),
-
-  -- card / entry
-  card_brand         VARCHAR(32),
-  last4              VARCHAR(4),
-  entry_mode         VARCHAR(64),
+  txn_amount_minor         BIGINT,
+  order_amount_minor       BIGINT,
+  tip_amount_minor         BIGINT,
+  cashback_amount_minor    BIGINT,
+  currency                 VARCHAR(3),
+  approved_amount_minor    BIGINT,
 
   -- processor
-  processor          VARCHAR(64),
-  processor_status   VARCHAR(64),
-  processor_code     VARCHAR(32),
-  approval_code      VARCHAR(32),
-  retrieval_ref      VARCHAR(64),
-  batch_id           VARCHAR(64),
+  processor                VARCHAR(64),
+  acquirer                 VARCHAR(64),
+  processor_status         VARCHAR(64),
+  processor_code           VARCHAR(32),
+  approval_code            VARCHAR(32),
+  retrieval_ref            VARCHAR(64),
+  batch_id                 VARCHAR(64),
+  processor_transaction_id VARCHAR(255),
 
-  customer_user_id   BIGINT,
+  references_json          JSONB NOT NULL DEFAULT '[]',
+  links_json               JSONB NOT NULL DEFAULT '[]',
+  funding_source           JSONB NOT NULL DEFAULT '{}',
+  context_json             JSONB NOT NULL DEFAULT '{}',
+  processor_options        JSONB NOT NULL DEFAULT '{}',
+  processor_response       JSONB NOT NULL DEFAULT '{}',
+  amounts_json             JSONB NOT NULL DEFAULT '{}',
+  raw_payload              JSONB NOT NULL DEFAULT '{}',
 
-  references_json    JSONB NOT NULL DEFAULT '[]',
-  funding_source     JSONB NOT NULL DEFAULT '{}',
-  context_json       JSONB NOT NULL DEFAULT '{}',
-  raw_payload        JSONB NOT NULL DEFAULT '{}',
-
-  created_at_ext     TIMESTAMPTZ,
-  updated_at_ext     TIMESTAMPTZ,
-  created_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-  updated_at         TIMESTAMPTZ NOT NULL DEFAULT NOW()
+  created_at_ext           TIMESTAMPTZ,
+  updated_at_ext           TIMESTAMPTZ,
+  created_at               TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at               TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 CREATE INDEX idx_tx_business_updated ON transaction(business_id, updated_at_ext);
-CREATE INDEX idx_tx_order            ON transaction(order_id);
-CREATE INDEX idx_tx_action_status    ON transaction(action, status);
+CREATE INDEX idx_tx_status          ON transaction(status);
+CREATE INDEX idx_tx_action          ON transaction(action);
 
 -- Source (GET, opcionalno): /businesses/{businessId}/transactions/{transactionId}/receipt
 CREATE TABLE transaction_receipt (

--- a/app/Services/TransactionService.php
+++ b/app/Services/TransactionService.php
@@ -78,11 +78,10 @@ class TransactionService
      */
     public function upsert(array $transactionData, ?array $receiptData = null): bool
     {
-        // Require transaction id and business id
-        if (!isset($transactionData['id'], $transactionData['businessId'])) {
-            $this->context->getLog()->error(
-                'TransactionService::upsert: missing required fields id or businessId'
-            );
+        $transactionId = Format::stringOrNull($transactionData['id'] ?? null);
+        if ($transactionId === null) {
+            $this->context->getLog()->error('TransactionService::upsert: missing required field id');
+
             return false;
         }
 
@@ -90,48 +89,55 @@ class TransactionService
             $receiptData = $transactionData['receipt'];
         }
 
-        $transactionId = $transactionData['id'];
-        $businessId = $transactionData['businessId'];
+        $context = $transactionData['context'] ?? [];
+        if (!is_array($context)) {
+            $context = [];
+        }
+
+        $businessId = Format::stringOrNull($transactionData['businessId'] ?? ($context['businessId'] ?? null));
+        if ($businessId === null) {
+            $this->context->getLog()->error(
+                'TransactionService::upsert: missing business id in payload context'
+            );
+
+            return false;
+        }
 
         $now = (new \DateTime('now'))->format('Y-m-d H:i:sP');
 
-        $storeId = $transactionData['storeId']
-            ?? $transactionData['context']['storeId']
-            ?? null;
-        $storeId = Format::stringOrNull($storeId);
-        $references = $transactionData['references'] ?? [];
-        $orderId = $transactionData['orderId'] ?? null;
-        if (!$orderId && is_array($references)) {
-            foreach ($references as $reference) {
-                $type = strtoupper((string) ($reference['type'] ?? $reference['referenceType'] ?? ''));
-                if ($type === 'POYNT_ORDER' || $type === 'ORDER') {
-                    $orderId = $reference['id']
-                        ?? $reference['referenceId']
-                        ?? $reference['value']
-                        ?? null;
-                    if ($orderId) {
-                        break;
-                    }
-                }
-            }
-        }
-        $orderId = Format::stringOrNull($orderId);
+        $storeId = Format::stringOrNull($transactionData['storeId'] ?? ($context['storeId'] ?? null));
+        $storeDeviceId = Format::stringOrNull($transactionData['storeDeviceId'] ?? ($context['storeDeviceId'] ?? null));
+        $employeeUserId = Format::optionalInt($transactionData['employeeUserId'] ?? ($context['employeeUserId'] ?? null));
 
-        $action = $transactionData['action'] ?? $transactionData['type'] ?? null;
-        $status = $transactionData['status'] ?? null;
-        $settlementStatus = $transactionData['settlementStatus']
-            ?? ($transactionData['processorResponse']['settlementStatus'] ?? null);
-        $action = Format::stringOrNull($action);
-        $status = Format::stringOrNull($status);
-        $settlementStatus = Format::stringOrNull($settlementStatus);
-        $settled = Format::optionalBool($transactionData['settled'] ?? null);
+        $signatureRequired = Format::optionalBool($transactionData['signatureRequired'] ?? null);
+        $signatureCaptured = Format::optionalBool($transactionData['signatureCaptured'] ?? null);
+        $pinCaptured = Format::optionalBool($transactionData['pinCaptured'] ?? null);
+        $adjusted = Format::optionalBool($transactionData['adjusted'] ?? null);
+        $amountsAdjusted = Format::optionalBool($transactionData['amountsAdjusted'] ?? null);
+        $authOnly = Format::optionalBool($transactionData['authOnly'] ?? null);
         $partiallyApproved = Format::optionalBool($transactionData['partiallyApproved'] ?? null);
+        $actionVoid = Format::optionalBool($transactionData['actionVoid'] ?? null);
+        $voided = Format::optionalBool($transactionData['voided'] ?? null);
+        $settled = Format::optionalBool($transactionData['settled'] ?? null);
+        $reversalVoid = Format::optionalBool($transactionData['reversalVoid'] ?? null);
 
-        $amounts = $transactionData['amounts'] ?? [];
+        $action = Format::stringOrNull($transactionData['action'] ?? ($transactionData['type'] ?? null));
+        $status = Format::stringOrNull($transactionData['status'] ?? null);
+        $settlementStatus = Format::stringOrNull($transactionData['settlementStatus'] ?? null);
+        $transactionInstruction = Format::stringOrNull($context['transactionInstruction'] ?? null);
+        $source = Format::stringOrNull($context['source'] ?? null);
+        $sourceApp = Format::stringOrNull($context['sourceApp'] ?? null);
+        $mcc = Format::stringOrNull($context['mcc'] ?? null);
+
+        $customerUserId = Format::optionalInt($transactionData['customerUserId'] ?? null);
+        $customerLanguage = Format::stringOrNull($transactionData['customerLanguage'] ?? null);
+
+        $amounts = is_array($transactionData['amounts'] ?? null) ? $transactionData['amounts'] : [];
         $transactionAmount = Format::amount($amounts['transactionAmount'] ?? null);
         $orderAmount = Format::amount($amounts['orderAmount'] ?? null);
         $tipAmount = Format::amount($amounts['tipAmount'] ?? null);
         $cashbackAmount = Format::amount($amounts['cashbackAmount'] ?? null);
+        $customerOptedNoTip = Format::optionalBool($amounts['customerOptedNoTip'] ?? null);
         $currency = $amounts['currency'] ?? null;
         if ($currency === null && isset($amounts['transactionAmount']) && is_array($amounts['transactionAmount'])) {
             $currency = $amounts['transactionAmount']['currency'] ?? null;
@@ -139,7 +145,7 @@ class TransactionService
         $currency = $currency ?? ($transactionData['currency'] ?? null);
         $currency = Format::stringOrNull($currency);
 
-        $fundingSource = $transactionData['fundingSource'] ?? [];
+        $fundingSource = is_array($transactionData['fundingSource'] ?? null) ? $transactionData['fundingSource'] : [];
         $card = $fundingSource['card'] ?? [];
         $cardBrand = $card['brand'] ?? $card['cardBrand'] ?? null;
         if (is_array($cardBrand)) {
@@ -147,41 +153,49 @@ class TransactionService
         }
         $cardBrand = $cardBrand ?? ($card['type'] ?? null);
         $cardBrand = Format::stringOrNull($cardBrand);
-        $cardLast4 = $card['numberLast4'] ?? ($card['lastFourDigits'] ?? null);
-        $cardLast4 = Format::stringOrNull($cardLast4);
-        $entryMode = $card['entryMode']
+        $cardLast4 = Format::stringOrNull($card['numberLast4'] ?? ($card['lastFourDigits'] ?? null));
+        $entryMode = Format::stringOrNull(
+            $card['entryMode']
             ?? $card['entryMethod']
-            ?? ($transactionData['entryMode'] ?? $fundingSource['entryDetails']['entryMode'] ?? null);
-        $entryMode = Format::stringOrNull($entryMode);
+            ?? ($transactionData['entryMode'] ?? ($fundingSource['entryDetails']['entryMode'] ?? null))
+        );
 
+        $processorResponse = is_array($transactionData['processorResponse'] ?? null)
+            ? $transactionData['processorResponse']
+            : [];
         $processor = $transactionData['processor'] ?? [];
-        $processorResponse = $transactionData['processorResponse'] ?? [];
         $processorName = $processor['name']
             ?? $processor['processor']
             ?? ($processorResponse['processor'] ?? null);
         $processorName = Format::stringOrNull($processorName);
-        $processorStatus = $processor['status'] ?? ($processorResponse['status'] ?? null);
-        $processorStatus = Format::stringOrNull($processorStatus);
-        $processorCode = $processor['responseCode']
+        $acquirer = Format::stringOrNull($processorResponse['acquirer'] ?? null);
+        $processorStatus = Format::stringOrNull($processor['status'] ?? ($processorResponse['status'] ?? null));
+        $processorCode = Format::stringOrNull(
+            $processor['responseCode']
             ?? $processor['statusCode']
-            ?? ($processorResponse['responseCode'] ?? $processorResponse['statusCode'] ?? null);
-        $processorCode = Format::stringOrNull($processorCode);
-        $approvalCode = $processor['authCode']
+            ?? ($processorResponse['responseCode'] ?? $processorResponse['statusCode'] ?? null)
+        );
+        $approvalCode = Format::stringOrNull(
+            $processor['authCode']
             ?? $processor['approvalCode']
-            ?? ($processorResponse['authorizationCode'] ?? $processorResponse['approvalCode'] ?? null);
-        $approvalCode = Format::stringOrNull($approvalCode);
-        $retrievalRef = $processor['rrn']
+            ?? ($processorResponse['authorizationCode'] ?? $processorResponse['approvalCode'] ?? null)
+        );
+        $retrievalRef = Format::stringOrNull(
+            $processor['rrn']
             ?? $processor['retrievalReferenceNumber']
-            ?? ($processorResponse['retrievalReferenceNumber'] ?? $processorResponse['retrievalRefNum'] ?? null);
-        $retrievalRef = Format::stringOrNull($retrievalRef);
-        $batchId = $processor['batchId'] ?? ($processorResponse['batchId'] ?? null);
-        $batchId = Format::stringOrNull($batchId);
+            ?? ($processorResponse['retrievalReferenceNumber'] ?? $processorResponse['retrievalRefNum'] ?? null)
+        );
+        $batchId = Format::stringOrNull($processor['batchId'] ?? ($processorResponse['batchId'] ?? null));
+        $processorTransactionId = Format::stringOrNull($processorResponse['transactionId'] ?? null);
+        $approvedAmount = Format::amount($processorResponse['approvedAmount'] ?? null);
 
-        $customerUserId = Format::optionalInt($transactionData['customerUserId'] ?? null);
-
-        $referencesJson = Format::jsonArray($references);
+        $referencesJson = Format::jsonArray($transactionData['references'] ?? []);
+        $linksJson = Format::jsonArray($transactionData['links'] ?? []);
         $fundingSourceJson = Format::jsonObject($fundingSource);
-        $contextJson = Format::jsonObject($transactionData['context'] ?? []);
+        $contextJson = Format::jsonObject($context);
+        $processorOptionsJson = Format::jsonObject($transactionData['processorOptions'] ?? []);
+        $processorResponseJson = Format::jsonObject($processorResponse);
+        $amountsJson = Format::jsonObject($amounts);
         $rawPayload = Format::jsonObject($transactionData);
 
         $createdAtExt = Format::optionalTimestamp($transactionData['createdAt'] ?? null);
@@ -190,50 +204,76 @@ class TransactionService
         try {
             $this->context->getConn()->executeStatement(
                 'INSERT INTO transaction (
-                    transaction_id, business_id, store_id, order_id,
-                    action, status, settlement_status, settled, partially_approved,
+                    transaction_id, business_id, store_id, store_device_id, employee_user_id,
+                    signature_required, signature_captured, pin_captured, adjusted, amounts_adjusted,
+                    auth_only, partially_approved, action_void, voided, settled, reversal_void,
+                    action, status, settlement_status, transaction_instruction, source, source_app, mcc,
+                    customer_user_id, customer_language, customer_opted_no_tip,
                     txn_amount_minor, order_amount_minor, tip_amount_minor, cashback_amount_minor, currency,
-                    card_brand, last4, entry_mode,
-                    processor, processor_status, processor_code, approval_code, retrieval_ref, batch_id,
-                    customer_user_id, references_json, funding_source, context_json, raw_payload,
-                    created_at_ext, updated_at_ext,
+                    approved_amount_minor, processor, acquirer, processor_status, processor_code,
+                    approval_code, retrieval_ref, batch_id, processor_transaction_id,
+                    references_json, links_json, funding_source, context_json, processor_options, processor_response,
+                    amounts_json, raw_payload, created_at_ext, updated_at_ext,
                     created_at, updated_at
                 ) VALUES (
-                    :transactionId, :businessId, :storeId, :orderId,
-                    :action, :status, :settlementStatus, :settled, :partiallyApproved,
+                    :transactionId, :businessId, :storeId, :storeDeviceId, :employeeUserId,
+                    :signatureRequired, :signatureCaptured, :pinCaptured, :adjusted, :amountsAdjusted,
+                    :authOnly, :partiallyApproved, :actionVoid, :voided, :settled, :reversalVoid,
+                    :action, :status, :settlementStatus, :transactionInstruction, :source, :sourceApp, :mcc,
+                    :customerUserId, :customerLanguage, :customerOptedNoTip,
                     :txnAmountMinor, :orderAmountMinor, :tipAmountMinor, :cashbackAmountMinor, :currency,
-                    :cardBrand, :last4, :entryMode,
-                    :processor, :processorStatus, :processorCode, :approvalCode, :retrievalRef, :batchId,
-                    :customerUserId, :referencesJson, :fundingSource, :contextJson, :rawPayload,
-                    :createdAtExt, :updatedAtExt,
+                    :approvedAmountMinor, :processor, :acquirer, :processorStatus, :processorCode,
+                    :approvalCode, :retrievalRef, :batchId, :processorTransactionId,
+                    :referencesJson, :linksJson, :fundingSource, :contextJson, :processorOptions, :processorResponse,
+                    :amountsJson, :rawPayload, :createdAtExt, :updatedAtExt,
                     :createdAt, :updatedAt
                 ) ON CONFLICT (transaction_id) DO UPDATE SET
                     business_id = EXCLUDED.business_id,
                     store_id = EXCLUDED.store_id,
-                    order_id = EXCLUDED.order_id,
+                    store_device_id = EXCLUDED.store_device_id,
+                    employee_user_id = EXCLUDED.employee_user_id,
+                    signature_required = EXCLUDED.signature_required,
+                    signature_captured = EXCLUDED.signature_captured,
+                    pin_captured = EXCLUDED.pin_captured,
+                    adjusted = EXCLUDED.adjusted,
+                    amounts_adjusted = EXCLUDED.amounts_adjusted,
+                    auth_only = EXCLUDED.auth_only,
+                    partially_approved = EXCLUDED.partially_approved,
+                    action_void = EXCLUDED.action_void,
+                    voided = EXCLUDED.voided,
+                    settled = EXCLUDED.settled,
+                    reversal_void = EXCLUDED.reversal_void,
                     action = EXCLUDED.action,
                     status = EXCLUDED.status,
                     settlement_status = EXCLUDED.settlement_status,
-                    settled = EXCLUDED.settled,
-                    partially_approved = EXCLUDED.partially_approved,
+                    transaction_instruction = EXCLUDED.transaction_instruction,
+                    source = EXCLUDED.source,
+                    source_app = EXCLUDED.source_app,
+                    mcc = EXCLUDED.mcc,
+                    customer_user_id = EXCLUDED.customer_user_id,
+                    customer_language = EXCLUDED.customer_language,
+                    customer_opted_no_tip = EXCLUDED.customer_opted_no_tip,
                     txn_amount_minor = EXCLUDED.txn_amount_minor,
                     order_amount_minor = EXCLUDED.order_amount_minor,
                     tip_amount_minor = EXCLUDED.tip_amount_minor,
                     cashback_amount_minor = EXCLUDED.cashback_amount_minor,
                     currency = EXCLUDED.currency,
-                    card_brand = EXCLUDED.card_brand,
-                    last4 = EXCLUDED.last4,
-                    entry_mode = EXCLUDED.entry_mode,
+                    approved_amount_minor = EXCLUDED.approved_amount_minor,
                     processor = EXCLUDED.processor,
+                    acquirer = EXCLUDED.acquirer,
                     processor_status = EXCLUDED.processor_status,
                     processor_code = EXCLUDED.processor_code,
                     approval_code = EXCLUDED.approval_code,
                     retrieval_ref = EXCLUDED.retrieval_ref,
                     batch_id = EXCLUDED.batch_id,
-                    customer_user_id = EXCLUDED.customer_user_id,
+                    processor_transaction_id = EXCLUDED.processor_transaction_id,
                     references_json = EXCLUDED.references_json,
+                    links_json = EXCLUDED.links_json,
                     funding_source = EXCLUDED.funding_source,
                     context_json = EXCLUDED.context_json,
+                    processor_options = EXCLUDED.processor_options,
+                    processor_response = EXCLUDED.processor_response,
+                    amounts_json = EXCLUDED.amounts_json,
                     raw_payload = EXCLUDED.raw_payload,
                     created_at_ext = EXCLUDED.created_at_ext,
                     updated_at_ext = EXCLUDED.updated_at_ext,
@@ -242,30 +282,50 @@ class TransactionService
                     'transactionId' => $transactionId,
                     'businessId' => $businessId,
                     'storeId' => $storeId,
-                    'orderId' => $orderId,
+                    'storeDeviceId' => $storeDeviceId,
+                    'employeeUserId' => $employeeUserId,
+                    'signatureRequired' => $signatureRequired,
+                    'signatureCaptured' => $signatureCaptured,
+                    'pinCaptured' => $pinCaptured,
+                    'adjusted' => $adjusted,
+                    'amountsAdjusted' => $amountsAdjusted,
+                    'authOnly' => $authOnly,
+                    'partiallyApproved' => $partiallyApproved,
+                    'actionVoid' => $actionVoid,
+                    'voided' => $voided,
+                    'settled' => $settled,
+                    'reversalVoid' => $reversalVoid,
                     'action' => $action,
                     'status' => $status,
                     'settlementStatus' => $settlementStatus,
-                    'settled' => $settled,
-                    'partiallyApproved' => $partiallyApproved,
+                    'transactionInstruction' => $transactionInstruction,
+                    'source' => $source,
+                    'sourceApp' => $sourceApp,
+                    'mcc' => $mcc,
+                    'customerUserId' => $customerUserId,
+                    'customerLanguage' => $customerLanguage,
+                    'customerOptedNoTip' => $customerOptedNoTip,
                     'txnAmountMinor' => $transactionAmount,
                     'orderAmountMinor' => $orderAmount,
                     'tipAmountMinor' => $tipAmount,
                     'cashbackAmountMinor' => $cashbackAmount,
                     'currency' => $currency,
-                    'cardBrand' => $cardBrand,
-                    'last4' => $cardLast4,
-                    'entryMode' => $entryMode,
+                    'approvedAmountMinor' => $approvedAmount,
                     'processor' => $processorName,
+                    'acquirer' => $acquirer,
                     'processorStatus' => $processorStatus,
                     'processorCode' => $processorCode,
                     'approvalCode' => $approvalCode,
                     'retrievalRef' => $retrievalRef,
                     'batchId' => $batchId,
-                    'customerUserId' => $customerUserId,
+                    'processorTransactionId' => $processorTransactionId,
                     'referencesJson' => $referencesJson,
+                    'linksJson' => $linksJson,
                     'fundingSource' => $fundingSourceJson,
                     'contextJson' => $contextJson,
+                    'processorOptions' => $processorOptionsJson,
+                    'processorResponse' => $processorResponseJson,
+                    'amountsJson' => $amountsJson,
                     'rawPayload' => $rawPayload,
                     'createdAtExt' => $createdAtExt,
                     'updatedAtExt' => $updatedAtExt,

--- a/database/migrations/20241112000000_recreate_transaction_table.sql
+++ b/database/migrations/20241112000000_recreate_transaction_table.sql
@@ -1,0 +1,68 @@
+DROP TABLE IF EXISTS transaction_receipt;
+DROP TABLE IF EXISTS transaction;
+
+CREATE TABLE transaction (
+    transaction_id VARCHAR(255) PRIMARY KEY,
+    business_id VARCHAR(255) NOT NULL,
+    store_id VARCHAR(255),
+    store_device_id VARCHAR(255),
+    employee_user_id BIGINT,
+    signature_required BOOLEAN,
+    signature_captured BOOLEAN,
+    pin_captured BOOLEAN,
+    adjusted BOOLEAN,
+    amounts_adjusted BOOLEAN,
+    auth_only BOOLEAN,
+    partially_approved BOOLEAN,
+    action_void BOOLEAN,
+    voided BOOLEAN,
+    settled BOOLEAN,
+    reversal_void BOOLEAN,
+    action VARCHAR(32),
+    status VARCHAR(32),
+    settlement_status VARCHAR(32),
+    transaction_instruction VARCHAR(64),
+    source VARCHAR(32),
+    source_app VARCHAR(255),
+    mcc VARCHAR(16),
+    customer_user_id BIGINT,
+    customer_language VARCHAR(16),
+    customer_opted_no_tip BOOLEAN,
+    txn_amount_minor BIGINT,
+    order_amount_minor BIGINT,
+    tip_amount_minor BIGINT,
+    cashback_amount_minor BIGINT,
+    currency VARCHAR(3),
+    approved_amount_minor BIGINT,
+    processor VARCHAR(64),
+    acquirer VARCHAR(64),
+    processor_status VARCHAR(64),
+    processor_code VARCHAR(32),
+    approval_code VARCHAR(32),
+    retrieval_ref VARCHAR(64),
+    batch_id VARCHAR(64),
+    processor_transaction_id VARCHAR(255),
+    references_json JSONB NOT NULL DEFAULT '[]',
+    links_json JSONB NOT NULL DEFAULT '[]',
+    funding_source JSONB NOT NULL DEFAULT '{}',
+    context_json JSONB NOT NULL DEFAULT '{}',
+    processor_options JSONB NOT NULL DEFAULT '{}',
+    processor_response JSONB NOT NULL DEFAULT '{}',
+    amounts_json JSONB NOT NULL DEFAULT '{}',
+    raw_payload JSONB NOT NULL DEFAULT '{}',
+    created_at_ext TIMESTAMPTZ,
+    updated_at_ext TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_tx_business_updated ON transaction (business_id, updated_at_ext);
+CREATE INDEX IF NOT EXISTS idx_tx_status ON transaction (status);
+CREATE INDEX IF NOT EXISTS idx_tx_action ON transaction (action);
+
+CREATE TABLE transaction_receipt (
+    transaction_id VARCHAR(255) PRIMARY KEY REFERENCES transaction(transaction_id) ON DELETE CASCADE,
+    html TEXT,
+    payload JSONB NOT NULL DEFAULT '{}',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);

--- a/database/migrations/20241115000000_alter_transaction_table_expand_columns.sql
+++ b/database/migrations/20241115000000_alter_transaction_table_expand_columns.sql
@@ -1,0 +1,41 @@
+BEGIN;
+
+ALTER TABLE transaction
+    ADD COLUMN IF NOT EXISTS store_device_id VARCHAR(255),
+    ADD COLUMN IF NOT EXISTS employee_user_id BIGINT,
+    ADD COLUMN IF NOT EXISTS signature_required BOOLEAN,
+    ADD COLUMN IF NOT EXISTS signature_captured BOOLEAN,
+    ADD COLUMN IF NOT EXISTS pin_captured BOOLEAN,
+    ADD COLUMN IF NOT EXISTS adjusted BOOLEAN,
+    ADD COLUMN IF NOT EXISTS amounts_adjusted BOOLEAN,
+    ADD COLUMN IF NOT EXISTS auth_only BOOLEAN,
+    ADD COLUMN IF NOT EXISTS action_void BOOLEAN,
+    ADD COLUMN IF NOT EXISTS voided BOOLEAN,
+    ADD COLUMN IF NOT EXISTS reversal_void BOOLEAN,
+    ADD COLUMN IF NOT EXISTS transaction_instruction VARCHAR(64),
+    ADD COLUMN IF NOT EXISTS source VARCHAR(32),
+    ADD COLUMN IF NOT EXISTS source_app VARCHAR(255),
+    ADD COLUMN IF NOT EXISTS mcc VARCHAR(16),
+    ADD COLUMN IF NOT EXISTS customer_language VARCHAR(16),
+    ADD COLUMN IF NOT EXISTS customer_opted_no_tip BOOLEAN,
+    ADD COLUMN IF NOT EXISTS approved_amount_minor BIGINT,
+    ADD COLUMN IF NOT EXISTS acquirer VARCHAR(64),
+    ADD COLUMN IF NOT EXISTS processor_transaction_id VARCHAR(255),
+    ADD COLUMN IF NOT EXISTS links_json JSONB NOT NULL DEFAULT '[]'::jsonb,
+    ADD COLUMN IF NOT EXISTS processor_options JSONB NOT NULL DEFAULT '{}'::jsonb,
+    ADD COLUMN IF NOT EXISTS processor_response JSONB NOT NULL DEFAULT '{}'::jsonb,
+    ADD COLUMN IF NOT EXISTS amounts_json JSONB NOT NULL DEFAULT '{}'::jsonb;
+
+ALTER TABLE transaction
+    DROP COLUMN IF EXISTS order_id,
+    DROP COLUMN IF EXISTS card_brand,
+    DROP COLUMN IF EXISTS last4,
+    DROP COLUMN IF EXISTS entry_mode;
+
+DROP INDEX IF EXISTS idx_tx_order;
+DROP INDEX IF EXISTS idx_tx_action_status;
+CREATE INDEX IF NOT EXISTS idx_tx_business_updated ON transaction (business_id, updated_at_ext);
+CREATE INDEX IF NOT EXISTS idx_tx_status ON transaction (status);
+CREATE INDEX IF NOT EXISTS idx_tx_action ON transaction (action);
+
+COMMIT;

--- a/tests/Services/TransactionServiceTest.php
+++ b/tests/Services/TransactionServiceTest.php
@@ -42,117 +42,119 @@ namespace Services {
         public function testUpsertNormalisesTransactionPayload(): void
         {
             $transactionData = [
-                'id' => 'd2ac85ec-c346-4dcf-9695-e626bdb6add7',
-                'businessId' => '3fb53611-061a-4464-8ca7-0b91ca7c98cf',
+                'id' => '29c5b96d-0180-1000-d4b4-c6fb481f142d',
                 'signatureRequired' => false,
                 'signatureCaptured' => false,
                 'pinCaptured' => false,
-                'adjusted' => false,
-                'amountsAdjusted' => false,
-                'authOnly' => false,
+                'adjusted' => true,
+                'amountsAdjusted' => true,
+                'authOnly' => true,
                 'partiallyApproved' => false,
                 'actionVoid' => false,
                 'voided' => false,
-                'settled' => true,
+                'settled' => false,
                 'reversalVoid' => false,
-                'paymentTokenUsed' => false,
-                'createdAt' => '2025-07-21T07:30:05Z',
-                'updatedAt' => '2025-07-22T06:41:27Z',
+                'createdAt' => '2022-04-14T20:31:06Z',
+                'updatedAt' => '2022-04-14T20:32:22Z',
                 'context' => [
                     'businessType' => 'TEST_MERCHANT',
-                    'transmissionAtLocal' => '2025-07-21T07:30:05Z',
-                    'employeeUserId' => 518295917,
-                    'storeDeviceId' => 'urn:tid:3b09adcb-716b-3d76-a5e8-ab3deb449b29',
-                    'sourceApp' => 'co.poynt.virtualterminal',
-                    'mcc' => '1520',
-                    'applicationId' => 'urn:aid:virtual-terminal',
+                    'transmissionAtLocal' => '2022-04-14T20:31:05Z',
+                    'employeeUserId' => 369299726,
+                    'storeDeviceId' => 'urn:tid:c1e269b9-5afe-379e-b28c-c63a3373f3af',
+                    'sourceApp' => 'co.poynt.posconnector',
+                    'mcc' => '5812',
+                    'transactionInstruction' => 'ONLINE_AUTH_REQUIRED',
                     'source' => 'INSTORE',
-                    'businessId' => '3fb53611-061a-4464-8ca7-0b91ca7c98cf',
-                    'storeId' => '194a72bf-5802-4354-8ab6-fb482780cef6',
-                    'channelId' => 'b3b1e892-b073-11ee-bbe7-02bda9370977',
+                    'businessId' => 'a3f24e9e-6764-42f2-bbcd-5541e7f3be38',
+                    'storeId' => '0ac7c74b-d88e-4bd8-8d6b-ddf8db6ec700',
                 ],
                 'fundingSource' => [
                     'debit' => false,
-                    'debitOverride' => false,
-                    'debitBin' => false,
                     'card' => [
                         'cardBrand' => [
                             'createdAt' => '2020-05-27T16:14:32Z',
-                            'scheme' => 'MASTERCARD',
-                            'displayName' => 'Mastercard',
-                            'id' => '8cd7082b-2cdd-4264-a4e3-57f78851ead3',
+                            'scheme' => 'VISA',
+                            'displayName' => 'Visa',
+                            'id' => 'c74ab71f-9024-4de0-910d-54c6a9c2bbc5',
                         ],
-                        'type' => 'MASTERCARD',
+                        'type' => 'VISA',
                         'source' => 'DIRECT',
                         'status' => 'ACTIVE',
+                        'expirationDate' => 31,
                         'expirationMonth' => 12,
-                        'expirationYear' => 2027,
-                        'id' => 684057658,
-                        'numberFirst6' => '222300',
-                        'numberLast4' => '3222',
-                        'numberMasked' => '222300******3222',
-                        'numberHashed' => 'FA20B7098A5C729CACAD608C549A6EEE5594865766B7D037ECE91C0BDAEF5D8C',
+                        'expirationYear' => 2023,
+                        'id' => 369442365,
+                        'numberFirst6' => '405413',
+                        'numberLast4' => '6357',
+                        'numberMasked' => '4054136357',
                         'cardHolderFirstName' => '',
                         'cardHolderLastName' => '',
-                        'cardHolderFullName' => '',
-                        'cardId' => '79f5ee85-166f-438e-b919-8385720a3c3d',
+                        'cardHolderFullName' => '/',
+                        'serviceCode' => '201',
+                        'cardId' => '885f6b75-5e8f-4933-a55d-cc53a8dda6e9',
                     ],
                     'entryDetails' => [
-                        'customerPresenceStatus' => 'VIRTUAL_TERMINAL_NOT_PRESENT',
-                        'entryMode' => 'KEYED',
+                        'customerPresenceStatus' => 'PRESENT',
+                        'entryMode' => 'CONTACTLESS_MAGSTRIPE',
                     ],
                     'type' => 'CREDIT_DEBIT',
-                    'verificationData' => [
-                        'cardHolderBillingAddress' => [
-                            'status' => 'ADDED',
-                            'createdAt' => '2025-07-21T07:30:05Z',
-                            'updatedAt' => '2025-07-21T07:30:05Z',
-                            'id' => 43644892,
-                            'line1' => '2298 Client Ave',
-                            'postalCode' => '95076',
-                            'countryCode' => 'US',
-                        ],
+                ],
+                'links' => [
+                    [
+                        'href' => '71241c6f-ff98-46b2-879f-1805596465ca',
+                        'rel' => 'CAPTURE',
+                        'method' => 'GET',
                     ],
                 ],
-                'customerUserId' => 692824955,
+                'references' => [
+                    [
+                        'id' => '',
+                        'customType' => 'externalReferenceId',
+                        'type' => 'CUSTOM',
+                    ],
+                    [
+                        'id' => '38caea72-3965-48af-9dfe-ab81145abe4e',
+                        'type' => 'POYNT_ORDER',
+                    ],
+                ],
+                'customerUserId' => 369458304,
                 'processorOptions' => [
-                    'processorToken' => '0',
+                    'scaIndicator' => 'supported',
                 ],
                 'processorResponse' => [
-                    'avsResult' => [
-                        'addressResult' => 'MATCH',
-                        'postalCodeResult' => 'MATCH',
-                        'actualResult' => 'Y',
-                    ],
-                    'cvResult' => 'MATCH',
-                    'approvedAmount' => 1000,
+                    'approvedAmount' => 2500,
                     'processor' => 'MOCK',
-                    'acquirer' => 'POYNT',
+                    'acquirer' => 'CHASE_PAYMENTECH',
                     'status' => 'Successful',
                     'statusCode' => '1',
                     'statusMessage' => 'Successful',
-                    'approvalCode' => '419763',
+                    'transactionId' => '29c5b96d-0180-1000-d4b4-c6fb481f142d',
+                    'approvalCode' => '219475',
                     'batchId' => '1',
-                    'retrievalRefNum' => 'd2ac85ec-c346-4dcf-9695-e626bdb6add7',
-                    'cvActualResult' => 'M',
+                    'retrievalRefNum' => '29c5b96d-0180-1000-d4b4-c6fb481f142d',
                 ],
-                'transactionNumber' => '5c2aeb14-8464-471e-9fcf-3c27d150c29e',
                 'notes' => '',
-                'settlementStatus' => 'SETTLED',
-                'action' => 'SALE',
+                'customerLanguage' => 'en',
+                'settlementStatus' => 'UNSETTLED',
+                'action' => 'AUTHORIZE',
                 'amounts' => [
                     'customerOptedNoTip' => false,
-                    'transactionAmount' => 1000,
-                    'orderAmount' => 1000,
-                    'tipAmount' => 0,
+                    'transactionAmount' => 7500,
+                    'orderAmount' => 2500,
+                    'tipAmount' => 5000,
                     'cashbackAmount' => 0,
                     'currency' => 'USD',
                 ],
                 'status' => 'CAPTURED',
             ];
 
-            $expectedFundingSource = Format::jsonObject($transactionData['fundingSource']);
             $expectedContext = Format::jsonObject($transactionData['context']);
+            $expectedFundingSource = Format::jsonObject($transactionData['fundingSource']);
+            $expectedLinks = Format::jsonArray($transactionData['links']);
+            $expectedReferences = Format::jsonArray($transactionData['references']);
+            $expectedProcessorOptions = Format::jsonObject($transactionData['processorOptions']);
+            $expectedProcessorResponse = Format::jsonObject($transactionData['processorResponse']);
+            $expectedAmountsJson = Format::jsonObject($transactionData['amounts']);
             $expectedRawPayload = Format::jsonObject($transactionData);
             $expectedCreatedAtExt = Format::optionalTimestamp($transactionData['createdAt']);
             $expectedUpdatedAtExt = Format::optionalTimestamp($transactionData['updatedAt']);
@@ -164,39 +166,64 @@ namespace Services {
                     $this->stringContains('INSERT INTO transaction'),
                     $this->callback(function (array $params) use (
                         $transactionData,
-                        $expectedFundingSource,
                         $expectedContext,
+                        $expectedFundingSource,
+                        $expectedLinks,
+                        $expectedReferences,
+                        $expectedProcessorOptions,
+                        $expectedProcessorResponse,
+                        $expectedAmountsJson,
                         $expectedRawPayload,
                         $expectedCreatedAtExt,
                         $expectedUpdatedAtExt
                     ): bool {
                         self::assertSame($transactionData['id'], $params['transactionId']);
-                        self::assertSame($transactionData['businessId'], $params['businessId']);
-                        self::assertSame('194a72bf-5802-4354-8ab6-fb482780cef6', $params['storeId']);
-                        self::assertNull($params['orderId']);
-                        self::assertSame('SALE', $params['action']);
-                        self::assertSame('CAPTURED', $params['status']);
-                        self::assertSame('SETTLED', $params['settlementStatus']);
-                        self::assertTrue($params['settled']);
+                        self::assertSame('a3f24e9e-6764-42f2-bbcd-5541e7f3be38', $params['businessId']);
+                        self::assertSame('0ac7c74b-d88e-4bd8-8d6b-ddf8db6ec700', $params['storeId']);
+                        self::assertSame('urn:tid:c1e269b9-5afe-379e-b28c-c63a3373f3af', $params['storeDeviceId']);
+                        self::assertSame(369299726, $params['employeeUserId']);
+                        self::assertFalse($params['signatureRequired']);
+                        self::assertFalse($params['signatureCaptured']);
+                        self::assertFalse($params['pinCaptured']);
+                        self::assertTrue($params['adjusted']);
+                        self::assertTrue($params['amountsAdjusted']);
+                        self::assertTrue($params['authOnly']);
                         self::assertFalse($params['partiallyApproved']);
-                        self::assertSame(1000, $params['txnAmountMinor']);
-                        self::assertSame(1000, $params['orderAmountMinor']);
-                        self::assertSame(0, $params['tipAmountMinor']);
+                        self::assertFalse($params['actionVoid']);
+                        self::assertFalse($params['voided']);
+                        self::assertFalse($params['settled']);
+                        self::assertFalse($params['reversalVoid']);
+                        self::assertSame('AUTHORIZE', $params['action']);
+                        self::assertSame('CAPTURED', $params['status']);
+                        self::assertSame('UNSETTLED', $params['settlementStatus']);
+                        self::assertSame('ONLINE_AUTH_REQUIRED', $params['transactionInstruction']);
+                        self::assertSame('INSTORE', $params['source']);
+                        self::assertSame('co.poynt.posconnector', $params['sourceApp']);
+                        self::assertSame('5812', $params['mcc']);
+                        self::assertSame(369458304, $params['customerUserId']);
+                        self::assertSame('en', $params['customerLanguage']);
+                        self::assertFalse($params['customerOptedNoTip']);
+                        self::assertSame(7500, $params['txnAmountMinor']);
+                        self::assertSame(2500, $params['orderAmountMinor']);
+                        self::assertSame(5000, $params['tipAmountMinor']);
                         self::assertSame(0, $params['cashbackAmountMinor']);
                         self::assertSame('USD', $params['currency']);
-                        self::assertSame('Mastercard', $params['cardBrand']);
-                        self::assertSame('3222', $params['last4']);
-                        self::assertSame('KEYED', $params['entryMode']);
+                        self::assertSame(2500, $params['approvedAmountMinor']);
                         self::assertSame('MOCK', $params['processor']);
+                        self::assertSame('CHASE_PAYMENTECH', $params['acquirer']);
                         self::assertSame('Successful', $params['processorStatus']);
                         self::assertSame('1', $params['processorCode']);
-                        self::assertSame('419763', $params['approvalCode']);
-                        self::assertSame('d2ac85ec-c346-4dcf-9695-e626bdb6add7', $params['retrievalRef']);
+                        self::assertSame('219475', $params['approvalCode']);
+                        self::assertSame('29c5b96d-0180-1000-d4b4-c6fb481f142d', $params['retrievalRef']);
                         self::assertSame('1', $params['batchId']);
-                        self::assertSame(692824955, $params['customerUserId']);
-                        self::assertSame('[]', $params['referencesJson']);
+                        self::assertSame('29c5b96d-0180-1000-d4b4-c6fb481f142d', $params['processorTransactionId']);
+                        self::assertSame($expectedReferences, $params['referencesJson']);
+                        self::assertSame($expectedLinks, $params['linksJson']);
                         self::assertSame($expectedFundingSource, $params['fundingSource']);
                         self::assertSame($expectedContext, $params['contextJson']);
+                        self::assertSame($expectedProcessorOptions, $params['processorOptions']);
+                        self::assertSame($expectedProcessorResponse, $params['processorResponse']);
+                        self::assertSame($expectedAmountsJson, $params['amountsJson']);
                         self::assertSame($expectedRawPayload, $params['rawPayload']);
                         self::assertSame($expectedCreatedAtExt, $params['createdAtExt']);
                         self::assertSame($expectedUpdatedAtExt, $params['updatedAtExt']);
@@ -210,7 +237,7 @@ namespace Services {
 
             $service = new TransactionService(
                 $this->context,
-                $transactionData['businessId'],
+                null,
                 $this->createMock(ClientInterface::class)
             );
 


### PR DESCRIPTION
## Summary
- add a guard migration that augments existing transaction tables with the new columns, json blobs, and indexes expected by the refactored transaction upsert
- drop obsolete legacy transaction columns and indexes so older databases align with the new schema

## Testing
- php -l app/Services/TransactionService.php
- php -l tests/Services/TransactionServiceTest.php

------
https://chatgpt.com/codex/tasks/task_e_6900cbd81a0483298c3f910b7de8886b