### PR TITLE
Handle paginated Poynt fetches

### DIFF
--- a/app/Services/OrderService.php
+++ b/app/Services/OrderService.php
@@ -4,6 +4,7 @@ namespace App\Services;
 
 use App\Core\Context;
 use App\Services\Support\FetchResponseLogger;
+use App\Services\Support\PaginatedRequest;
 use App\Services\Support\PoyntDataFormatter as Format;
 use Doctrine\DBAL\ParameterType;
 use GuzzleHttp\ClientInterface;
@@ -47,13 +48,22 @@ class OrderService
         }
 
         try {
-            $response = $this->httpClient->get(self::POYNT_ENDPOINT . '/' . $businessId . '/orders', [
+            $url = self::POYNT_ENDPOINT . '/' . $businessId . '/orders';
+            $requestOptions = [
                 'headers' => [
                     'Authorization' => 'Bearer ' . $accessToken,
                 ],
-            ]);
+            ];
+
+            $response = $this->httpClient->get($url, $requestOptions);
 
             $data = json_decode($response->getBody(), true);
+            if (!is_array($data)) {
+                return false;
+            }
+
+            $data = PaginatedRequest::collect($this->httpClient, $data, $url, $requestOptions, 'orders');
+
             if (isset($data['orders']) && is_array($data['orders'])) {
                 $payload = $data['orders'];
 
@@ -70,21 +80,17 @@ class OrderService
                 return $payload;
             }
 
-            if (is_array($data)) {
-                FetchResponseLogger::info(
-                    $this->context->getLog(),
-                    'OrderService::fetchByBusinessId response',
-                    [
-                        'businessId' => $businessId,
-                        'entity' => 'orders',
-                        'payload' => $data,
-                    ]
-                );
+            FetchResponseLogger::info(
+                $this->context->getLog(),
+                'OrderService::fetchByBusinessId response',
+                [
+                    'businessId' => $businessId,
+                    'entity' => 'orders',
+                    'payload' => $data,
+                ]
+            );
 
-                return $data;
-            }
-
-            return false;
+            return $data;
         } catch (GuzzleException $e) {
             $this->context->getLog()->error(
                 sprintf('OrderService::fetchByBusinessId: %s', $e->getMessage())

--- a/app/Services/ProductService.php
+++ b/app/Services/ProductService.php
@@ -4,6 +4,7 @@ namespace App\Services;
 
 use App\Core\Context;
 use App\Services\Support\FetchResponseLogger;
+use App\Services\Support\PaginatedRequest;
 use App\Services\Support\PoyntDataFormatter as Format;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\GuzzleException;
@@ -202,26 +203,33 @@ class ProductService
         $accessToken = $tokenService->getMerchantToken($businessId);
 
         try {
-            $response = $this->httpClient->get(self::POYNT_ENDPOINT . '/' . $businessId . '/products', [
+            $url = self::POYNT_ENDPOINT . '/' . $businessId . '/products';
+            $requestOptions = [
                 'headers' => [
                     'Authorization' => 'Bearer ' . $accessToken,
                 ],
-            ]);
+            ];
+
+            $response = $this->httpClient->get($url, $requestOptions);
 
             $data = json_decode($response->getBody(), true);
-            if (is_array($data)) {
-                FetchResponseLogger::info(
-                    $this->context->getLog(),
-                    'ProductService::fetchByBusinessId response',
-                    [
-                        'businessId' => $businessId,
-                        'entity' => 'products',
-                        'payload' => $data,
-                    ]
-                );
+            if (!is_array($data)) {
+                return false;
             }
 
-            return $data ?? false;
+            $data = PaginatedRequest::collect($this->httpClient, $data, $url, $requestOptions, 'products');
+
+            FetchResponseLogger::info(
+                $this->context->getLog(),
+                'ProductService::fetchByBusinessId response',
+                [
+                    'businessId' => $businessId,
+                    'entity' => 'products',
+                    'payload' => $data,
+                ]
+            );
+
+            return $data;
         } catch (GuzzleException $e) {
             $this->context->getLog()->error(
                 'ProductService::fetchByBusinessId: ' . $e->getMessage()

--- a/app/Services/Support/PaginatedRequest.php
+++ b/app/Services/Support/PaginatedRequest.php
@@ -1,0 +1,218 @@
+<?php
+
+namespace App\Services\Support;
+
+use GuzzleHttp\ClientInterface;
+
+final class PaginatedRequest
+{
+    private function __construct()
+    {
+    }
+
+    /**
+     * Ensure the entity list in the provided payload includes all pages when pagination is enabled.
+     *
+     * @param ClientInterface $httpClient
+     * @param array $initialData
+     * @param string $initialUrl
+     * @param array $options
+     * @param string $entityKey
+     * @return array
+     */
+    public static function collect(
+        ClientInterface $httpClient,
+        array $initialData,
+        string $initialUrl,
+        array $options,
+        string $entityKey
+    ): array {
+        $items = [];
+        if (isset($initialData[$entityKey]) && is_array($initialData[$entityKey])) {
+            $items = $initialData[$entityKey];
+        }
+
+        $totalCount = self::extractCount($initialData);
+        if ($totalCount === null || $totalCount <= count($items)) {
+            return $initialData;
+        }
+
+        $origin = self::buildOrigin($initialUrl);
+        $visited = [];
+        $nextUrl = self::extractNextUrl($initialData, $origin);
+
+        while ($nextUrl !== null) {
+            if (isset($visited[$nextUrl])) {
+                break;
+            }
+            $visited[$nextUrl] = true;
+
+            $pageResponse = $httpClient->get($nextUrl, $options);
+            $pageData = json_decode((string) $pageResponse->getBody(), true);
+            if (!is_array($pageData)) {
+                break;
+            }
+
+            $pageItems = $pageData[$entityKey] ?? [];
+            if (is_array($pageItems) && $pageItems !== []) {
+                $items = array_merge($items, $pageItems);
+            }
+
+            $pageCount = self::extractCount($pageData);
+            if ($pageCount !== null) {
+                $totalCount = max($totalCount, $pageCount);
+            }
+
+            if ($totalCount !== null && count($items) >= $totalCount) {
+                break;
+            }
+
+            $nextUrl = self::extractNextUrl($pageData, $origin);
+        }
+
+        $initialData[$entityKey] = $items;
+        if ($totalCount !== null) {
+            $initialData['count'] = $totalCount;
+        }
+
+        return $initialData;
+    }
+
+    private static function extractCount(array $data): ?int
+    {
+        if (!array_key_exists('count', $data)) {
+            return null;
+        }
+
+        $count = $data['count'];
+        if (is_int($count)) {
+            return $count;
+        }
+
+        if (is_numeric($count)) {
+            return (int) $count;
+        }
+
+        return null;
+    }
+
+    private static function extractNextUrl(array $data, string $origin): ?string
+    {
+        foreach (self::normaliseLinks($data) as $link) {
+            if (!is_array($link)) {
+                continue;
+            }
+
+            $rel = $link['rel'] ?? $link['type'] ?? null;
+            if (!is_string($rel) || strtolower($rel) !== 'next') {
+                continue;
+            }
+
+            $href = $link['href'] ?? $link['uri'] ?? $link['url'] ?? null;
+            if (!is_string($href) || $href === '') {
+                continue;
+            }
+
+            $href = trim($href);
+            if (parse_url($href, PHP_URL_SCHEME) === null && $origin !== '') {
+                $href = rtrim($origin, '/') . '/' . ltrim($href, '/');
+            }
+
+            return $href;
+        }
+
+        return null;
+    }
+
+    private static function normaliseLinks(array $data): array
+    {
+        $links = [];
+
+        foreach (['links', 'link'] as $key) {
+            if (!array_key_exists($key, $data)) {
+                continue;
+            }
+
+            $value = $data[$key];
+            $links = array_merge($links, self::parseLinkValue($value));
+        }
+
+        return $links;
+    }
+
+    /**
+     * @param mixed $value
+     * @return array<int, array<string, mixed>>
+     */
+    private static function parseLinkValue($value): array
+    {
+        $links = [];
+
+        if (is_array($value)) {
+            if (self::isAssoc($value) && self::looksLikeSingleLink($value)) {
+                $links[] = $value;
+                return $links;
+            }
+
+            if (self::isAssoc($value) && !self::looksLikeSingleLink($value)) {
+                foreach ($value as $rel => $linkValue) {
+                    if (is_array($linkValue)) {
+                        $link = $linkValue;
+                        if (!isset($link['rel']) && is_string($rel)) {
+                            $link['rel'] = $rel;
+                        }
+                        $links[] = $link;
+                    } elseif (is_string($linkValue)) {
+                        $links[] = [
+                            'rel' => is_string($rel) ? $rel : 'next',
+                            'href' => $linkValue,
+                        ];
+                    }
+                }
+                return $links;
+            }
+
+            foreach ($value as $link) {
+                if (is_array($link)) {
+                    $links[] = $link;
+                }
+            }
+
+            return $links;
+        }
+
+        if (is_string($value) && $value !== '') {
+            $links[] = [
+                'rel' => 'next',
+                'href' => $value,
+            ];
+        }
+
+        return $links;
+    }
+
+    private static function looksLikeSingleLink(array $value): bool
+    {
+        return array_key_exists('rel', $value) || array_key_exists('href', $value) || array_key_exists('uri', $value);
+    }
+
+    private static function isAssoc(array $value): bool
+    {
+        return array_keys($value) !== range(0, count($value) - 1);
+    }
+
+    private static function buildOrigin(string $url): string
+    {
+        $parts = parse_url($url);
+        if ($parts === false || !isset($parts['scheme'], $parts['host'])) {
+            return '';
+        }
+
+        $origin = $parts['scheme'] . '://' . $parts['host'];
+        if (isset($parts['port'])) {
+            $origin .= ':' . $parts['port'];
+        }
+
+        return $origin;
+    }
+}

--- a/app/Services/TransactionService.php
+++ b/app/Services/TransactionService.php
@@ -4,6 +4,7 @@ namespace App\Services;
 
 use App\Core\Context;
 use App\Services\Support\FetchResponseLogger;
+use App\Services\Support\PaginatedRequest;
 use App\Services\Support\PoyntDataFormatter as Format;
 use Doctrine\DBAL\ParameterType;
 use GuzzleHttp\ClientInterface;
@@ -51,17 +52,20 @@ class TransactionService
 
         try {
             $url = self::POYNT_ENDPOINT . '/' . $businessId . '/transactions';
-            $response = $this->httpClient->get($url, [
+            $requestOptions = [
                 'headers' => [
                     'Authorization' => 'Bearer ' . $accessToken,
                 ],
-            ]);
+            ];
+
+            $response = $this->httpClient->get($url, $requestOptions);
 
             $data = json_decode($response->getBody(), true);
             if (!is_array($data) || !isset($data['transactions']) || !is_array($data['transactions'])) {
                 return false;
             }
 
+            $data = PaginatedRequest::collect($this->httpClient, $data, $url, $requestOptions, 'transactions');
             $transactions = $data['transactions'];
 
             FetchResponseLogger::info(


### PR DESCRIPTION
## Summary
- add a shared helper to follow pagination links when the API returns partial datasets
- update product, order, and transaction fetch routines to collect every page before logging or returning data
- keep responses consistent by returning the aggregated payloads after pagination is resolved

## Testing
- php -l app/Services/Support/PaginatedRequest.php
- php -l app/Services/ProductService.php
- php -l app/Services/OrderService.php
- php -l app/Services/TransactionService.php

------
https://chatgpt.com/codex/tasks/task_e_6903762ddab48329b76a09ef5861d251