### PR TITLE
Ensure paylink base schema includes URL fields

### DIFF
--- a/SQL/poynt-v2.sql
+++ b/SQL/poynt-v2.sql
@@ -551,13 +551,19 @@ ALTER TABLE tax
 CREATE TABLE paylink (
   paylink_id      VARCHAR(255) PRIMARY KEY,
   business_id     VARCHAR(255) NOT NULL,
+  url             TEXT,
+  vanity_url      TEXT,
   domain          VARCHAR(255),
+  title           TEXT,
+  description     TEXT,
   status          VARCHAR(32),
   amount_minor    BIGINT,
   currency        VARCHAR(3),
   metadata        JSONB NOT NULL DEFAULT '{}',
+  expires_at_ext  TIMESTAMPTZ,
   created_at_ext  TIMESTAMPTZ,
   updated_at_ext  TIMESTAMPTZ,
+  raw_payload     JSONB NOT NULL DEFAULT '{}',
   created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );

--- a/database/migrations/20241010000000_create_core_entities.sql
+++ b/database/migrations/20241010000000_create_core_entities.sql
@@ -262,13 +262,19 @@ CREATE INDEX IF NOT EXISTS idx_tax_business ON tax (business_id, active);
 CREATE TABLE IF NOT EXISTS paylink (
     paylink_id VARCHAR(255) PRIMARY KEY,
     business_id VARCHAR(255) NOT NULL,
+    url TEXT,
+    vanity_url TEXT,
     domain VARCHAR(255),
+    title TEXT,
+    description TEXT,
     status VARCHAR(32),
     amount_minor BIGINT,
     currency VARCHAR(3),
     metadata JSONB NOT NULL DEFAULT '{}',
+    expires_at_ext TIMESTAMPTZ,
     created_at_ext TIMESTAMPTZ,
     updated_at_ext TIMESTAMPTZ,
+    raw_payload JSONB NOT NULL DEFAULT '{}',
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );


### PR DESCRIPTION
## Summary
- add the URL, vanity URL, title, description, expiration, and raw payload columns to the base paylink migration so new databases match the runtime expectations
- update the reference SQL schema to include the same columns for parity with the migration

## Testing
- not run (schema-only change)


------
https://chatgpt.com/codex/tasks/task_e_6903670a768c8329a86db54b5d40c144