### PR TITLE
Update order item timestamps in poynt v2 schema

### DIFF
--- a/SQL/poynt-v2.sql
+++ b/SQL/poynt-v2.sql
@@ -218,6 +218,8 @@ CREATE TABLE order_item (
   raw_payload      JSONB NOT NULL DEFAULT '{}',
   created_at_ext   TIMESTAMPTZ,
   updated_at_ext   TIMESTAMPTZ,
+  created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   PRIMARY KEY (order_id, order_item_id)
 );
 CREATE INDEX idx_order_item_product ON order_item(product_id);

--- a/database/migrations/20241123000000_alter_order_item_add_timestamps.sql
+++ b/database/migrations/20241123000000_alter_order_item_add_timestamps.sql
@@ -1,0 +1,25 @@
+ALTER TABLE order_item
+    ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+
+ALTER TABLE order_item
+    ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+
+ALTER TABLE order_item
+    ADD COLUMN IF NOT EXISTS created_at_ext TIMESTAMPTZ;
+
+ALTER TABLE order_item
+    ADD COLUMN IF NOT EXISTS updated_at_ext TIMESTAMPTZ;
+
+UPDATE order_item
+SET created_at = NOW()
+WHERE created_at IS NULL;
+
+UPDATE order_item
+SET updated_at = NOW()
+WHERE updated_at IS NULL;
+
+ALTER TABLE order_item
+    ALTER COLUMN created_at SET DEFAULT NOW(),
+    ALTER COLUMN created_at SET NOT NULL,
+    ALTER COLUMN updated_at SET DEFAULT NOW(),
+    ALTER COLUMN updated_at SET NOT NULL;


### PR DESCRIPTION
## Summary
- add created_at and updated_at columns with defaults to the order_item table definition in the poynt-v2 schema to match the migration

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6903717fdb0083299df595fda5c31330