### PR TITLE
Handle nested order context fields

### DIFF
--- a/app/Services/OrderService.php
+++ b/app/Services/OrderService.php
@@ -73,19 +73,35 @@ class OrderService
      */
     public function upsert(array $orderData): bool
     {
-        if (!isset($orderData['id'], $orderData['businessId'])) {
+        $orderId = $orderData['id'] ?? null;
+        $businessId = $this->coalesceValue($orderData, [
+            ['businessId'],
+            ['context', 'businessId'],
+        ]);
+
+        if (!$orderId || !$businessId) {
             $this->context->getLog()->error(
                 'OrderService::upsert: missing required order fields (id or businessId)'
             );
             return false;
         }
 
-        $orderId = $orderData['id'];
-        $businessId = $orderData['businessId'];
-        $storeId = $orderData['storeId'] ?? null;
-        $status = $orderData['status'] ?? null;
-        $fulfillmentStatus = $orderData['fulfillmentStatus'] ?? null;
-        $transactionStatusSummary = $orderData['transactionStatusSummary'] ?? null;
+        $storeId = $this->coalesceValue($orderData, [
+            ['storeId'],
+            ['context', 'storeId'],
+        ]);
+        $status = $this->coalesceValue($orderData, [
+            ['status'],
+            ['statuses', 'status'],
+        ]);
+        $fulfillmentStatus = $this->coalesceValue($orderData, [
+            ['fulfillmentStatus'],
+            ['statuses', 'fulfillmentStatus'],
+        ]);
+        $transactionStatusSummary = $this->coalesceValue($orderData, [
+            ['transactionStatusSummary'],
+            ['statuses', 'transactionStatusSummary'],
+        ]);
 
         $currency = $this->coalesceValue($orderData, [
             ['currency'],
@@ -134,14 +150,25 @@ class OrderService
         ]);
 
         $customerUserId = Format::optionalInt($orderData['customerUserId'] ?? $orderData['customer']['userId'] ?? null);
-        $employeeUserId = Format::optionalInt($orderData['employeeUserId'] ?? null);
+        $employeeUserId = Format::optionalInt($this->coalesceValue($orderData, [
+            ['employeeUserId'],
+            ['context', 'employeeUserId'],
+        ]));
         $storeDeviceId = $this->coalesceValue($orderData, [
             ['storeDeviceId'],
             ['deviceId'],
             ['context', 'storeDeviceId'],
         ]);
-        $source = $orderData['source'] ?? null;
-        $sourceApp = $orderData['sourceApp'] ?? $orderData['sourceApplication'] ?? null;
+        $source = $this->coalesceValue($orderData, [
+            ['source'],
+            ['context', 'source'],
+        ]);
+        $sourceApp = $this->coalesceValue($orderData, [
+            ['sourceApp'],
+            ['sourceApplication'],
+            ['context', 'sourceApp'],
+            ['context', 'sourceApplication'],
+        ]);
 
         $taxExempted = Format::optionalBool($orderData['taxExempted'] ?? null);
         $valid = Format::optionalBool($orderData['valid'] ?? null);


### PR DESCRIPTION
## Summary
- update `OrderService::upsert` to source business and store identifiers from nested context payloads
- coalesce status, source, and employee metadata from both root and nested structures to handle varying order shapes

## Testing
- not run (vendor/phpunit not installed in environment)


------
https://chatgpt.com/codex/tasks/task_e_690212a1803c8329a309b6ded143ec4a