### PR TITLE
Align subscription webhooks with organization scope

### DIFF
--- a/app/Services/WebhookService.php
+++ b/app/Services/WebhookService.php
@@ -49,8 +49,7 @@ class WebhookService
     public function registerWebhook(string $merchantAccessToken, array $events): mixed
     {
         $businessId = $this->businessId;
-        // When dealing with subscription event use, developer organization ID, NOT business ID
-        if (in_array('APPLICATION_SUBSCRIPTION_START', $events)) {
+        if ($this->eventsRequireOrgId($events)) {
             $businessId = ConfigApp::$orgId;
         }
 
@@ -493,6 +492,18 @@ class WebhookService
             }
 
             $deliveries = $this->fetchDeliveriesForBusiness($businessId, $merchantToken);
+
+            $orgBusinessId = ConfigApp::$orgId ?? '';
+            if (
+                is_string($orgBusinessId)
+                && $orgBusinessId !== ''
+                && $orgBusinessId !== $businessId
+            ) {
+                $orgDeliveries = $this->fetchDeliveriesForBusiness($orgBusinessId, $merchantToken);
+                if ($orgDeliveries !== []) {
+                    $deliveries = array_merge($deliveries, $orgDeliveries);
+                }
+            }
             $deliveriesByHook = [];
             $deliveriesMissingHookId = [];
             foreach ($deliveries as $delivery) {
@@ -675,6 +686,23 @@ class WebhookService
 
             $hookId = $hook['id'];
 
+            $hookBusinessId = $hook['businessId'] ?? null;
+            if (!is_string($hookBusinessId) || $hookBusinessId === '') {
+                $hookBusinessId = $businessId;
+            }
+
+            $eventTypes = [];
+            if (isset($hook['eventTypes'])) {
+                $eventTypes = is_array($hook['eventTypes']) ? $hook['eventTypes'] : [$hook['eventTypes']];
+            }
+
+            if ($this->eventsRequireOrgId($eventTypes)) {
+                $orgId = ConfigApp::$orgId ?? '';
+                if (is_string($orgId) && $orgId !== '') {
+                    $hookBusinessId = $orgId;
+                }
+            }
+
             try {
                 $this->httpClient->delete(
                     self::POYNT_WEBHOOK_URL . '/' . rawurlencode($hookId),
@@ -683,7 +711,7 @@ class WebhookService
                             'Authorization' => 'Bearer ' . $accessToken,
                         ],
                         'query' => [
-                            'businessId' => $businessId,
+                            'businessId' => $hookBusinessId,
                         ],
                     ]
                 );
@@ -692,7 +720,7 @@ class WebhookService
                     sprintf(
                         'WebhookService::deleteAllByBusinessId: deleted hook %s for business %s',
                         $hookId,
-                        $businessId
+                        $hookBusinessId
                     )
                 );
             } catch (BadResponseException|GuzzleException $e) {
@@ -700,7 +728,7 @@ class WebhookService
                     sprintf(
                         'WebhookService::deleteAllByBusinessId: failed deleting hook %s for business %s: %s',
                         $hookId,
-                        $businessId,
+                        $hookBusinessId,
                         $e->getMessage()
                     )
                 );
@@ -712,7 +740,7 @@ class WebhookService
     }
 
     /**
-     * Fetch all hooks for the configured developer organization, following pagination links.
+     * Fetch all hooks associated with the merchant business as well as any organization-scoped entries.
      *
      * @param string $businessId
      * @param string $appToken
@@ -722,12 +750,56 @@ class WebhookService
      */
     private function fetchAllHooks(string $businessId, string $appToken): array|false
     {
+        $hooksById = [];
+        $anonymousHooks = [];
+
+        $businessIds = [$businessId];
+        $orgId = ConfigApp::$orgId ?? '';
+        if (is_string($orgId) && $orgId !== '' && $orgId !== $businessId) {
+            $businessIds[] = $orgId;
+        }
+
+        foreach ($businessIds as $targetBusinessId) {
+            $pageHooks = $this->fetchHooksForBusiness($targetBusinessId, $appToken);
+            if ($pageHooks === false) {
+                return false;
+            }
+
+            foreach ($pageHooks as $hook) {
+                if (!is_array($hook)) {
+                    continue;
+                }
+
+                $hookId = $hook['id'] ?? null;
+                if (is_string($hookId) && $hookId !== '') {
+                    $hooksById[$hookId] = $hook;
+                    continue;
+                }
+
+                $anonymousHooks[] = $hook;
+            }
+        }
+
+        return array_merge(array_values($hooksById), $anonymousHooks);
+    }
+
+    /**
+     * Fetch hooks for a specific business identifier, following pagination links.
+     *
+     * @param string $businessId
+     * @param string $appToken
+     * @return array<int, mixed>|false
+     * @throws BadResponseException
+     * @throws GuzzleException
+     */
+    private function fetchHooksForBusiness(string $businessId, string $appToken): array|false
+    {
         $options = [
             'headers' => [
                 'Authorization' => 'Bearer ' . $appToken,
             ],
             'query' => [
-                'businessId' => ConfigApp::$orgId,
+                'businessId' => $businessId,
             ],
         ];
 
@@ -759,12 +831,7 @@ class WebhookService
                     continue;
                 }
 
