### PR TITLE
Fix fetch response logging flag evaluation

### DIFF
--- a/app/Services/Support/FetchResponseLogger.php
+++ b/app/Services/Support/FetchResponseLogger.php
@@ -33,8 +33,12 @@ final class FetchResponseLogger
             'isDevelopment',
             'development',
         ] as $property) {
-            if (property_exists(ConfigApp::class, $property)) {
-                return (bool) ConfigApp::${$property};
+            if (!property_exists(ConfigApp::class, $property)) {
+                continue;
+            }
+
+            if ((bool) ConfigApp::${$property}) {
+                return true;
             }
         }
 

--- a/tests/Services/Support/FetchResponseLoggerTest.php
+++ b/tests/Services/Support/FetchResponseLoggerTest.php
@@ -6,6 +6,7 @@ namespace App\Config {
     if (!class_exists(__NAMESPACE__ . '\\ConfigApp')) {
         class ConfigApp
         {
+            public static bool $logFetchByBusinessIdResponses = false;
             public static bool $logFetchResponses = true;
         }
     }
@@ -23,7 +24,22 @@ namespace Tests\Services\Support {
         protected function setUp(): void
         {
             parent::setUp();
+            \App\Config\ConfigApp::$logFetchByBusinessIdResponses = false;
             \App\Config\ConfigApp::$logFetchResponses = true;
+        }
+
+        public function testLoggingEnabledWhenAnyConfigFlagIsTrue(): void
+        {
+            \App\Config\ConfigApp::$logFetchByBusinessIdResponses = true;
+            \App\Config\ConfigApp::$logFetchResponses = false;
+
+            $logger = new RecordingLogger();
+
+            FetchResponseLogger::info($logger, 'enabled message');
+
+            self::assertCount(1, $logger->records);
+            $record = $logger->records[0];
+            self::assertSame('enabled message', $record['message']);
         }
 
         public function testContextIsMovedIntoDetailsAndTypeDefaults(): void


### PR DESCRIPTION
## Summary
- ensure `FetchResponseLogger` only enables response logging when a configuration flag is truthy instead of short-circuiting on the first defined flag
- extend the logger test stub to cover multiple configuration flags and verify logging remains enabled when any flag is true

## Testing
- Not run (composer install requires a GitHub token to download dependencies)


------
https://chatgpt.com/codex/tasks/task_e_690234af96588329aa7fbf49fb536d70