### PR TITLE
Add CLI to gather onboarding resources by business or store

### DIFF
--- a/app/Services/CallbackService.php
+++ b/app/Services/CallbackService.php
@@ -761,7 +761,46 @@ class CallbackService
         }
     }
 
-    private function gatherInitialResources(string $businessId): bool
+    public function gatherResourcesForBusiness(string $businessId): bool
+    {
+        return $this->gatherInitialResources($businessId);
+    }
+
+    public function gatherResourcesForStore(string $businessId, string $storeId): bool
+    {
+        $storeId = trim($storeId);
+
+        if ($storeId === '') {
+            $this->context->getLog()->warning(
+                sprintf('CallbackService::gatherResourcesForStore missing storeId for business %s.', $businessId)
+            );
+
+            return false;
+        }
+
+        $this->context->getLog()->info(
+            sprintf(
+                'CallbackService::gatherResourcesForStore starting for business %s store %s.',
+                $businessId,
+                $storeId
+            )
+        );
+
+        $result = $this->gatherInitialResources($businessId, $this->createStoreResourceFilter($storeId));
+
+        $this->context->getLog()->info(
+            sprintf(
+                'CallbackService::gatherResourcesForStore finished for business %s store %s with status: %s.',
+                $businessId,
+                $storeId,
+                $result ? 'success' : 'failure'
+            )
+        );
+
+        return $result;
+    }
+
+    private function gatherInitialResources(string $businessId, ?callable $itemFilter = null): bool
     {
         $this->context->getLog()->info(
             sprintf('CallbackService::gatherInitialResources starting for business %s.', $businessId)
@@ -775,7 +814,7 @@ class CallbackService
                 sprintf('CallbackService::gatherInitialResources syncing %s for business %s.', $serviceClass, $businessId)
             );
 
-            $result = $this->syncResourceCollection($businessId, $service, $serviceClass);
+            $result = $this->syncResourceCollection($businessId, $service, $serviceClass, $itemFilter);
             if (!$result) {
                 $allSuccessful = false;
                 $this->context->getLog()->warning(
@@ -807,10 +846,129 @@ class CallbackService
         return $allSuccessful;
     }
 
+    private function createStoreResourceFilter(string $storeId): callable
+    {
+        return function (array $item) use ($storeId): bool {
+            return $this->itemAppliesToStore($item, $storeId);
+        };
+    }
+
+    private function itemAppliesToStore(array $item, string $storeId): bool
+    {
+        $storeIdentifiers = $this->extractStoreIdentifiersFromItem($item);
+
+        if ($storeIdentifiers === []) {
+            return true;
+        }
+
+        return in_array($storeId, $storeIdentifiers, true);
+    }
+
+    private function extractStoreIdentifiersFromItem(array $item): array
+    {
+        $candidates = [];
+
+        foreach (['storeId', 'store_id'] as $key) {
+            if (array_key_exists($key, $item)) {
+                $candidates[] = $this->normalizeStoreIdentifier($item[$key]);
+            }
+        }
+
+        if (array_key_exists('store', $item)) {
+            $candidates = array_merge($candidates, $this->collectStoreIdentifiers($item['store']));
+        }
+
+        if (array_key_exists('stores', $item)) {
+            $candidates = array_merge($candidates, $this->collectStoreIdentifiers($item['stores']));
+        }
+
+        if (array_key_exists('storeIds', $item)) {
+            $candidates = array_merge($candidates, $this->collectStoreIdentifiers($item['storeIds']));
+        }
+
+        return array_values(array_unique(array_filter($candidates, static function ($value): bool {
+            return is_string($value) && $value !== '';
+        })));
+    }
+
+    private function collectStoreIdentifiers(mixed $value): array
+    {
+        if ($value === null) {
+            return [];
+        }
+
+        if (is_string($value)) {
+            $normalized = trim($value);
+
+            return $normalized === '' ? [] : [$normalized];
+        }
+
+        if (!is_array($value)) {
+            return [];
+        }
+
+        if (!array_is_list($value)) {
+            $results = [];
+
+            foreach (['id', 'storeId', 'store_id'] as $key) {
+                if (array_key_exists($key, $value)) {
+                    $results = array_merge($results, $this->collectStoreIdentifiers($value[$key]));
+                }
+            }
+
+            return $results;
+        }
+
+        $results = [];
+
+        foreach ($value as $nested) {
+            $results = array_merge($results, $this->collectStoreIdentifiers($nested));
+        }
+
+        return $results;
+    }
+
+    private function normalizeStoreIdentifier(mixed $value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if (is_string($value)) {
+            $normalized = trim($value);
+
+            return $normalized === '' ? null : $normalized;
+        }
+
+        if (is_array($value)) {
+            foreach (['id', 'storeId', 'store_id'] as $key) {
+                if (array_key_exists($key, $value)) {
+                    return $this->normalizeStoreIdentifier($value[$key]);
+                }
+            }
+
+            if (array_is_list($value)) {
+                foreach ($value as $nested) {
+                    $normalized = $this->normalizeStoreIdentifier($nested);
+                    if ($normalized !== null) {
+                        return $normalized;
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+
     /**
      * @param object $service
      */
-    private function syncResourceCollection(string $businessId, object $service, ?string $serviceClass = null): bool
+    private function syncResourceCollection(
+        string $businessId,
+        object $service,
+        ?string $serviceClass = null,
+        ?callable $itemFilter = null
+    ): bool
     {
         $serviceClass = $serviceClass ?? get_class($service);
 
@@ -861,6 +1019,19 @@ class CallbackService
         }
 
         $normalized = $this->normalizeResourceItems($raw);
+
+        if ($itemFilter !== null) {
+            $normalized['items'] = array_values(array_filter(
+                $normalized['items'],
+                function ($item) use ($itemFilter): bool {
+                    if (!is_array($item)) {
+                        return true;
+                    }
+
+                    return $itemFilter($item);
+                }
+            ));
+        }
         $allSuccessful = true;
         $processedItems = 0;
         $successfulItems = 0;

--- a/scripts/gather_resources.php
+++ b/scripts/gather_resources.php
@@ -1,0 +1,81 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+use App\Config\ConfigApp;
+use App\Config\ConfigDatabase;
+use App\Core\Api;
+use App\Core\Context;
+use App\Http\GuzzleClientFactory;
+use App\Modules\OAuth\PlatformRegistry;
+use App\Services\CallbackService;
+use App\Services\ServiceFactory;
+use App\Services\Support\LoggerFactory;
+use Doctrine\DBAL\DriverManager;
+
+require_once __DIR__ . '/../public/bootstrap.php';
+
+$options = getopt('', ['business:', 'store::']);
+
+if (!isset($options['business'])) {
+    fwrite(STDERR, "Usage: php scripts/gather_resources.php --business=<BUSINESS_ID> [--store=<STORE_ID>]\\n");
+    exit(1);
+}
+
+$businessId = trim((string) $options['business']);
+if ($businessId === '') {
+    fwrite(STDERR, "The --business option cannot be empty.\\n");
+    exit(1);
+}
+
+$storeId = null;
+if (array_key_exists('store', $options)) {
+    $storeIdCandidate = trim((string) $options['store']);
+    if ($storeIdCandidate !== '') {
+        $storeId = $storeIdCandidate;
+    }
+}
+
+$connectionParams = [
+    'driver' => 'pdo_pgsql',
+    'host' => ConfigDatabase::$host,
+    'port' => ConfigDatabase::$port,
+    'dbname' => ConfigDatabase::$database,
+    'user' => ConfigDatabase::$username,
+    'password' => ConfigDatabase::$password,
+    'charset' => ConfigDatabase::$charset,
+];
+
+$conn = DriverManager::getConnection($connectionParams);
+$conn->executeStatement("SET TIME ZONE '" . ConfigApp::$timezone . "'");
+
+$logConnection = DriverManager::getConnection($connectionParams);
+$logConnection->executeStatement("SET TIME ZONE '" . ConfigApp::$timezone . "'");
+
+[$log, $requestId] = LoggerFactory::create($conn, $logConnection);
+
+$api = new Api('', $log, $requestId);
+$httpClientFactory = new GuzzleClientFactory();
+$context = new Context($api, $conn, $log, $httpClientFactory);
+$serviceFactory = new ServiceFactory($context);
+$platformRegistry = new PlatformRegistry($context);
+
+$callbackService = new CallbackService($context, $platformRegistry, $serviceFactory);
+
+if ($storeId !== null) {
+    $result = $callbackService->gatherResourcesForStore($businessId, $storeId);
+    $message = $result
+        ? sprintf('Successfully gathered resources for business %s store %s.', $businessId, $storeId)
+        : sprintf('Failed to gather resources for business %s store %s.', $businessId, $storeId);
+} else {
+    $result = $callbackService->gatherResourcesForBusiness($businessId);
+    $message = $result
+        ? sprintf('Successfully gathered resources for business %s.', $businessId)
+        : sprintf('Failed to gather resources for business %s.', $businessId);
+}
+
+$stream = $result ? STDOUT : STDERR;
+fwrite($stream, $message . "\n");
+
+exit($result ? 0 : 1);

--- a/tests/Services/CallbackServiceTest.php
+++ b/tests/Services/CallbackServiceTest.php
@@ -318,4 +318,66 @@ class CallbackServiceTest extends TestCase
 
         $this->assertSame('plan-pro', $method->invoke($callbackService, $plans, 'PRO'));
     }
+
+    public function testGatherResourcesForStoreFiltersItemsByStoreId(): void
+    {
+        $logger = $this->createMock(Logger::class);
+        $logger->method('info');
+        $logger->method('warning');
+        $logger->method('error');
+        $logger->method('debug');
+
+        $context = $this->createMock(Context::class);
+        $context->method('getLog')->willReturn($logger);
+
+        $service = new class {
+            public array $upserted = [];
+
+            public function fetchByBusinessId(?string $businessId = null): array
+            {
+                return [
+                    ['storeId' => 'store-1', 'value' => 'first'],
+                    ['storeId' => 'store-2', 'value' => 'second'],
+                    ['value' => 'no-store'],
+                    ['store' => ['id' => 'store-2', 'name' => 'Nested']],
+                    ['stores' => [
+                        ['id' => 'store-3'],
+                        ['id' => 'store-2'],
+                    ]],
+                    ['storeIds' => ['store-4', 'store-2']],
+                ];
+            }
+
+            public function upsert(array $payload): bool
+            {
+                $this->upserted[] = $payload;
+
+                return true;
+            }
+        };
+
+        $serviceFactory = $this->createMock(ServiceFactory::class);
+        $serviceFactory->method('onboardingResources')->willReturn([$service]);
+
+        $callbackService = new CallbackService(
+            $context,
+            $this->createMock(PlatformRegistry::class),
+            $serviceFactory
+        );
+
+        $result = $callbackService->gatherResourcesForStore('business-123', 'store-2');
+
+        $this->assertTrue($result);
+        $this->assertSame([
+            ['storeId' => 'store-2', 'value' => 'second'],
+            ['value' => 'no-store'],
+            ['store' => ['id' => 'store-2', 'name' => 'Nested']],
+            ['stores' => [
+                ['id' => 'store-3'],
+                ['id' => 'store-2'],
+            ]],
+            ['storeIds' => ['store-4', 'store-2']],
+        ], $service->upserted);
+    }
+
 }


### PR DESCRIPTION
## Summary
- expose public wrappers in `CallbackService` for gathering onboarding resources per business or per store and filter store-scoped records
- add a CLI script to trigger resource gathering for a business or targeted store
- cover the store filtering logic with a dedicated unit test

## Testing
- php -l app/Services/CallbackService.php
- php -l scripts/gather_resources.php
- composer install *(fails: requires GitHub token for downloads)*

------
https://chatgpt.com/codex/tasks/task_e_690a1dc08cd4832987e3c5aaa6861896