-                $hookId = $hook['id'] ?? null;
-                if (is_string($hookId) && $hookId !== '') {
-                    $hooks[$hookId] = $hook;
-                } else {
-                    $hooks[] = $hook;
-                }
+                $hooks[] = $hook;
             }
 
             $nextCandidate = $this->extractNextHooksUrl($payload);
@@ -780,7 +847,7 @@ class WebhookService
             $nextUrl = $nextCandidate;
         }
 
-        return array_values($hooks);
+        return $hooks;
     }
 
     private function fetchDeliveriesForBusiness(string $businessId, string $accessToken): array
@@ -830,6 +897,24 @@ class WebhookService
             );
             return [];
         }
+    }
+
+    /**
+     * @param array<int, mixed> $events
+     */
+    private function eventsRequireOrgId(array $events): bool
+    {
+        foreach ($events as $event) {
+            if (!is_string($event)) {
+                continue;
+            }
+
+            if (str_starts_with($event, 'APPLICATION_SUBSCRIPTION_')) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private function normalizeHooks(mixed $payload): array|false
@@ -916,6 +1001,18 @@ class WebhookService
         foreach ($requiredKeys as $key) {
             if (!array_key_exists($key, $flattened)) {
                 $flattened[$key] = null;
+            }
+        }
+
+        $eventTypes = $flattened['eventTypes'];
+        if (!is_array($eventTypes)) {
+            $eventTypes = $eventTypes === null ? [] : [$eventTypes];
+        }
+
+        if ($this->eventsRequireOrgId($eventTypes)) {
+            $orgBusinessId = ConfigApp::$orgId ?? '';
+            if (is_string($orgBusinessId) && $orgBusinessId !== '') {
+                $flattened['businessId'] = $orgBusinessId;
             }
         }
 

--- a/tests/Services/WebhookServiceTest.php
+++ b/tests/Services/WebhookServiceTest.php
@@ -2,62 +2,322 @@
 
 declare(strict_types=1);
 
-namespace Tests\Services;
+namespace App\Config {
+    if (!class_exists(__NAMESPACE__ . '\\ConfigApp')) {
+        class ConfigApp
+        {
+            public static string $orgId = '';
+            public static string $appId = '';
+            public static string $webRootUrl = '';
+        }
+    }
+}
 
-use App\Core\Context;
-use App\Services\WebhookService;
-use App\Services\Support\PoyntDataFormatter as Format;
-use Doctrine\DBAL\Connection;
-use GuzzleHttp\ClientInterface;
-use Monolog\Logger;
-use PHPUnit\Framework\TestCase;
-use ReflectionMethod;
+namespace Tests\Services {
 
-class WebhookServiceTest extends TestCase
-{
-    public function testSyncDeliveriesPersistsAttemptAndTimestamps(): void
+    use App\Config\ConfigApp;
+    use App\Core\Context;
+    use App\Services\Support\PoyntDataFormatter as Format;
+    use App\Services\WebhookService;
+    use Doctrine\DBAL\Connection;
+    use GuzzleHttp\ClientInterface;
+    use GuzzleHttp\Psr7\Response;
+    use Monolog\Logger;
+    use PHPUnit\Framework\TestCase;
+    use ReflectionMethod;
+
+    class WebhookServiceTest extends TestCase
     {
-        $logger = $this->createMock(Logger::class);
-        $connection = $this->createMock(Connection::class);
-        $context = $this->createMock(Context::class);
-        $context->method('getLog')->willReturn($logger);
-        $context->method('getConn')->willReturn($connection);
+        public function testSyncDeliveriesPersistsAttemptAndTimestamps(): void
+        {
+            $logger = $this->createMock(Logger::class);
+            $connection = $this->createMock(Connection::class);
+            $context = $this->createMock(Context::class);
+            $context->method('getLog')->willReturn($logger);
+            $context->method('getConn')->willReturn($connection);
 
-        $httpClient = $this->createMock(ClientInterface::class);
-        $service = new WebhookService($context, null, $httpClient);
+            $httpClient = $this->createMock(ClientInterface::class);
+            $service = new WebhookService($context, null, $httpClient);
 
-        $delivery = [
-            'id'            => 'delivery-123',
-            'businessId'    => 'business-abc',
-            'hookId'        => 'hook-456',
-            'eventType'     => 'APPLICATION_SUBSCRIPTION_START',
-            'status'        => 'ERRORED',
-            'attempt'       => 4,
-            'createdAt'     => '2024-02-01T12:34:56Z',
-            'updatedAt'     => '2024-02-01T13:00:00Z',
-            'properties'    => ['planId' => 'plan-789'],
-            'deliveryUrl'   => 'https://example.test/webhook',
-        ];
+            $delivery = [
+                'id'            => 'delivery-123',
+                'businessId'    => 'business-abc',
+                'hookId'        => 'hook-456',
+                'eventType'     => 'APPLICATION_SUBSCRIPTION_START',
+                'status'        => 'ERRORED',
+                'attempt'       => 4,
+                'createdAt'     => '2024-02-01T12:34:56Z',
+                'updatedAt'     => '2024-02-01T13:00:00Z',
+                'properties'    => ['planId' => 'plan-789'],
+                'deliveryUrl'   => 'https://example.test/webhook',
+            ];
 
-        $expectedTimestamp = Format::optionalTimestamp($delivery['updatedAt']);
+            $expectedTimestamp = Format::optionalTimestamp($delivery['updatedAt']);
 
-        $connection
-            ->expects($this->once())
-            ->method('executeStatement')
-            ->with(
-                $this->stringContains('INSERT INTO hook_delivery'),
-                $this->callback(function (array $params) use ($expectedTimestamp) {
-                    $this->assertArrayHasKey('retryCount', $params);
-                    $this->assertSame(4, $params['retryCount']);
-                    $this->assertArrayHasKey('deliveredAt', $params);
-                    $this->assertSame($expectedTimestamp, $params['deliveredAt']);
+            $connection
+                ->expects($this->once())
+                ->method('executeStatement')
+                ->with(
+                    $this->stringContains('INSERT INTO hook_delivery'),
+                    $this->callback(function (array $params) use ($expectedTimestamp) {
+                        $this->assertArrayHasKey('retryCount', $params);
+                        $this->assertSame(4, $params['retryCount']);
+                        $this->assertArrayHasKey('deliveredAt', $params);
+                        $this->assertSame($expectedTimestamp, $params['deliveredAt']);
 
-                    return true;
-                })
-            );
+                        return true;
+                    })
+                );
 
-        $method = new ReflectionMethod($service, 'syncDeliveries');
-        $method->setAccessible(true);
-        $method->invoke($service, 'hook-456', 'business-abc', [$delivery]);
+            $method = new ReflectionMethod($service, 'syncDeliveries');
+            $method->setAccessible(true);
+            $method->invoke($service, 'hook-456', 'business-abc', [$delivery]);
+        }
+
+        public function testRegisterWebhookUsesOrgIdForSubscriptionEvents(): void
+        {
+            ConfigApp::$orgId = 'org-123';
+            ConfigApp::$appId = 'app-123';
+            ConfigApp::$webRootUrl = 'https://example.test';
+
+            $logger = $this->createMock(Logger::class);
+            $logger->method('info');
+
+            $connection = $this->createMock(Connection::class);
+            $connection
+                ->expects($this->once())
+                ->method('insert')
+                ->with('webhook_audit', $this->isType('array'));
+
+            $context = $this->createMock(Context::class);
+            $context->method('getLog')->willReturn($logger);
+            $context->method('getConn')->willReturn($connection);
+
+            $httpClient = $this->createMock(ClientInterface::class);
+            $httpClient
+                ->expects($this->once())
+                ->method('post')
+                ->with(
+                    WebhookService::POYNT_WEBHOOK_URL,
+                    $this->callback(function (array $options): bool {
+                        $this->assertSame('Bearer merchant-token', $options['headers']['Authorization']);
+                        $this->assertSame('org-123', $options['json']['businessId']);
+                        $this->assertSame(
+                            ['APPLICATION_SUBSCRIPTION_PAYMENT_SUCCESS'],
+                            $options['json']['eventTypes']
+                        );
+
+                        return true;
+                    })
+                )
+                ->willReturn(new Response(200, [], json_encode(['id' => 'hook-1'])));
+
+            $service = new WebhookService($context, 'business-123', $httpClient);
+
+            $result = $service->registerWebhook('merchant-token', ['APPLICATION_SUBSCRIPTION_PAYMENT_SUCCESS']);
+
+            $this->assertSame(['id' => 'hook-1'], $result);
+        }
+
+        public function testRegisterWebhookUsesBusinessIdWhenNoSubscriptionEvents(): void
+        {
+            ConfigApp::$orgId = 'org-123';
+            ConfigApp::$appId = 'app-123';
+            ConfigApp::$webRootUrl = 'https://example.test';
+
+            $logger = $this->createMock(Logger::class);
+            $logger->method('info');
+
+            $connection = $this->createMock(Connection::class);
+            $connection
+                ->expects($this->once())
+                ->method('insert')
+                ->with('webhook_audit', $this->isType('array'));
+
+            $context = $this->createMock(Context::class);
+            $context->method('getLog')->willReturn($logger);
+            $context->method('getConn')->willReturn($connection);
+
+            $httpClient = $this->createMock(ClientInterface::class);
+            $httpClient
+                ->expects($this->once())
+                ->method('post')
+                ->with(
+                    WebhookService::POYNT_WEBHOOK_URL,
+                    $this->callback(function (array $options): bool {
+                        $this->assertSame('business-123', $options['json']['businessId']);
+                        $this->assertSame(['ORDER_COMPLETED'], $options['json']['eventTypes']);
+
+                        return true;
+                    })
+                )
+                ->willReturn(new Response(200, [], json_encode(['id' => 'hook-2'])));
+
+            $service = new WebhookService($context, 'business-123', $httpClient);
+
+            $result = $service->registerWebhook('merchant-token', ['ORDER_COMPLETED']);
+
+            $this->assertSame(['id' => 'hook-2'], $result);
+        }
+
+        public function testFetchByBusinessIdFetchesOrgDeliveriesForSubscriptionHooks(): void
+        {
+            ConfigApp::$orgId = 'org-456';
+            ConfigApp::$appId = 'app-456';
+
+            $logger = $this->createMock(Logger::class);
+            $logger->method('info');
+            $logger->method('error');
+            $logger->method('warning');
+
+            $connection = $this->getMockBuilder(Connection::class)
+                ->onlyMethods(['fetchAssociative', 'isTransactionActive', 'isRollbackOnly'])
+                ->getMock();
+            $connection->method('isTransactionActive')->willReturn(false);
+            $connection->method('isRollbackOnly')->willReturn(false);
+            $connection
+                ->expects($this->exactly(2))
+                ->method('fetchAssociative')
+                ->with($this->isType('string'), ['biz' => 'business-123'])
+                ->willReturnOnConsecutiveCalls(
+                    ['access_token' => 'merchant-token'],
+                    ['access_token' => 'app-token']
+                );
+
+            $context = $this->createMock(Context::class);
+            $context->method('getConn')->willReturn($connection);
+            $context->method('getLog')->willReturn($logger);
+
+            $hookPayload = [
+                'count' => 1,
+                'hooks' => [
+                    [
+                        'id' => 'hook-sub',
+                        'eventTypes' => ['APPLICATION_SUBSCRIPTION_END'],
+                        'deliveryUrl' => 'https://example.test/webhooks',
+                        'businessId' => 'business-123',
+                        'applicationId' => 'urn:aid:' . ConfigApp::$appId,
+                        'status' => 'ACTIVE',
+                        'createdAt' => '2024-01-01T00:00:00Z',
+                        'updatedAt' => '2024-01-01T00:00:00Z',
+                    ],
+                ],
+            ];
+
+            $httpClient = $this->createMock(ClientInterface::class);
+            $httpClient
+                ->expects($this->exactly(4))
+                ->method('get')
+                ->withConsecutive(
+                    [
+                        WebhookService::POYNT_WEBHOOK_URL,
+                        [
+                            'headers' => ['Authorization' => 'Bearer app-token'],
+                            'query' => ['businessId' => 'business-123'],
+                        ],
+                    ],
+                    [
+                        WebhookService::POYNT_WEBHOOK_URL,
+                        [
+                            'headers' => ['Authorization' => 'Bearer app-token'],
+                            'query' => ['businessId' => ConfigApp::$orgId],
+                        ],
+                    ],
+                    [
+                        'https://services.poynt.net/businesses/business-123/deliveries',
+                        ['headers' => ['Authorization' => 'Bearer merchant-token']],
+                    ],
+                    [
+                        'https://services.poynt.net/businesses/' . ConfigApp::$orgId . '/deliveries',
+                        ['headers' => ['Authorization' => 'Bearer merchant-token']],
+                    ]
+                )
+                ->willReturnOnConsecutiveCalls(
+                    new Response(200, [], json_encode(['hooks' => []])),
+                    new Response(200, [], json_encode($hookPayload)),
+                    new Response(200, [], json_encode(['deliveries' => []])),
+                    new Response(200, [], json_encode(['deliveries' => []]))
+                );
+
+            $service = new WebhookService($context, 'business-123', $httpClient);
+
+            $result = $service->fetchByBusinessId('business-123');
+
+            $this->assertIsArray($result);
+            $this->assertCount(1, $result);
+            $this->assertSame('hook-sub', $result[0]['id']);
+            $this->assertSame(ConfigApp::$orgId, $result[0]['businessId']);
+        }
+
+        public function testDeleteAllByBusinessIdUsesHookSpecificBusinessIds(): void
+        {
+            ConfigApp::$orgId = 'org-789';
+
+            $logger = $this->createMock(Logger::class);
+            $logger->method('info');
+            $logger->method('error');
+            $logger->method('warning');
+
+            $connection = $this->getMockBuilder(Connection::class)
+                ->onlyMethods(['fetchAssociative', 'isTransactionActive', 'isRollbackOnly'])
+                ->getMock();
+            $connection->method('isTransactionActive')->willReturn(false);
+            $connection->method('isRollbackOnly')->willReturn(false);
+            $connection
+                ->expects($this->once())
+                ->method('fetchAssociative')
+                ->with($this->isType('string'), ['biz' => 'business-123'])
+                ->willReturn(['access_token' => 'merchant-token']);
+
+            $context = $this->createMock(Context::class);
+            $context->method('getConn')->willReturn($connection);
+            $context->method('getLog')->willReturn($logger);
+
+            $httpClient = $this->createMock(ClientInterface::class);
+            $httpClient
+                ->expects($this->exactly(2))
+                ->method('delete')
+                ->withConsecutive(
+                    [
+                        WebhookService::POYNT_WEBHOOK_URL . '/hook-business',
+                        [
+                            'headers' => ['Authorization' => 'Bearer merchant-token'],
+                            'query' => ['businessId' => 'business-123'],
+                        ],
+                    ],
+                    [
+                        WebhookService::POYNT_WEBHOOK_URL . '/hook-org',
+                        [
+                            'headers' => ['Authorization' => 'Bearer merchant-token'],
+                            'query' => ['businessId' => ConfigApp::$orgId],
+                        ],
+                    ]
+                );
+
+            $service = $this->getMockBuilder(WebhookService::class)
+                ->setConstructorArgs([$context, 'business-123', $httpClient])
+                ->onlyMethods(['fetchByBusinessId'])
+                ->getMock();
+
+            $service
+                ->expects($this->once())
+                ->method('fetchByBusinessId')
+                ->with('business-123')
+                ->willReturn([
+                    [
+                        'id' => 'hook-business',
+                        'businessId' => 'business-123',
+                        'eventTypes' => ['ORDER_COMPLETED'],
+                    ],
+                    [
+                        'id' => 'hook-org',
+                        'eventTypes' => ['APPLICATION_SUBSCRIPTION_START'],
+                    ],
+                ]);
+
+            $result = $service->deleteAllByBusinessId('business-123');
+
+            $this->assertTrue($result);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- ensure delivery fetches for subscription hooks query the organization scope alongside the merchant business
- normalise fetched subscription hooks so their businessId reflects the configured organization id
- adjust webhook service tests to cover the organization identifier overrides

## Testing
- php -l app/Services/WebhookService.php
- php -l tests/Services/WebhookServiceTest.php


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691484e439188329adecd4c90e2856da)