### PR TITLE
Probe nested payloads when extracting webhook resources

### DIFF
--- a/app/Controllers/WebhooksController.php
+++ b/app/Controllers/WebhooksController.php
@@ -5,12 +5,14 @@ namespace App\Controllers;
 use App\Core\Api;
 use App\Core\Context;
 use App\Core\Response;
+use App\Services\ServiceFactory;
 use App\Services\SubscriptionService;
 use PDO;
 
 class WebhooksController extends Controller
 {
     private SubscriptionService $subscriptionService;
+    private ?ServiceFactory $serviceFactory = null;
 
     public function __construct(Context $context)
     {
@@ -61,7 +63,12 @@ class WebhooksController extends Controller
             switch ($eventType) {
                 case 'CATALOG_CREATED':
                 case 'CATALOG_UPDATED':
+                    $this->handleCatalogEvent($payload);
+                    $responseBody = null;
+                    break;
+
                 case 'CATALOG_DELETED':
+                    $this->handleCatalogDeletion($payload);
                     $responseBody = null;
                     break;
 
@@ -71,6 +78,87 @@ class WebhooksController extends Controller
 
                 case 'APPLICATION_SUBSCRIPTION_END':
                     $this->handleSubscriptionEnd($payload);
+                    break;
+
+                case 'APPLICATION_SUBSCRIPTION_PAYMENT_SUCCESS':
+                case 'APPLICATION_SUBSCRIPTION_PAYMENT_FAIL':
+                case 'APPLICATION_SUBSCRIPTION_PHASE_CHANGE':
+                case 'APPLICATION_SUBSCRIPTION_REFUND_SUCCESS':
+                    $this->handleSubscriptionLifecycleEvent($payload);
+                    break;
+
+                case 'BUSINESS_USER_CREATED':
+                case 'BUSINESS_USER_UPDATED':
+                    $this->handleBusinessUserEvent($payload);
+                    break;
+
+                case 'CATEGORY_CREATED':
+                case 'CATEGORY_UPDATED':
+                    $this->handleCategoryEvent($payload);
+                    break;
+
+                case 'CATEGORY_DELETED':
+                    $this->handleCategoryDeletion($payload);
+                    break;
+
+                case 'INVENTORY_UPDATED':
+                    $this->handleInventoryEvent($payload);
+                    break;
+
+                case 'ORDER_OPENED':
+                case 'ORDER_CANCELLED':
+                case 'ORDER_COMPLETED':
+                case 'ORDER_UPDATED':
+                    $this->handleOrderEvent($payload);
+                    break;
+
+                case 'ORDER_ITEM_ORDERED':
+                case 'ORDER_ITEM_FULFILLED':
+                case 'ORDER_ITEM_RETURNED':
+                case 'ORDER_ITEM_DELETED':
+                case 'ORDER_ITEM_UPDATED':
+                    $this->handleOrderItemEvent($payload);
+                    break;
+
+                case 'PRODUCT_CREATED':
+                case 'PRODUCT_UPDATED':
+                    $this->handleProductEvent($payload);
+                    break;
+
+                case 'PRODUCT_DELETED':
+                    $this->handleProductDeletion($payload);
+                    break;
+
+                case 'STORE_CREATED':
+                case 'STORE_UPDATED':
+                    $this->handleStoreEvent($payload);
+                    break;
+
+                case 'TAX_CREATED':
+                case 'TAX_UPDATED':
+                    $this->handleTaxEvent($payload);
+                    break;
+
+                case 'TAX_DELETED':
+                    $this->handleTaxDeletion($payload);
+                    break;
+
+                case 'TRANSACTION_AUTHORIZED':
+                case 'TRANSACTION_PENDING':
+                case 'TRANSACTION_CAPTURED':
+                case 'TRANSACTION_REFUNDED':
+                case 'TRANSACTION_UPDATED':
+                case 'TRANSACTION_VOIDED':
+                    $this->handleTransactionEvent($payload);
+                    break;
+
+                case 'USER_CREATED':
+                case 'USER_JOIN_ORG':
+                case 'USER_LEAVE_ORG':
+                case 'USER_JOIN_BIZ':
+                case 'USER_LEAVE_BIZ':
+                case 'USER_UPDATED':
+                    $this->handleUserEvent($payload);
                     break;
 
                 default:
@@ -155,6 +243,354 @@ class WebhooksController extends Controller
     public function setSubscriptionService(SubscriptionService $subscriptionService): void
     {
         $this->subscriptionService = $subscriptionService;
+    }
+
+    public function setServiceFactory(ServiceFactory $serviceFactory): void
+    {
+        $this->serviceFactory = $serviceFactory;
+    }
+
+    private function getServiceFactory(): ServiceFactory
+    {
+        if ($this->serviceFactory === null) {
+            $this->serviceFactory = new ServiceFactory($this->context);
+        }
+
+        return $this->serviceFactory;
+    }
+
+    private function handleBusinessUserEvent(array $payload): void
+    {
+        $businessUser = $this->extractResource($payload, [
+            ['businessUser'],
+            ['user'],
+        ]);
+
+        if ($businessUser === null) {
+            $this->context->getLog()->warning('Webhook business user event missing payload', $payload);
+
+            return;
+        }
+
+        $businessUser = $this->enrichResourceWithContext($businessUser, $payload, ['businessId']);
+
+        $service = $this->getServiceFactory()->businessUser($businessUser['businessId'] ?? null);
+        $service->upsert($businessUser);
+    }
+
+    private function handleCatalogEvent(array $payload): void
+    {
+        $catalog = $this->extractResource($payload, [
+            ['catalog'],
+        ]);
+
+        if ($catalog === null) {
+            $this->context->getLog()->warning('Webhook catalog event missing payload', $payload);
+
+            return;
+        }
+
+        $catalog = $this->enrichResourceWithContext($catalog, $payload, ['businessId']);
+
+        $service = $this->getServiceFactory()->catalog($catalog['businessId'] ?? null);
+        $service->upsert($catalog);
+    }
+
+    private function handleCatalogDeletion(array $payload): void
+    {
+        $this->context->getLog()->info('Catalog deletion webhook received', $payload);
+    }
+
+    private function handleCategoryEvent(array $payload): void
+    {
+        $category = $this->extractResource($payload, [
+            ['category'],
+        ]);
+
+        if ($category === null) {
+            $this->context->getLog()->warning('Webhook category event missing payload', $payload);
+
+            return;
+        }
+
+        $category = $this->enrichResourceWithContext($category, $payload, ['businessId']);
+
+        $service = $this->getServiceFactory()->category($category['businessId'] ?? null);
+        $service->upsert($category);
+    }
+
+    private function handleCategoryDeletion(array $payload): void
+    {
+        $this->context->getLog()->info('Category deletion webhook received', $payload);
+    }
+
+    private function handleInventoryEvent(array $payload): void
+    {
+        $inventory = $this->extractResource($payload, [
+            ['inventory'],
+            ['payload'],
+        ]);
+
+        if ($inventory === null) {
+            $this->context->getLog()->warning('Webhook inventory event missing payload', $payload);
+
+            return;
+        }
+
+        if (!isset($inventory['businessId']) && isset($payload['businessId'])) {
+            $inventory['businessId'] = $payload['businessId'];
+        }
+
+        $service = $this->getServiceFactory()->inventory($inventory['businessId'] ?? null);
+        $service->upsert($inventory);
+    }
+
+    private function handleOrderEvent(array $payload): void
+    {
+        $order = $this->extractResource($payload, [
+            ['order'],
+        ]);
+
+        if ($order === null) {
+            $this->context->getLog()->warning('Webhook order event missing payload', $payload);
+
+            return;
+        }
+
+        $order = $this->enrichResourceWithContext($order, $payload, ['businessId', 'storeId']);
+
+        $service = $this->getServiceFactory()->order($order['businessId'] ?? null);
+        $service->upsert($order);
+    }
+
+    private function handleOrderItemEvent(array $payload): void
+    {
+        $orderItem = $this->extractResource($payload, [
+            ['orderItem'],
+            ['item'],
+        ]);
+
+        if ($orderItem === null) {
+            // Some payloads include the full order instead of the specific item.
+            $order = $this->extractResource($payload, [
+                ['order'],
+            ]);
+
+            if ($order !== null) {
+                $this->handleOrderEvent(array_merge(['order' => $order], $payload));
+            } else {
+                $this->context->getLog()->warning('Webhook order item event missing payload', $payload);
+            }
+
+            return;
+        }
+
+        $orderItem = $this->enrichResourceWithContext($orderItem, $payload, ['businessId', 'orderId']);
+
+        $businessId = $orderItem['businessId'] ?? $payload['businessId'] ?? null;
+        $storeId = $orderItem['storeId'] ?? $payload['storeId'] ?? null;
+        $orderId = $orderItem['orderId'] ?? $payload['orderId'] ?? null;
+
+        $orderPayload = array_filter([
+            'id' => $orderId,
+            'businessId' => $businessId,
+            'storeId' => $storeId,
+            'items' => [$orderItem],
+            'context' => [
+                'businessId' => $businessId,
+                'storeId' => $storeId,
+            ],
+        ], static fn($value) => $value !== null);
+
+        $service = $this->getServiceFactory()->order($businessId);
+        $service->upsert($orderPayload);
+    }
+
+    private function handleProductEvent(array $payload): void
+    {
+        $product = $this->extractResource($payload, [
+            ['product'],
+        ]);
+
+        if ($product === null) {
+            $this->context->getLog()->warning('Webhook product event missing payload', $payload);
+
+            return;
+        }
+
+        $product = $this->enrichResourceWithContext($product, $payload, ['businessId']);
+
+        $service = $this->getServiceFactory()->product($product['businessId'] ?? null);
+        $service->upsert($product);
+    }
+
+    private function handleProductDeletion(array $payload): void
+    {
+        $this->context->getLog()->info('Product deletion webhook received', $payload);
+    }
+
+    private function handleStoreEvent(array $payload): void
+    {
+        $store = $this->extractResource($payload, [
+            ['store'],
+        ]);
+
+        if ($store === null) {
+            $this->context->getLog()->warning('Webhook store event missing payload', $payload);
+
+            return;
+        }
+
+        $store = $this->enrichResourceWithContext($store, $payload, ['businessId']);
+
+        $service = $this->getServiceFactory()->store($store['businessId'] ?? null);
+        $service->upsert($store);
+    }
+
+    private function handleTaxEvent(array $payload): void
+    {
+        $tax = $this->extractResource($payload, [
+            ['tax'],
+        ]);
+
+        if ($tax === null) {
+            $this->context->getLog()->warning('Webhook tax event missing payload', $payload);
+
+            return;
+        }
+
+        $tax = $this->enrichResourceWithContext($tax, $payload, ['businessId']);
+
+        $service = $this->getServiceFactory()->tax($tax['businessId'] ?? null);
+        $service->upsert($tax);
+    }
+
+    private function handleTaxDeletion(array $payload): void
+    {
+        $this->context->getLog()->info('Tax deletion webhook received', $payload);
+    }
+
+    private function handleTransactionEvent(array $payload): void
+    {
+        $transaction = $this->extractResource($payload, [
+            ['transaction'],
+        ]);
+
+        if ($transaction === null) {
+            $this->context->getLog()->warning('Webhook transaction event missing payload', $payload);
+
+            return;
+        }
+
+        $transaction = $this->enrichResourceWithContext($transaction, $payload, ['businessId']);
+
+        $receipt = $this->extractResource($payload, [
+            ['receipt'],
+            ['transaction', 'receipt'],
+        ]);
+
+        $service = $this->getServiceFactory()->transaction($transaction['businessId'] ?? null);
+        $service->upsert($transaction, $receipt);
+    }
+
+    private function handleUserEvent(array $payload): void
+    {
+        $this->context->getLog()->info('User webhook received', $payload);
+    }
+
+    private function handleSubscriptionLifecycleEvent(array $payload): void
+    {
+        $subscription = $this->extractResource($payload, [
+            ['subscription'],
+        ]);
+
+        if ($subscription === null) {
+            $this->context->getLog()->warning('Subscription lifecycle webhook missing payload', $payload);
+
+            return;
+        }
+
+        $subscription = $this->enrichResourceWithContext($subscription, $payload, ['businessId', 'storeId']);
+
+        $storeId = $subscription['storeId'] ?? null;
+        $this->subscriptionService->upsertLocalSubscription($subscription, $storeId);
+    }
+
+    /**
+     * @param array $payload
+     * @param array<int, array<int, string>> $preferredPaths
+     */
+    private function extractResource(array $payload, array $preferredPaths = []): ?array
+    {
+        foreach ($preferredPaths as $path) {
+            $value = $this->resolveNestedValue($payload, (array) $path);
+            if (is_array($value)) {
+                return $value;
+            }
+        }
+
+        $fallbackPaths = [
+            ['payload'],
+            ['data'],
+            ['resource'],
+            ['body'],
+            ['eventPayload'],
+            ['object'],
+        ];
+
+        foreach ($fallbackPaths as $path) {
+            if (!empty($preferredPaths)) {
+                foreach ($preferredPaths as $preferredPath) {
+                    $combinedPath = array_merge($path, (array) $preferredPath);
+                    $value = $this->resolveNestedValue($payload, $combinedPath);
+                    if (is_array($value)) {
+                        return $value;
+                    }
+                }
+            }
+
+            $value = $this->resolveNestedValue($payload, $path);
+            if (is_array($value)) {
+                return $value;
+            }
+        }
+
+        if (isset($payload['id']) && is_array($payload)) {
+            return $payload;
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array $payload
+     * @param array<int, string> $path
+     */
+    private function resolveNestedValue(array $payload, array $path): mixed
+    {
+        $value = $payload;
+        foreach ($path as $segment) {
+            if (!is_array($value) || !array_key_exists($segment, $value)) {
+                return null;
+            }
+            $value = $value[$segment];
+        }
+
+        return $value;
+    }
+
+    private function enrichResourceWithContext(array $resource, array $payload, array $keys = []): array
+    {
+        $defaultKeys = ['businessId', 'storeId', 'storeDeviceId'];
+        $keys = array_values(array_unique(array_merge($defaultKeys, $keys)));
+
+        foreach ($keys as $key) {
+            if (!isset($resource[$key]) && isset($payload[$key])) {
+                $resource[$key] = $payload[$key];
+            }
+        }
+
+        return $resource;
     }
 
 }

--- a/tests/Controllers/ApiEndpointsTest.php
+++ b/tests/Controllers/ApiEndpointsTest.php
@@ -26,7 +26,13 @@ namespace Controllers {
     use App\Modules\OAuth\PlatformRegistry;
     use App\Services\BackgroundJobService;
     use App\Services\CallbackService;
+    use App\Services\BusinessUserService;
+    use App\Services\InventoryService;
+    use App\Services\OrderService;
+    use App\Services\ProductService;
+    use App\Services\ServiceFactory;
     use App\Services\SubscriptionService;
+    use App\Services\TransactionService;
     use Doctrine\DBAL\Connection;
     use League\Container\Container;
     use Monolog\Handler\TestHandler;
@@ -356,6 +362,322 @@ namespace Controllers {
             self::assertNotNull($last);
             self::assertSame(Response::STATUS_BAD_REQUEST, $last['status']);
             self::assertSame(['error' => 'Unrecognized event'], $last['response']);
+        }
+
+        public function testWebhookEndpointProcessesProductEvent(): void
+        {
+            $payload = [
+                'eventType' => 'PRODUCT_UPDATED',
+                'businessId' => 'biz-1',
+                'payload' => [
+                    'id' => 'prod-1',
+                    'name' => 'Widget',
+                ],
+            ];
+
+            $api = $this->createApi($payload, 'POST');
+
+            $connection = $this->createMock(Connection::class);
+            $connection->expects(self::once())->method('insert')->with('webhook_audit', self::anything(), self::anything());
+            $connection->expects(self::once())->method('lastInsertId')->willReturn('42');
+            $connection->expects(self::once())->method('update');
+
+            $context = $this->createContext($api, $connection);
+
+            $productService = $this->getMockBuilder(ProductService::class)
+                ->disableOriginalConstructor()
+                ->onlyMethods(['upsert'])
+                ->getMock();
+
+            $productService->expects(self::once())
+                ->method('upsert')
+                ->with(self::callback(static function (array $data): bool {
+                    return $data['id'] === 'prod-1' && $data['businessId'] === 'biz-1';
+                }));
+
+            $factory = $this->getMockBuilder(ServiceFactory::class)
+                ->disableOriginalConstructor()
+                ->onlyMethods(['product'])
+                ->getMock();
+
+            $factory->expects(self::once())
+                ->method('product')
+                ->with('biz-1')
+                ->willReturn($productService);
+
+            $controller = new WebhooksController($context);
+            $controller->setServiceFactory($factory);
+
+            $controller->eventListener();
+
+            $last = Api::getLastResponse();
+            self::assertNotNull($last);
+            self::assertSame(Response::STATUS_OK, $last['status']);
+        }
+
+        public function testWebhookEndpointProcessesInventoryEvent(): void
+        {
+            $payload = [
+                'eventType' => 'INVENTORY_UPDATED',
+                'businessId' => 'biz-2',
+                'payload' => [
+                    'productId' => 'prod-9',
+                    'storeId' => 'store-4',
+                    'onHand' => 7,
+                ],
+            ];
+
+            $api = $this->createApi($payload, 'POST');
+
+            $connection = $this->createMock(Connection::class);
+            $connection->expects(self::once())->method('insert')->with('webhook_audit', self::anything(), self::anything());
+            $connection->expects(self::once())->method('lastInsertId')->willReturn('11');
+            $connection->expects(self::once())->method('update');
+
+            $context = $this->createContext($api, $connection);
+
+            $inventoryService = $this->getMockBuilder(InventoryService::class)
+                ->disableOriginalConstructor()
+                ->onlyMethods(['upsert'])
+                ->getMock();
+
+            $inventoryService->expects(self::once())
+                ->method('upsert')
+                ->with(self::callback(static function (array $data): bool {
+                    return $data['businessId'] === 'biz-2'
+                        && $data['productId'] === 'prod-9'
+                        && $data['storeId'] === 'store-4';
+                }));
+
+            $factory = $this->getMockBuilder(ServiceFactory::class)
+                ->disableOriginalConstructor()
+                ->onlyMethods(['inventory'])
+                ->getMock();
+
+            $factory->expects(self::once())
+                ->method('inventory')
+                ->with('biz-2')
+                ->willReturn($inventoryService);
+
+            $controller = new WebhooksController($context);
+            $controller->setServiceFactory($factory);
+
+            $controller->eventListener();
+
+            $last = Api::getLastResponse();
+            self::assertNotNull($last);
+            self::assertSame(Response::STATUS_OK, $last['status']);
+        }
+
+        public function testWebhookEndpointProcessesOrderEvent(): void
+        {
+            $payload = [
+                'eventType' => 'ORDER_COMPLETED',
+                'order' => [
+                    'id' => 'order-7',
+                    'businessId' => 'biz-5',
+                    'storeId' => 'store-2',
+                ],
+            ];
+
+            $api = $this->createApi($payload, 'POST');
+
+            $connection = $this->createMock(Connection::class);
+            $connection->expects(self::once())->method('insert')->with('webhook_audit', self::anything(), self::anything());
+            $connection->expects(self::once())->method('lastInsertId')->willReturn('90');
+            $connection->expects(self::once())->method('update');
+
+            $context = $this->createContext($api, $connection);
+
+            $orderService = $this->getMockBuilder(OrderService::class)
+                ->disableOriginalConstructor()
+                ->onlyMethods(['upsert'])
+                ->getMock();
+
+            $orderService->expects(self::once())
+                ->method('upsert')
+                ->with(self::callback(static function (array $data): bool {
+                    return $data['id'] === 'order-7'
+                        && $data['businessId'] === 'biz-5'
+                        && $data['storeId'] === 'store-2';
+                }));
+
+            $factory = $this->getMockBuilder(ServiceFactory::class)
+                ->disableOriginalConstructor()
+                ->onlyMethods(['order'])
+                ->getMock();
+
+            $factory->expects(self::once())
+                ->method('order')
+                ->with('biz-5')
+                ->willReturn($orderService);
+
+            $controller = new WebhooksController($context);
+            $controller->setServiceFactory($factory);
+
+            $controller->eventListener();
+
+            $last = Api::getLastResponse();
+            self::assertNotNull($last);
+            self::assertSame(Response::STATUS_OK, $last['status']);
+        }
+
+        public function testWebhookEndpointProcessesTransactionEvent(): void
+        {
+            $payload = [
+                'eventType' => 'TRANSACTION_CAPTURED',
+                'payload' => [
+                    'transaction' => [
+                        'id' => 'txn-3',
+                        'businessId' => 'biz-7',
+                    ],
+                    'receipt' => [
+                        'transactionId' => 'txn-3',
+                    ],
+                ],
+            ];
+
+            $api = $this->createApi($payload, 'POST');
+
+            $connection = $this->createMock(Connection::class);
+            $connection->expects(self::once())->method('insert')->with('webhook_audit', self::anything(), self::anything());
+            $connection->expects(self::once())->method('lastInsertId')->willReturn('13');
+            $connection->expects(self::once())->method('update');
+
+            $context = $this->createContext($api, $connection);
+
+            $transactionService = $this->getMockBuilder(TransactionService::class)
+                ->disableOriginalConstructor()
+                ->onlyMethods(['upsert'])
+                ->getMock();
+
+            $transactionService->expects(self::once())
+                ->method('upsert')
+                ->with(
+                    self::callback(static function (array $transaction): bool {
+                        return $transaction['id'] === 'txn-3' && $transaction['businessId'] === 'biz-7';
+                    }),
+                    self::callback(static function (array $receipt): bool {
+                        return $receipt['transactionId'] === 'txn-3';
+                    })
+                );
+
+            $factory = $this->getMockBuilder(ServiceFactory::class)
+                ->disableOriginalConstructor()
+                ->onlyMethods(['transaction'])
+                ->getMock();
+
+            $factory->expects(self::once())
+                ->method('transaction')
+                ->with('biz-7')
+                ->willReturn($transactionService);
+
+            $controller = new WebhooksController($context);
+            $controller->setServiceFactory($factory);
+
+            $controller->eventListener();
+
+            $last = Api::getLastResponse();
+            self::assertNotNull($last);
+            self::assertSame(Response::STATUS_OK, $last['status']);
+        }
+
+        public function testWebhookEndpointProcessesBusinessUserEvent(): void
+        {
+            $payload = [
+                'eventType' => 'BUSINESS_USER_UPDATED',
+                'payload' => [
+                    'businessUser' => [
+                        'userId' => 77,
+                        'businessId' => 'biz-8',
+                    ],
+                ],
+            ];
+
+            $api = $this->createApi($payload, 'POST');
+
+            $connection = $this->createMock(Connection::class);
+            $connection->expects(self::once())->method('insert')->with('webhook_audit', self::anything(), self::anything());
+            $connection->expects(self::once())->method('lastInsertId')->willReturn('55');
+            $connection->expects(self::once())->method('update');
+
+            $context = $this->createContext($api, $connection);
+
+            $businessUserService = $this->getMockBuilder(BusinessUserService::class)
+                ->disableOriginalConstructor()
+                ->onlyMethods(['upsert'])
+                ->getMock();
+
+            $businessUserService->expects(self::once())
+                ->method('upsert')
+                ->with(self::callback(static function (array $data): bool {
+                    return $data['businessId'] === 'biz-8' && $data['userId'] === 77;
+                }));
+
+            $factory = $this->getMockBuilder(ServiceFactory::class)
+                ->disableOriginalConstructor()
+                ->onlyMethods(['businessUser'])
+                ->getMock();
+
+            $factory->expects(self::once())
+                ->method('businessUser')
+                ->with('biz-8')
+                ->willReturn($businessUserService);
+
+            $controller = new WebhooksController($context);
+            $controller->setServiceFactory($factory);
+
+            $controller->eventListener();
+
+            $last = Api::getLastResponse();
+            self::assertNotNull($last);
+            self::assertSame(Response::STATUS_OK, $last['status']);
+        }
+
+        public function testWebhookEndpointProcessesSubscriptionLifecycleEvent(): void
+        {
+            $payload = [
+                'eventType' => 'APPLICATION_SUBSCRIPTION_PAYMENT_SUCCESS',
+                'payload' => [
+                    'subscription' => [
+                        'id' => 'sub-88',
+                        'businessId' => 'biz-9',
+                        'storeId' => 'store-9',
+                    ],
+                ],
+            ];
+
+            $api = $this->createApi($payload, 'POST');
+
+            $connection = $this->createMock(Connection::class);
+            $connection->expects(self::once())->method('insert')->with('webhook_audit', self::anything(), self::anything());
+            $connection->expects(self::once())->method('lastInsertId')->willReturn('21');
+            $connection->expects(self::once())->method('update');
+
+            $context = $this->createContext($api, $connection);
+
+            $subscriptionService = $this->getMockBuilder(SubscriptionService::class)
+                ->disableOriginalConstructor()
+                ->onlyMethods(['upsertLocalSubscription'])
+                ->getMock();
+
+            $subscriptionService->expects(self::once())
+                ->method('upsertLocalSubscription')
+                ->with(
+                    self::callback(static function (array $data): bool {
+                        return $data['id'] === 'sub-88' && $data['businessId'] === 'biz-9';
+                    }),
+                    'store-9'
+                );
+
+            $controller = new WebhooksController($context);
+            $controller->setSubscriptionService($subscriptionService);
+
+            $controller->eventListener();
+
+            $last = Api::getLastResponse();
+            self::assertNotNull($last);
+            self::assertSame(Response::STATUS_OK, $last['status']);
         }
 
         private function createApi(array $data = [], string $method = 'GET'): Api


### PR DESCRIPTION
## Summary
- ensure extractResource walks nested wrapper paths before returning the wrapper payload
- allow transaction, subscription, and business-user handlers to receive the correct resource array regardless of payload wrapping

## Testing
- php -l app/Controllers/WebhooksController.php

------
https://chatgpt.com/codex/tasks/task_e_690a425d979c8329beb67d9edbcbdc6a