### PR TITLE
Restore business purge helpers

### DIFF
--- a/app/Services/CallbackService.php
+++ b/app/Services/CallbackService.php
@@ -6,6 +6,8 @@ use App\Core\Context;
 use App\Core\Response;
 use App\Modules\OAuth\PlatformRegistry;
 use App\Modules\OAuth\OAuthHandlerInterface;
+use DateTime;
+use DateTimeInterface;
 use RuntimeException;
 use Throwable;
 
@@ -700,7 +702,10 @@ class CallbackService
         array $appTokenPayload,
         array $merchantTokenPayload
     ): bool {
-        $appAccessToken = $this->extractAccessToken($appTokenPayload);
+        $normalizedAppToken = $this->normalizeTokenPayload($appTokenPayload);
+        $normalizedMerchantToken = $this->normalizeTokenPayload($merchantTokenPayload);
+
+        $appAccessToken = $this->extractAccessToken($normalizedAppToken);
         if ($appAccessToken === null) {
             $this->context->getLog()->error(
                 sprintf(
@@ -712,11 +717,33 @@ class CallbackService
             return false;
         }
 
-        $merchantAccessToken = $this->extractAccessToken($merchantTokenPayload);
+        if (!isset($normalizedAppToken['refreshToken']) || !isset($normalizedAppToken['expiresIn'])) {
+            $this->context->getLog()->error(
+                sprintf(
+                    'CallbackService::purgeAndReinstall aborted for business %s: incomplete app token payload.',
+                    $businessId
+                )
+            );
+
+            return false;
+        }
+
+        $merchantAccessToken = $this->extractAccessToken($normalizedMerchantToken);
         if ($merchantAccessToken === null) {
             $this->context->getLog()->error(
                 sprintf(
                     'CallbackService::purgeAndReinstall aborted for business %s: missing accessToken in merchant token payload.',
+                    $businessId
+                )
+            );
+
+            return false;
+        }
+
+        if (!isset($normalizedMerchantToken['refreshToken']) || !isset($normalizedMerchantToken['expiresIn'])) {
+            $this->context->getLog()->error(
+                sprintf(
+                    'CallbackService::purgeAndReinstall aborted for business %s: incomplete merchant token payload.',
                     $businessId
                 )
             );
@@ -730,8 +757,8 @@ class CallbackService
 
         try {
             $tokenService = $this->serviceFactory->token();
-            $tokenService->saveAppToken($businessId, $appTokenPayload);
-            $tokenService->saveMerchantToken($businessId, $merchantTokenPayload);
+            $tokenService->saveAppToken($businessId, $normalizedAppToken);
+            $tokenService->saveMerchantToken($businessId, $normalizedMerchantToken);
         } catch (Throwable $e) {
             $this->context->getLog()->error(
                 sprintf(
@@ -748,11 +775,64 @@ class CallbackService
         return $this->runBusinessWorkflow(
             $businessId,
             $storeId,
-            $appTokenPayload,
-            $merchantTokenPayload,
+            $normalizedAppToken,
+            $normalizedMerchantToken,
             null,
             null
         );
+    }
+
+    /**
+     * Ensure token payloads contain camelCase keys expected by TokenService.
+     */
+    private function normalizeTokenPayload(array $token): array
+    {
+        $normalized = $token;
+
+        if (!isset($normalized['accessToken']) && isset($token['access_token'])) {
+            $normalized['accessToken'] = $token['access_token'];
+        }
+
+        if (!isset($normalized['refreshToken']) && isset($token['refresh_token'])) {
+            $normalized['refreshToken'] = $token['refresh_token'];
+        }
+
+        if (!isset($normalized['expiresIn']) && isset($token['expires_in'])) {
+            $normalized['expiresIn'] = $token['expires_in'];
+        }
+
+        if (!isset($normalized['expiresIn'])) {
+            foreach (['expiresAt', 'expires_at'] as $key) {
+                if (!array_key_exists($key, $token)) {
+                    continue;
+                }
+
+                $dateTime = $this->coerceExpiresAtToDateTime($token[$key]);
+                if ($dateTime !== null) {
+                    $normalized['expiresIn'] = $dateTime;
+                    break;
+                }
+            }
+        }
+
+        return $normalized;
+    }
+
+    private function coerceExpiresAtToDateTime(mixed $value): ?DateTime
+    {
+        if ($value instanceof DateTimeInterface) {
+            return DateTime::createFromInterface($value);
+        }
+
+        if (is_string($value) && trim($value) !== '') {
+            try {
+                return new DateTime($value);
+            } catch (Throwable $e) {
+                return null;
+            }
+        }
+
+        return null;
     }
 
     public function purgeBusinessInstallation(string $businessId, bool $preserveTokens = true): bool

--- a/app/Services/CallbackService.php
+++ b/app/Services/CallbackService.php
@@ -694,6 +694,160 @@ class CallbackService
         return null;
     }
 
+    public function purgeAndReinstall(
+        string $businessId,
+        ?string $storeId,
+        array $appTokenPayload,
+        array $merchantTokenPayload
+    ): bool {
+        $appAccessToken = $this->extractAccessToken($appTokenPayload);
+        if ($appAccessToken === null) {
+            $this->context->getLog()->error(
+                sprintf(
+                    'CallbackService::purgeAndReinstall aborted for business %s: missing accessToken in app token payload.',
+                    $businessId
+                )
+            );
+
+            return false;
+        }
+
+        $merchantAccessToken = $this->extractAccessToken($merchantTokenPayload);
+        if ($merchantAccessToken === null) {
+            $this->context->getLog()->error(
+                sprintf(
+                    'CallbackService::purgeAndReinstall aborted for business %s: missing accessToken in merchant token payload.',
+                    $businessId
+                )
+            );
+
+            return false;
+        }
+
+        if (!$this->purgeBusinessInstallation($businessId, false)) {
+            return false;
+        }
+
+        try {
+            $tokenService = $this->serviceFactory->token();
+            $tokenService->saveAppToken($businessId, $appTokenPayload);
+            $tokenService->saveMerchantToken($businessId, $merchantTokenPayload);
+        } catch (Throwable $e) {
+            $this->context->getLog()->error(
+                sprintf(
+                    'CallbackService::purgeAndReinstall failed to persist tokens for business %s: %s',
+                    $businessId,
+                    $e->getMessage()
+                ),
+                ['exception' => $e]
+            );
+
+            return false;
+        }
+
+        return $this->runBusinessWorkflow(
+            $businessId,
+            $storeId,
+            $appTokenPayload,
+            $merchantTokenPayload,
+            null,
+            null
+        );
+    }
+
+    public function purgeBusinessInstallation(string $businessId, bool $preserveTokens = true): bool
+    {
+        $this->context->getLog()->info(
+            sprintf('CallbackService::purgeBusinessInstallation starting for business %s.', $businessId)
+        );
+
+        $conn = $this->context->getConn();
+        $transactionStarted = false;
+
+        $deleteStatements = [
+            'DELETE FROM hook_delivery WHERE business_id = :biz',
+            'DELETE FROM hook WHERE business_id = :biz',
+            'DELETE FROM paylink_link WHERE business_id = :biz',
+            'DELETE FROM paylink_payment WHERE business_id = :biz',
+            'DELETE FROM paylink_item WHERE business_id = :biz',
+            'DELETE FROM paylink WHERE business_id = :biz',
+            'DELETE FROM order_item USING "order" WHERE order_item.order_id = "order".order_id AND "order".business_id = :biz',
+            'DELETE FROM order_history USING "order" WHERE order_history.order_id = "order".order_id AND "order".business_id = :biz',
+            'DELETE FROM order_shipment USING "order" WHERE order_shipment.order_id = "order".order_id AND "order".business_id = :biz',
+            'DELETE FROM "order" WHERE business_id = :biz',
+            'DELETE FROM transaction WHERE business_id = :biz',
+            'DELETE FROM subscription WHERE business_id = :biz',
+            'DELETE FROM variant_inventory WHERE business_id = :biz',
+            'DELETE FROM inventory WHERE business_id = :biz',
+            'DELETE FROM inventory_summary WHERE business_id = :biz',
+            'DELETE FROM product_variant WHERE product_id IN (SELECT product_id FROM product WHERE business_id = :biz)',
+            'DELETE FROM catalog_product WHERE catalog_id IN (SELECT catalog_id FROM catalog WHERE business_id = :biz)',
+            'DELETE FROM catalog_product WHERE product_id IN (SELECT product_id FROM product WHERE business_id = :biz)',
+            'DELETE FROM product WHERE business_id = :biz',
+            'DELETE FROM category WHERE business_id = :biz',
+            'DELETE FROM catalog WHERE business_id = :biz',
+            'DELETE FROM tax WHERE business_id = :biz',
+            'DELETE FROM business_user WHERE business_id = :biz',
+            'DELETE FROM customer WHERE business_id = :biz',
+            'DELETE FROM terminal WHERE store_id IN (SELECT store_id FROM store WHERE business_id = :biz)',
+            'DELETE FROM store WHERE business_id = :biz',
+            'DELETE FROM token_refresh_log WHERE business_id = :biz',
+        ];
+
+        if (!$preserveTokens) {
+            $deleteStatements[] = 'DELETE FROM app_token WHERE business_id = :biz';
+            $deleteStatements[] = 'DELETE FROM merchant_token WHERE business_id = :biz';
+        }
+
+        $deleteStatements[] = 'DELETE FROM business WHERE business_id = :biz';
+
+        try {
+            $conn->beginTransaction();
+            $transactionStarted = true;
+
+            foreach ($deleteStatements as $statement) {
+                $conn->executeStatement($statement, ['biz' => $businessId]);
+            }
+
+            $conn->commit();
+
+            $this->context->getLog()->info(
+                sprintf('CallbackService::purgeBusinessInstallation finished for business %s.', $businessId)
+            );
+
+            return true;
+        } catch (Throwable $e) {
+            if ($transactionStarted) {
+                try {
+                    if (method_exists($conn, 'isTransactionActive') && $conn->isTransactionActive()) {
+                        $conn->rollBack();
+                    } else {
+                        $conn->rollBack();
+                    }
+                } catch (Throwable $rollbackError) {
+                    $this->context->getLog()->warning(
+                        sprintf(
+                            'CallbackService::purgeBusinessInstallation rollback warning for business %s: %s',
+                            $businessId,
+                            $rollbackError->getMessage()
+                        )
+                    );
+                }
+            }
+
+            $this->context->getLog()->error(
+                sprintf(
+                    'CallbackService::purgeBusinessInstallation failed for business %s: %s',
+                    $businessId,
+                    $e->getMessage()
+                ),
+                ['exception' => $e]
+            );
+
+            return false;
+        }
+    }
+
     private function isStoreScopedPlan(array $plan): bool
     {
         $rawScope = null;

--- a/scripts/purge_business.php
+++ b/scripts/purge_business.php
@@ -256,7 +256,7 @@ if (!empty($subscriptionIds)) {
 
 $callbackService = new CallbackService($context, $platformRegistry, $serviceFactory);
 
-$callbackService->purgeBusiness($businessId, !$dropTokens);
+$callbackService->purgeBusinessInstallation($businessId, !$dropTokens);
 
 echo sprintf(
     "Purged local data for business %s (%s tokens).\n",

--- a/tests/Services/CallbackServiceTest.php
+++ b/tests/Services/CallbackServiceTest.php
@@ -8,11 +8,13 @@ use App\Core\Context;
 use App\Modules\OAuth\PlatformRegistry;
 use App\Services\CallbackService;
 use App\Services\ServiceFactory;
+use App\Services\TokenService;
 use Doctrine\DBAL\Connection;
 use Monolog\Logger;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use ReflectionMethod;
+use DateTime;
 
 class CallbackServiceTest extends TestCase
 {
@@ -200,6 +202,97 @@ class CallbackServiceTest extends TestCase
 
         $this->assertNotContains('DELETE FROM app_token WHERE business_id = :biz', $capturedStatements);
         $this->assertNotContains('DELETE FROM merchant_token WHERE business_id = :biz', $capturedStatements);
+    }
+
+    public function testPurgeAndReinstallNormalizesPersistedTokens(): void
+    {
+        $logger = $this->createMock(Logger::class);
+        $logger->method('info')->willReturn(null);
+        $logger->method('debug')->willReturn(null);
+        $logger->method('error')->willReturn(null);
+
+        $context = $this->createMock(Context::class);
+        $context->method('getLog')->willReturn($logger);
+        $context->method('getConn')->willReturn($this->createMock(Connection::class));
+
+        $tokenService = $this->createMock(TokenService::class);
+        $tokenService->expects($this->once())
+            ->method('saveAppToken')
+            ->with(
+                'business-123',
+                $this->callback(function (array $payload): bool {
+                    $this->assertSame('app-access', $payload['accessToken']);
+                    $this->assertSame('app-refresh', $payload['refreshToken']);
+                    $this->assertArrayHasKey('expiresIn', $payload);
+                    $this->assertInstanceOf(DateTime::class, $payload['expiresIn']);
+
+                    return true;
+                })
+            );
+
+        $tokenService->expects($this->once())
+            ->method('saveMerchantToken')
+            ->with(
+                'business-123',
+                $this->callback(function (array $payload): bool {
+                    $this->assertSame('merchant-access', $payload['accessToken']);
+                    $this->assertSame('merchant-refresh', $payload['refreshToken']);
+                    $this->assertArrayHasKey('expiresIn', $payload);
+                    $this->assertInstanceOf(DateTime::class, $payload['expiresIn']);
+
+                    return true;
+                })
+            );
+
+        $serviceFactory = $this->createMock(ServiceFactory::class);
+        $serviceFactory->method('token')->willReturn($tokenService);
+
+        $callbackService = $this->getMockBuilder(CallbackService::class)
+            ->setConstructorArgs([
+                $context,
+                $this->createMock(PlatformRegistry::class),
+                $serviceFactory,
+            ])
+            ->onlyMethods(['purgeBusinessInstallation', 'runBusinessWorkflow'])
+            ->getMock();
+
+        $callbackService->expects($this->once())
+            ->method('purgeBusinessInstallation')
+            ->with('business-123', false)
+            ->willReturn(true);
+
+        $callbackService->expects($this->once())
+            ->method('runBusinessWorkflow')
+            ->with(
+                'business-123',
+                'store-456',
+                $this->callback(function (array $payload): bool {
+                    return isset($payload['accessToken'], $payload['refreshToken'], $payload['expiresIn']);
+                }),
+                $this->callback(function (array $payload): bool {
+                    return isset($payload['accessToken'], $payload['refreshToken'], $payload['expiresIn']);
+                }),
+                null,
+                null
+            )
+            ->willReturn(true);
+
+        $result = $callbackService->purgeAndReinstall(
+            'business-123',
+            'store-456',
+            [
+                'access_token' => 'app-access',
+                'refresh_token' => 'app-refresh',
+                'expires_at' => '2024-01-02T03:04:05+00:00',
+            ],
+            [
+                'access_token' => 'merchant-access',
+                'refresh_token' => 'merchant-refresh',
+                'expires_at' => '2024-01-03T04:05:06+00:00',
+            ]
+        );
+
+        $this->assertTrue($result);
     }
 
     public function testSelectDefaultPlanIdHandlesNestedItems(): void

--- a/tests/Services/CallbackServiceTest.php
+++ b/tests/Services/CallbackServiceTest.php
@@ -136,7 +136,7 @@ class CallbackServiceTest extends TestCase
         $this->assertFalse($result);
     }
 
-    public function testPurgeBusinessRemovesTokensWhenRequested(): void
+    public function testPurgeBusinessInstallationRemovesTokensWhenRequested(): void
     {
         $logger = $this->createMock(Logger::class);
         $context = $this->createMock(Context::class);
@@ -163,13 +163,13 @@ class CallbackServiceTest extends TestCase
             $this->createMock(ServiceFactory::class)
         );
 
-        $callbackService->purgeBusiness('business-123', false);
+        $callbackService->purgeBusinessInstallation('business-123', false);
 
         $this->assertContains('DELETE FROM app_token WHERE business_id = :biz', $capturedStatements);
         $this->assertContains('DELETE FROM merchant_token WHERE business_id = :biz', $capturedStatements);
     }
 
-    public function testPurgeBusinessPreservesTokensByDefault(): void
+    public function testPurgeBusinessInstallationPreservesTokensByDefault(): void
     {
         $logger = $this->createMock(Logger::class);
         $context = $this->createMock(Context::class);
@@ -196,7 +196,7 @@ class CallbackServiceTest extends TestCase
             $this->createMock(ServiceFactory::class)
         );
 
-        $callbackService->purgeBusiness('business-123');
+        $callbackService->purgeBusinessInstallation('business-123');
 
         $this->assertNotContains('DELETE FROM app_token WHERE business_id = :biz', $capturedStatements);
         $this->assertNotContains('DELETE FROM merchant_token WHERE business_id = :biz', $capturedStatements);


### PR DESCRIPTION
## Summary
- reintroduce purge orchestration helpers in `CallbackService` to rebuild local state, persist OAuth tokens, and remove business data safely
- point the purge CLI at the restored helper so onboarding rollback, CLI, and tests all share the same entry point
- refresh service tests to exercise the reinstated purge behavior and token preservation flag

## Testing
- php -l app/Services/CallbackService.php
- php -l scripts/purge_business.php
- php -l tests/Services/CallbackServiceTest.php
- vendor/bin/phpunit tests/Services/CallbackServiceTest.php *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6909f16517e0832997946404f7345421