### PR TITLE
Guard fetchByBusinessId logging in non-production environments

### DIFF
--- a/app/Services/BusinessService.php
+++ b/app/Services/BusinessService.php
@@ -3,6 +3,7 @@
 namespace App\Services;
 
 use App\Core\Context;
+use App\Services\Support\FetchResponseLogger;
 use App\Services\Support\PoyntDataFormatter as Format;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\GuzzleException;
@@ -153,7 +154,19 @@ class BusinessService {
             return false;
         }
 
-        return [$business];
+        $payload = [$business];
+
+        FetchResponseLogger::info(
+            $this->context->getLog(),
+            'BusinessService::fetchByBusinessId response',
+            [
+                'businessId' => $businessId,
+                'entity' => 'businesses',
+                'payload' => $payload,
+            ]
+        );
+
+        return $payload;
     }
 
     /**

--- a/app/Services/BusinessUserService.php
+++ b/app/Services/BusinessUserService.php
@@ -3,6 +3,7 @@
 namespace App\Services;
 
 use App\Core\Context;
+use App\Services\Support\FetchResponseLogger;
 use App\Services\Support\PoyntDataFormatter as Format;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\GuzzleException;
@@ -140,6 +141,18 @@ class BusinessUserService
             ]);
 
             $data = json_decode($response->getBody(), true);
+            if (is_array($data)) {
+                FetchResponseLogger::info(
+                    $this->context->getLog(),
+                    'BusinessUserService::fetchByBusinessId response',
+                    [
+                        'businessId' => $businessId,
+                        'entity' => 'businessUsers',
+                        'payload' => $data,
+                    ]
+                );
+            }
+
             return $data ?? false;
         } catch (GuzzleException $e) {
             $this->context->getLog()->error(

--- a/app/Services/CatalogService.php
+++ b/app/Services/CatalogService.php
@@ -3,6 +3,7 @@
 namespace App\Services;
 
 use App\Core\Context;
+use App\Services\Support\FetchResponseLogger;
 use App\Services\Support\PoyntDataFormatter as Format;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\GuzzleException;
@@ -138,6 +139,16 @@ class CatalogService
                     $catalog['products'] = $this->extractProducts($fullPayload);
                 }
             }
+
+            FetchResponseLogger::info(
+                $this->context->getLog(),
+                'CatalogService::fetchByBusinessId response',
+                [
+                    'businessId' => $businessId,
+                    'entity' => 'catalogs',
+                    'payload' => $catalogs,
+                ]
+            );
 
             return $catalogs;
         } catch (GuzzleException $e) {

--- a/app/Services/CategoryService.php
+++ b/app/Services/CategoryService.php
@@ -3,6 +3,7 @@
 namespace App\Services;
 
 use App\Core\Context;
+use App\Services\Support\FetchResponseLogger;
 use App\Services\Support\PoyntDataFormatter as Format;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\GuzzleException;
@@ -50,8 +51,19 @@ class CategoryService
             }
 
             $categories = $this->collectCategories($businessId, $accessToken, $catalogs);
+            $payload = array_values($categories);
 
-            return array_values($categories);
+            FetchResponseLogger::info(
+                $this->context->getLog(),
+                'CategoryService::fetchByBusinessId response',
+                [
+                    'businessId' => $businessId,
+                    'entity' => 'categories',
+                    'payload' => $payload,
+                ]
+            );
+
+            return $payload;
         } catch (GuzzleException $e) {
             $this->context->getLog()->error('CategoryService::fetchByBusinessId: ' . $e->getMessage());
         }

--- a/app/Services/CustomerService.php
+++ b/app/Services/CustomerService.php
@@ -3,6 +3,7 @@
 namespace App\Services;
 
 use App\Core\Context;
+use App\Services\Support\FetchResponseLogger;
 use App\Services\Support\PoyntDataFormatter as Format;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\GuzzleException;
@@ -134,6 +135,18 @@ class CustomerService
             ]);
 
             $data = json_decode($response->getBody(), true);
+            if (is_array($data)) {
+                FetchResponseLogger::info(
+                    $this->context->getLog(),
+                    'CustomerService::fetchByBusinessId response',
+                    [
+                        'businessId' => $businessId,
+                        'entity' => 'customers',
+                        'payload' => $data,
+                    ]
+                );
+            }
+
             return $data ?? false;
         } catch (GuzzleException $e) {
             $this->context->getLog()->error(

--- a/app/Services/HookService.php
+++ b/app/Services/HookService.php
@@ -3,6 +3,7 @@
 namespace App\Services;
 
 use App\Core\Context;
+use App\Services\Support\FetchResponseLogger;
 use App\Services\Support\PoyntDataFormatter as Format;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\BadResponseException;
@@ -158,6 +159,16 @@ class HookService
                 }
             }
 
+            FetchResponseLogger::info(
+                $this->context->getLog(),
+                'HookService::fetchByBusinessId response',
+                [
+                    'businessId' => $businessId,
+                    'entity' => 'hooks',
+                    'payload' => $hooks,
+                ]
+            );
+
             return $hooks;
         } catch (BadResponseException $e) {
             $response = $e->getResponse();
@@ -167,6 +178,16 @@ class HookService
                         'HookService::fetchByBusinessId: GET /hooks?businessId=%s returned 404, treating as no hooks',
                         $businessId
                     )
+                );
+
+                FetchResponseLogger::info(
+                    $this->context->getLog(),
+                    'HookService::fetchByBusinessId response',
+                    [
+                        'businessId' => $businessId,
+                        'entity' => 'hooks',
+                        'payload' => [],
+                    ]
                 );
 
                 return [];

--- a/app/Services/InventoryService.php
+++ b/app/Services/InventoryService.php
@@ -3,6 +3,7 @@
 namespace App\Services;
 
 use App\Core\Context;
+use App\Services\Support\FetchResponseLogger;
 use App\Services\Support\PoyntDataFormatter as Format;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\GuzzleException;
@@ -63,6 +64,16 @@ class InventoryService
             $row['__resourceType'] = 'variant';
             $items[] = $row;
         }
+
+        FetchResponseLogger::info(
+            $this->context->getLog(),
+            'InventoryService::fetchByBusinessId response',
+            [
+                'businessId' => $businessId,
+                'entity' => 'inventory',
+                'payload' => $items,
+            ]
+        );
 
         return $items ?: false;
     }

--- a/app/Services/OrderService.php
+++ b/app/Services/OrderService.php
@@ -3,6 +3,7 @@
 namespace App\Services;
 
 use App\Core\Context;
+use App\Services\Support\FetchResponseLogger;
 use App\Services\Support\PoyntDataFormatter as Format;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\GuzzleException;
@@ -53,10 +54,36 @@ class OrderService
 
             $data = json_decode($response->getBody(), true);
             if (isset($data['orders']) && is_array($data['orders'])) {
-                return $data['orders'];
+                $payload = $data['orders'];
+
+                FetchResponseLogger::info(
+                    $this->context->getLog(),
+                    'OrderService::fetchByBusinessId response',
+                    [
+                        'businessId' => $businessId,
+                        'entity' => 'orders',
+                        'payload' => $payload,
+                    ]
+                );
+
+                return $payload;
             }
 
-            return is_array($data) ? $data : false;
+            if (is_array($data)) {
+                FetchResponseLogger::info(
+                    $this->context->getLog(),
+                    'OrderService::fetchByBusinessId response',
+                    [
+                        'businessId' => $businessId,
+                        'entity' => 'orders',
+                        'payload' => $data,
+                    ]
+                );
+
+                return $data;
+            }
+
+            return false;
         } catch (GuzzleException $e) {
             $this->context->getLog()->error(
                 sprintf('OrderService::fetchByBusinessId: %s', $e->getMessage())

--- a/app/Services/PaylinkService.php
+++ b/app/Services/PaylinkService.php
@@ -3,6 +3,7 @@
 namespace App\Services;
 
 use App\Core\Context;
+use App\Services\Support\FetchResponseLogger;
 use App\Services\Support\PoyntDataFormatter as Format;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\BadResponseException;
@@ -552,6 +553,16 @@ class PaylinkService
                 sprintf('PaylinkService::fetchByBusinessId: no stores found for business %s', $businessId)
             );
 
+            FetchResponseLogger::info(
+                $this->context->getLog(),
+                'PaylinkService::fetchByBusinessId response',
+                [
+                    'businessId' => $businessId,
+                    'entity' => 'paylinks',
+                    'payload' => [],
+                ]
+            );
+
             return [];
         }
 
@@ -570,6 +581,16 @@ class PaylinkService
                 'all' => $this->requestPaylinkCollection($storeId, $accessToken, 'all'),
             ];
         }
+
+        FetchResponseLogger::info(
+            $this->context->getLog(),
+            'PaylinkService::fetchByBusinessId response',
+            [
+                'businessId' => $businessId,
+                'entity' => 'paylinks',
+                'payload' => $results,
+            ]
+        );
 
         return $results;
     }

--- a/app/Services/ProductService.php
+++ b/app/Services/ProductService.php
@@ -3,6 +3,7 @@
 namespace App\Services;
 
 use App\Core\Context;
+use App\Services\Support\FetchResponseLogger;
 use App\Services\Support\PoyntDataFormatter as Format;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\GuzzleException;
@@ -208,6 +209,18 @@ class ProductService
             ]);
 
             $data = json_decode($response->getBody(), true);
+            if (is_array($data)) {
+                FetchResponseLogger::info(
+                    $this->context->getLog(),
+                    'ProductService::fetchByBusinessId response',
+                    [
+                        'businessId' => $businessId,
+                        'entity' => 'products',
+                        'payload' => $data,
+                    ]
+                );
+            }
+
             return $data ?? false;
         } catch (GuzzleException $e) {
             $this->context->getLog()->error(

--- a/app/Services/StoreService.php
+++ b/app/Services/StoreService.php
@@ -3,6 +3,7 @@
 namespace App\Services;
 
 use App\Core\Context;
+use App\Services\Support\FetchResponseLogger;
 use App\Services\Support\PoyntDataFormatter as Format;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\GuzzleException;
@@ -55,6 +56,16 @@ class StoreService
 
             $data = json_decode($response->getBody(), true);
             if (is_array($data)) {
+                FetchResponseLogger::info(
+                    $this->context->getLog(),
+                    'StoreService::fetchByBusinessId response',
+                    [
+                        'businessId' => $businessId,
+                        'entity' => 'stores',
+                        'payload' => $data,
+                    ]
+                );
+
                 return $data;
             }
         } catch (GuzzleException $e) {

--- a/app/Services/SubscriptionService.php
+++ b/app/Services/SubscriptionService.php
@@ -5,6 +5,7 @@ namespace App\Services;
 use App\Config\ConfigApp;
 use App\Core\Context;
 use App\Core\Response;
+use App\Services\Support\FetchResponseLogger;
 use App\Services\Support\PoyntDataFormatter as Format;
 use DateInterval;
 //use DateMalformedIntervalStringException;
@@ -738,6 +739,18 @@ class SubscriptionService
         }
 
         $subscriptions = $this->fetchSubscriptions($appToken, $businessId);
+
+        if (is_array($subscriptions)) {
+            FetchResponseLogger::info(
+                $this->context->getLog(),
+                'SubscriptionService::fetchByBusinessId response',
+                [
+                    'businessId' => $businessId,
+                    'entity' => 'subscriptions',
+                    'payload' => $subscriptions,
+                ]
+            );
+        }
 
         return $subscriptions ?: false;
     }

--- a/app/Services/Support/FetchResponseLogger.php
+++ b/app/Services/Support/FetchResponseLogger.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Services\Support;
+
+use App\Config\ConfigApp;
+use Psr\Log\LoggerInterface;
+
+final class FetchResponseLogger
+{
+    private function __construct()
+    {
+    }
+
+    public static function info(LoggerInterface $logger, string $message, array $context = []): void
+    {
+        if (!self::shouldLogResponses()) {
+            return;
+        }
+
+        $logger->info($message, $context);
+    }
+
+    private static function shouldLogResponses(): bool
+    {
+        if (!class_exists(ConfigApp::class)) {
+            return false;
+        }
+
+        foreach ([
+            'logFetchByBusinessIdResponses',
+            'logFetchResponses',
+            'enableFetchLogging',
+            'isDevelopment',
+            'development',
+        ] as $property) {
+            if (property_exists(ConfigApp::class, $property)) {
+                return (bool) ConfigApp::${$property};
+            }
+        }
+
+        if (property_exists(ConfigApp::class, 'environment')) {
+            $environment = ConfigApp::$environment;
+            if (is_string($environment) && strtolower($environment) === 'development') {
+                return true;
+            }
+        }
+
+        $env = self::getEnv('APP_ENV');
+        if (is_string($env) && strtolower($env) === 'development') {
+            return true;
+        }
+
+        $flag = self::getEnv('POYNT_LOG_FETCH_RESPONSES');
+        if (is_string($flag)) {
+            return filter_var($flag, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) ?? false;
+        }
+
+        return false;
+    }
+
+    private static function getEnv(string $key): ?string
+    {
+        return $_ENV[$key] ?? $_SERVER[$key] ?? getenv($key) ?: null;
+    }
+}

--- a/app/Services/TaxService.php
+++ b/app/Services/TaxService.php
@@ -3,6 +3,7 @@
 namespace App\Services;
 
 use App\Core\Context;
+use App\Services\Support\FetchResponseLogger;
 use App\Services\Support\PoyntDataFormatter as Format;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\GuzzleException;
@@ -130,6 +131,18 @@ class TaxService
             ]);
 
             $data = json_decode($response->getBody(), true);
+            if (is_array($data)) {
+                FetchResponseLogger::info(
+                    $this->context->getLog(),
+                    'TaxService::fetchByBusinessId response',
+                    [
+                        'businessId' => $businessId,
+                        'entity' => 'taxes',
+                        'payload' => $data,
+                    ]
+                );
+            }
+
             return $data ?? false;
         } catch (GuzzleException $e) {
             $this->context->getLog()->error(

--- a/app/Services/TransactionService.php
+++ b/app/Services/TransactionService.php
@@ -3,6 +3,7 @@
 namespace App\Services;
 
 use App\Core\Context;
+use App\Services\Support\FetchResponseLogger;
 use App\Services\Support\PoyntDataFormatter as Format;
 use Doctrine\DBAL\ParameterType;
 use GuzzleHttp\ClientInterface;
@@ -61,7 +62,19 @@ class TransactionService
                 return false;
             }
 
-            return $data['transactions'];
+            $transactions = $data['transactions'];
+
+            FetchResponseLogger::info(
+                $this->context->getLog(),
+                'TransactionService::fetchByBusinessId response',
+                [
+                    'businessId' => $businessId,
+                    'entity' => 'transactions',
+                    'payload' => $transactions,
+                ]
+            );
+
+            return $transactions;
         } catch (GuzzleException $e) {
             $this->context->getLog()->error(
                 sprintf('TransactionService::fetchByBusinessId: %s', $e->getMessage())


### PR DESCRIPTION
## Summary
- add a shared FetchResponseLogger helper that only emits fetch logs when development flags or environment variables are set
- update each service fetchByBusinessId callsite to use the gated logger so payloads are not written in production

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6902275f4410832985f763937e28cac2