### PR TITLE
Ensure fetch responses are stored in log details

### DIFF
--- a/app/Services/Support/FetchResponseLogger.php
+++ b/app/Services/Support/FetchResponseLogger.php
@@ -17,7 +17,7 @@ final class FetchResponseLogger
             return;
         }
 
-        $logger->info($message, $context);
+        $logger->info($message, self::normaliseContext($context));
     }
 
     private static function shouldLogResponses(): bool
@@ -61,5 +61,47 @@ final class FetchResponseLogger
     private static function getEnv(string $key): ?string
     {
         return $_ENV[$key] ?? $_SERVER[$key] ?? getenv($key) ?: null;
+    }
+
+    /**
+     * Ensure all context payload is stored under the "details" key so it reaches the database layer.
+     */
+    private static function normaliseContext(array $context): array
+    {
+        $details = [];
+
+        if (array_key_exists('details', $context)) {
+            $providedDetails = $context['details'];
+
+            if (is_array($providedDetails)) {
+                $details = $providedDetails;
+            } elseif ($providedDetails !== null) {
+                $details = ['value' => $providedDetails];
+            }
+
+            unset($context['details']);
+        }
+
+        $allowedTopLevelKeys = array_flip([
+            'type',
+            'merchant',
+            'url',
+            'request_id',
+        ]);
+
+        $extraContext = array_diff_key($context, $allowedTopLevelKeys);
+        $context = array_intersect_key($context, $allowedTopLevelKeys);
+
+        if (!empty($extraContext)) {
+            $details = array_merge($extraContext, $details);
+        }
+
+        $context['details'] = $details;
+
+        if (!isset($context['type'])) {
+            $context['type'] = 'fetch_response';
+        }
+
+        return $context;
     }
 }

--- a/tests/Services/Support/FetchResponseLoggerTest.php
+++ b/tests/Services/Support/FetchResponseLoggerTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Config {
+    if (!class_exists(__NAMESPACE__ . '\\ConfigApp')) {
+        class ConfigApp
+        {
+            public static bool $logFetchResponses = true;
+        }
+    }
+}
+
+namespace Tests\Services\Support {
+
+    use App\Services\Support\FetchResponseLogger;
+    use PHPUnit\Framework\TestCase;
+    use Psr\Log\LoggerInterface;
+    use Psr\Log\LogLevel;
+
+    class FetchResponseLoggerTest extends TestCase
+    {
+        protected function setUp(): void
+        {
+            parent::setUp();
+            \App\Config\ConfigApp::$logFetchResponses = true;
+        }
+
+        public function testContextIsMovedIntoDetailsAndTypeDefaults(): void
+        {
+            $logger = new RecordingLogger();
+
+            FetchResponseLogger::info($logger, 'test message', [
+                'businessId' => 'biz-123',
+                'payload' => ['foo' => 'bar'],
+            ]);
+
+            self::assertCount(1, $logger->records);
+            $record = $logger->records[0];
+
+            self::assertSame(LogLevel::INFO, $record['level']);
+            self::assertSame('test message', $record['message']);
+            self::assertSame('fetch_response', $record['context']['type']);
+            self::assertSame([
+                'businessId' => 'biz-123',
+                'payload' => ['foo' => 'bar'],
+            ], $record['context']['details']);
+        }
+
+        public function testProvidedTypeAndDetailsAreRespected(): void
+        {
+            $logger = new RecordingLogger();
+
+            FetchResponseLogger::info($logger, 'custom message', [
+                'type' => 'custom_type',
+                'merchant' => 'merchant-42',
+                'details' => ['payload' => ['baz' => 'qux']],
+                'extra' => 'value',
+            ]);
+
+            self::assertCount(1, $logger->records);
+            $record = $logger->records[0];
+
+            self::assertSame('custom_type', $record['context']['type']);
+            self::assertSame('merchant-42', $record['context']['merchant']);
+            self::assertArrayNotHasKey('extra', $record['context']);
+            self::assertSame([
+                'extra' => 'value',
+                'payload' => ['baz' => 'qux'],
+            ], $record['context']['details']);
+        }
+    }
+
+    /**
+     * Minimal PSR-3 logger that records log invocations for assertions.
+     */
+    class RecordingLogger implements LoggerInterface
+    {
+        /** @var array<int, array{level:string,message:string,context:array}> */
+        public array $records = [];
+
+        public function emergency($message, array $context = []): void
+        {
+            $this->log(LogLevel::EMERGENCY, $message, $context);
+        }
+
+        public function alert($message, array $context = []): void
+        {
+            $this->log(LogLevel::ALERT, $message, $context);
+        }
+
+        public function critical($message, array $context = []): void
+        {
+            $this->log(LogLevel::CRITICAL, $message, $context);
+        }
+
+        public function error($message, array $context = []): void
+        {
+            $this->log(LogLevel::ERROR, $message, $context);
+        }
+
+        public function warning($message, array $context = []): void
+        {
+            $this->log(LogLevel::WARNING, $message, $context);
+        }
+
+        public function notice($message, array $context = []): void
+        {
+            $this->log(LogLevel::NOTICE, $message, $context);
+        }
+
+        public function info($message, array $context = []): void
+        {
+            $this->log(LogLevel::INFO, $message, $context);
+        }
+
+        public function debug($message, array $context = []): void
+        {
+            $this->log(LogLevel::DEBUG, $message, $context);
+        }
+
+        public function log($level, $message, array $context = []): void
+        {
+            $this->records[] = [
+                'level' => $level,
+                'message' => $message,
+                'context' => $context,
+            ];
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- normalise fetch response logging context so payloads land in the database details column
- default response log entries to the fetch_response type while keeping existing metadata intact
- add unit coverage for the logging helper to lock behaviour in place

## Testing
- `composer install` *(fails: requires GitHub credentials in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_69023155f17c83298c6b529978ecd66b