### PR TITLE
Add logging for fetchByBusinessId responses

### DIFF
--- a/app/Services/BusinessService.php
+++ b/app/Services/BusinessService.php
@@ -153,7 +153,18 @@ class BusinessService {
             return false;
         }
 
-        return [$business];
+        $payload = [$business];
+
+        $this->context->getLog()->info(
+            'BusinessService::fetchByBusinessId response',
+            [
+                'businessId' => $businessId,
+                'entity' => 'businesses',
+                'payload' => $payload,
+            ]
+        );
+
+        return $payload;
     }
 
     /**

--- a/app/Services/BusinessUserService.php
+++ b/app/Services/BusinessUserService.php
@@ -140,6 +140,17 @@ class BusinessUserService
             ]);
 
             $data = json_decode($response->getBody(), true);
+            if (is_array($data)) {
+                $this->context->getLog()->info(
+                    'BusinessUserService::fetchByBusinessId response',
+                    [
+                        'businessId' => $businessId,
+                        'entity' => 'businessUsers',
+                        'payload' => $data,
+                    ]
+                );
+            }
+
             return $data ?? false;
         } catch (GuzzleException $e) {
             $this->context->getLog()->error(

--- a/app/Services/CatalogService.php
+++ b/app/Services/CatalogService.php
@@ -139,6 +139,15 @@ class CatalogService
                 }
             }
 
+            $this->context->getLog()->info(
+                'CatalogService::fetchByBusinessId response',
+                [
+                    'businessId' => $businessId,
+                    'entity' => 'catalogs',
+                    'payload' => $catalogs,
+                ]
+            );
+
             return $catalogs;
         } catch (GuzzleException $e) {
             $this->context->getLog()->error(

--- a/app/Services/CategoryService.php
+++ b/app/Services/CategoryService.php
@@ -50,8 +50,18 @@ class CategoryService
             }
 
             $categories = $this->collectCategories($businessId, $accessToken, $catalogs);
+            $payload = array_values($categories);
 
-            return array_values($categories);
+            $this->context->getLog()->info(
+                'CategoryService::fetchByBusinessId response',
+                [
+                    'businessId' => $businessId,
+                    'entity' => 'categories',
+                    'payload' => $payload,
+                ]
+            );
+
+            return $payload;
         } catch (GuzzleException $e) {
             $this->context->getLog()->error('CategoryService::fetchByBusinessId: ' . $e->getMessage());
         }

--- a/app/Services/CustomerService.php
+++ b/app/Services/CustomerService.php
@@ -134,6 +134,17 @@ class CustomerService
             ]);
 
             $data = json_decode($response->getBody(), true);
+            if (is_array($data)) {
+                $this->context->getLog()->info(
+                    'CustomerService::fetchByBusinessId response',
+                    [
+                        'businessId' => $businessId,
+                        'entity' => 'customers',
+                        'payload' => $data,
+                    ]
+                );
+            }
+
             return $data ?? false;
         } catch (GuzzleException $e) {
             $this->context->getLog()->error(

--- a/app/Services/HookService.php
+++ b/app/Services/HookService.php
@@ -158,6 +158,15 @@ class HookService
                 }
             }
 
+            $this->context->getLog()->info(
+                'HookService::fetchByBusinessId response',
+                [
+                    'businessId' => $businessId,
+                    'entity' => 'hooks',
+                    'payload' => $hooks,
+                ]
+            );
+
             return $hooks;
         } catch (BadResponseException $e) {
             $response = $e->getResponse();
@@ -167,6 +176,15 @@ class HookService
                         'HookService::fetchByBusinessId: GET /hooks?businessId=%s returned 404, treating as no hooks',
                         $businessId
                     )
+                );
+
+                $this->context->getLog()->info(
+                    'HookService::fetchByBusinessId response',
+                    [
+                        'businessId' => $businessId,
+                        'entity' => 'hooks',
+                        'payload' => [],
+                    ]
                 );
 
                 return [];

--- a/app/Services/InventoryService.php
+++ b/app/Services/InventoryService.php
@@ -64,6 +64,15 @@ class InventoryService
             $items[] = $row;
         }
 
+        $this->context->getLog()->info(
+            'InventoryService::fetchByBusinessId response',
+            [
+                'businessId' => $businessId,
+                'entity' => 'inventory',
+                'payload' => $items,
+            ]
+        );
+
         return $items ?: false;
     }
 

--- a/app/Services/OrderService.php
+++ b/app/Services/OrderService.php
@@ -53,10 +53,34 @@ class OrderService
 
             $data = json_decode($response->getBody(), true);
             if (isset($data['orders']) && is_array($data['orders'])) {
-                return $data['orders'];
+                $payload = $data['orders'];
+
+                $this->context->getLog()->info(
+                    'OrderService::fetchByBusinessId response',
+                    [
+                        'businessId' => $businessId,
+                        'entity' => 'orders',
+                        'payload' => $payload,
+                    ]
+                );
+
+                return $payload;
             }
 
-            return is_array($data) ? $data : false;
+            if (is_array($data)) {
+                $this->context->getLog()->info(
+                    'OrderService::fetchByBusinessId response',
+                    [
+                        'businessId' => $businessId,
+                        'entity' => 'orders',
+                        'payload' => $data,
+                    ]
+                );
+
+                return $data;
+            }
+
+            return false;
         } catch (GuzzleException $e) {
             $this->context->getLog()->error(
                 sprintf('OrderService::fetchByBusinessId: %s', $e->getMessage())

--- a/app/Services/PaylinkService.php
+++ b/app/Services/PaylinkService.php
@@ -552,6 +552,15 @@ class PaylinkService
                 sprintf('PaylinkService::fetchByBusinessId: no stores found for business %s', $businessId)
             );
 
+            $this->context->getLog()->info(
+                'PaylinkService::fetchByBusinessId response',
+                [
+                    'businessId' => $businessId,
+                    'entity' => 'paylinks',
+                    'payload' => [],
+                ]
+            );
+
             return [];
         }
 
@@ -570,6 +579,15 @@ class PaylinkService
                 'all' => $this->requestPaylinkCollection($storeId, $accessToken, 'all'),
             ];
         }
+
+        $this->context->getLog()->info(
+            'PaylinkService::fetchByBusinessId response',
+            [
+                'businessId' => $businessId,
+                'entity' => 'paylinks',
+                'payload' => $results,
+            ]
+        );
 
         return $results;
     }

--- a/app/Services/ProductService.php
+++ b/app/Services/ProductService.php
@@ -208,6 +208,17 @@ class ProductService
             ]);
 
             $data = json_decode($response->getBody(), true);
+            if (is_array($data)) {
+                $this->context->getLog()->info(
+                    'ProductService::fetchByBusinessId response',
+                    [
+                        'businessId' => $businessId,
+                        'entity' => 'products',
+                        'payload' => $data,
+                    ]
+                );
+            }
+
             return $data ?? false;
         } catch (GuzzleException $e) {
             $this->context->getLog()->error(

--- a/app/Services/StoreService.php
+++ b/app/Services/StoreService.php
@@ -55,6 +55,15 @@ class StoreService
 
             $data = json_decode($response->getBody(), true);
             if (is_array($data)) {
+                $this->context->getLog()->info(
+                    'StoreService::fetchByBusinessId response',
+                    [
+                        'businessId' => $businessId,
+                        'entity' => 'stores',
+                        'payload' => $data,
+                    ]
+                );
+
                 return $data;
             }
         } catch (GuzzleException $e) {

--- a/app/Services/SubscriptionService.php
+++ b/app/Services/SubscriptionService.php
@@ -739,6 +739,17 @@ class SubscriptionService
 
         $subscriptions = $this->fetchSubscriptions($appToken, $businessId);
 
+        if (is_array($subscriptions)) {
+            $this->context->getLog()->info(
+                'SubscriptionService::fetchByBusinessId response',
+                [
+                    'businessId' => $businessId,
+                    'entity' => 'subscriptions',
+                    'payload' => $subscriptions,
+                ]
+            );
+        }
+
         return $subscriptions ?: false;
     }
 

--- a/app/Services/TaxService.php
+++ b/app/Services/TaxService.php
@@ -130,6 +130,17 @@ class TaxService
             ]);
 
             $data = json_decode($response->getBody(), true);
+            if (is_array($data)) {
+                $this->context->getLog()->info(
+                    'TaxService::fetchByBusinessId response',
+                    [
+                        'businessId' => $businessId,
+                        'entity' => 'taxes',
+                        'payload' => $data,
+                    ]
+                );
+            }
+
             return $data ?? false;
         } catch (GuzzleException $e) {
             $this->context->getLog()->error(

--- a/app/Services/TransactionService.php
+++ b/app/Services/TransactionService.php
@@ -61,7 +61,18 @@ class TransactionService
                 return false;
             }
 
-            return $data['transactions'];
+            $transactions = $data['transactions'];
+
+            $this->context->getLog()->info(
+                'TransactionService::fetchByBusinessId response',
+                [
+                    'businessId' => $businessId,
+                    'entity' => 'transactions',
+                    'payload' => $transactions,
+                ]
+            );
+
+            return $transactions;
         } catch (GuzzleException $e) {
             $this->context->getLog()->error(
                 sprintf('TransactionService::fetchByBusinessId: %s', $e->getMessage())


### PR DESCRIPTION
## Summary
- add info-level logging to each service's `fetchByBusinessId` method so the returned payloads are captured with business and entity context

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6902275f4410832985f763937e28cac2