### PR TITLE
Fix formatValue recursion in sanity check view

### DIFF
--- a/app/Views/sanity-check.php
+++ b/app/Views/sanity-check.php
@@ -9,7 +9,7 @@ $escape = static function (mixed $value): string {
     return htmlspecialchars((string) $value, ENT_QUOTES, 'UTF-8');
 };
 
-$formatValue = static function (mixed $value) use ($escape): string {
+$formatValue = static function (mixed $value) use (&$formatValue, $escape): string {
     if ($value === null) {
         return '<span class="muted">null</span>';
     }


### PR DESCRIPTION
## Summary
- ensure the sanity check view's value formatter can recurse by capturing itself by reference

## Testing
- php -l app/Views/sanity-check.php

------
https://chatgpt.com/codex/tasks/task_e_69039ce314548329be8318c64ae949c6