### PR TITLE
Handle webhook deliveries with attempt field

### DIFF
--- a/app/Services/WebhookService.php
+++ b/app/Services/WebhookService.php
@@ -830,10 +830,21 @@ class WebhookService
 
             $deliveryId = $delivery['id'];
             $eventType = $delivery['eventType'] ?? null;
-            $deliveredAt = Format::optionalTimestamp($delivery['deliveredAt'] ?? $delivery['deliveredAtExt'] ?? null);
+            $deliveredAt = Format::optionalTimestamp(
+                $delivery['deliveredAt']
+                    ?? $delivery['deliveredAtExt']
+                    ?? $delivery['updatedAt']
+                    ?? $delivery['createdAt']
+                    ?? null
+            );
             $status = $delivery['status'] ?? null;
-            $httpStatus = isset($delivery['httpStatus']) ? (int)$delivery['httpStatus'] : null;
-            $retryCount = isset($delivery['retryCount']) ? (int)$delivery['retryCount'] : null;
+            $httpStatus = Format::optionalInt(
+                $delivery['httpStatus']
+                    ?? $delivery['statusCode']
+                    ?? $delivery['responseCode']
+                    ?? null
+            );
+            $retryCount = Format::optionalInt($delivery['retryCount'] ?? $delivery['attempt'] ?? null);
             $payload = Format::jsonObject($delivery);
 
             try {

--- a/tests/Services/WebhookServiceTest.php
+++ b/tests/Services/WebhookServiceTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Services;
+
+use App\Core\Context;
+use App\Services\WebhookService;
+use App\Services\Support\PoyntDataFormatter as Format;
+use Doctrine\DBAL\Connection;
+use GuzzleHttp\ClientInterface;
+use Monolog\Logger;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+class WebhookServiceTest extends TestCase
+{
+    public function testSyncDeliveriesPersistsAttemptAndTimestamps(): void
+    {
+        $logger = $this->createMock(Logger::class);
+        $connection = $this->createMock(Connection::class);
+        $context = $this->createMock(Context::class);
+        $context->method('getLog')->willReturn($logger);
+        $context->method('getConn')->willReturn($connection);
+
+        $httpClient = $this->createMock(ClientInterface::class);
+        $service = new WebhookService($context, null, $httpClient);
+
+        $delivery = [
+            'id'            => 'delivery-123',
+            'businessId'    => 'business-abc',
+            'hookId'        => 'hook-456',
+            'eventType'     => 'APPLICATION_SUBSCRIPTION_START',
+            'status'        => 'ERRORED',
+            'attempt'       => 4,
+            'createdAt'     => '2024-02-01T12:34:56Z',
+            'updatedAt'     => '2024-02-01T13:00:00Z',
+            'properties'    => ['planId' => 'plan-789'],
+            'deliveryUrl'   => 'https://example.test/webhook',
+        ];
+
+        $expectedTimestamp = Format::optionalTimestamp($delivery['updatedAt']);
+
+        $connection
+            ->expects($this->once())
+            ->method('executeStatement')
+            ->with(
+                $this->stringContains('INSERT INTO hook_delivery'),
+                $this->callback(function (array $params) use ($expectedTimestamp) {
+                    $this->assertArrayHasKey('retryCount', $params);
+                    $this->assertSame(4, $params['retryCount']);
+                    $this->assertArrayHasKey('deliveredAt', $params);
+                    $this->assertSame($expectedTimestamp, $params['deliveredAt']);
+
+                    return true;
+                })
+            );
+
+        $method = new ReflectionMethod($service, 'syncDeliveries');
+        $method->setAccessible(true);
+        $method->invoke($service, 'hook-456', 'business-abc', [$delivery]);
+    }
+}


### PR DESCRIPTION
## Summary
- treat webhook delivery payloads that omit deliveredAt/httpStatus by falling back to updated timestamps and alternate status fields
- accept attempt counters when retryCount is missing so we still persist retry metadata
- cover syncDeliveries with a PHPUnit test exercising the new delivery payload structure

## Testing
- php -l app/Services/WebhookService.php
- php -l tests/Services/WebhookServiceTest.php

------
https://chatgpt.com/codex/tasks/task_e_690b856a4808832982b8a4e14c485d52