### PR TITLE
Enhance catalog webhook sync

### DIFF
--- a/SQL/poynt-v2.sql
+++ b/SQL/poynt-v2.sql
@@ -455,6 +455,7 @@ CREATE TABLE catalog (
   business_id     VARCHAR(255) NOT NULL,
   name            VARCHAR(255),
   device_id       VARCHAR(255),
+  metadata        JSONB NOT NULL DEFAULT '{}',
   raw_payload     JSONB NOT NULL DEFAULT '{}',
   created_at_ext  TIMESTAMPTZ,
   updated_at_ext  TIMESTAMPTZ,
@@ -502,6 +503,33 @@ CREATE TABLE IF NOT EXISTS catalog_available_discount (
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     PRIMARY KEY (catalog_id, discount_id)
+);
+
+CREATE TABLE IF NOT EXISTS category_product (
+    catalog_id VARCHAR(255) NOT NULL,
+    category_id VARCHAR(255) NOT NULL,
+    product_id VARCHAR(255) NOT NULL,
+    business_id VARCHAR(255) NOT NULL,
+    position INTEGER,
+    payload JSONB NOT NULL DEFAULT '{}',
+    created_at_ext TIMESTAMPTZ,
+    updated_at_ext TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (catalog_id, category_id, product_id)
+);
+
+CREATE TABLE IF NOT EXISTS category_tax (
+    catalog_id VARCHAR(255) NOT NULL,
+    category_id VARCHAR(255) NOT NULL,
+    tax_id VARCHAR(255) NOT NULL,
+    business_id VARCHAR(255) NOT NULL,
+    payload JSONB NOT NULL DEFAULT '{}',
+    created_at_ext TIMESTAMPTZ,
+    updated_at_ext TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (catalog_id, category_id, tax_id)
 );
 
 -- Source (GET): /businesses/{businessId}/categories

--- a/app/Services/CatalogService.php
+++ b/app/Services/CatalogService.php
@@ -5,6 +5,7 @@ namespace App\Services;
 use App\Core\Context;
 use App\Services\Support\FetchResponseLogger;
 use App\Services\Support\PoyntDataFormatter as Format;
+use Doctrine\DBAL\Connection;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\GuzzleException;
 
@@ -45,6 +46,8 @@ class CatalogService
         $name = $catalogData['name'] ?? $catalogData['displayName'] ?? null;
         $deviceId = $catalogData['deviceId'] ?? null;
         $rawPayload = Format::jsonObject($catalogData);
+        $metadataPayload = $this->resolveCatalogMetadata($catalogData);
+        $metadata = Format::jsonObject($metadataPayload);
         $createdAtExt = Format::optionalTimestamp($catalogData['createdAt'] ?? null);
         $updatedAtExt = Format::optionalTimestamp($catalogData['updatedAt'] ?? null);
 
@@ -53,17 +56,18 @@ class CatalogService
         try {
             $this->context->getConn()->executeStatement(
                 'INSERT INTO catalog (
-                    catalog_id, business_id, name, device_id, raw_payload,
+                    catalog_id, business_id, name, device_id, metadata, raw_payload,
                     created_at_ext, updated_at_ext,
                     created_at, updated_at
                 ) VALUES (
-                    :catalogId, :businessId, :name, :deviceId, :rawPayload,
+                    :catalogId, :businessId, :name, :deviceId, :metadata, :rawPayload,
                     :createdAtExt, :updatedAtExt,
                     :createdAt, :updatedAt
                 ) ON CONFLICT (catalog_id) DO UPDATE SET
                     business_id = EXCLUDED.business_id,
                     name = EXCLUDED.name,
                     device_id = EXCLUDED.device_id,
+                    metadata = EXCLUDED.metadata,
                     raw_payload = EXCLUDED.raw_payload,
                     created_at_ext = EXCLUDED.created_at_ext,
                     updated_at_ext = EXCLUDED.updated_at_ext,
@@ -73,6 +77,7 @@ class CatalogService
                     'businessId' => $businessId,
                     'name' => $name,
                     'deviceId' => $deviceId,
+                    'metadata' => $metadata,
                     'rawPayload' => $rawPayload,
                     'createdAtExt' => $createdAtExt,
                     'updatedAtExt' => $updatedAtExt,
@@ -83,13 +88,13 @@ class CatalogService
 
             $this->context->getLog()->info("CatalogService::upsert: upserted catalog {$catalogId}");
             $products = $this->resolveCatalogProducts($catalogData);
-            if (!empty($products)) {
-                $this->syncCatalogProducts($catalogId, $products);
-            }
+            $this->syncCatalogProducts($catalogId, $products);
             $availableDiscounts = $this->resolveCatalogAvailableDiscounts($catalogData);
             if (!empty($availableDiscounts)) {
                 $this->syncCatalogAvailableDiscounts($catalogId, $availableDiscounts);
             }
+            $categories = $this->resolveCatalogCategories($catalogData);
+            $this->syncCatalogCategories($catalogId, $businessId, $categories);
             return true;
         } catch (\Throwable $e) {
             $this->context->getLog()->error(
@@ -201,6 +206,31 @@ class CatalogService
         return [];
     }
 
+    private function resolveCatalogMetadata(array $catalogData): mixed
+    {
+        if (array_key_exists('displayMetadata', $catalogData)) {
+            return $catalogData['displayMetadata'];
+        }
+
+        if (array_key_exists('metadata', $catalogData)) {
+            return $catalogData['metadata'];
+        }
+
+        if (isset($catalogData['catalog']) && is_array($catalogData['catalog'])) {
+            $inner = $catalogData['catalog'];
+
+            if (array_key_exists('displayMetadata', $inner)) {
+                return $inner['displayMetadata'];
+            }
+
+            if (array_key_exists('metadata', $inner)) {
+                return $inner['metadata'];
+            }
+        }
+
+        return [];
+    }
+
     private function resolveCatalogProducts(array $catalogData): array
     {
         if (isset($catalogData['products']) && is_array($catalogData['products'])) {
@@ -233,25 +263,54 @@ class CatalogService
         return [];
     }
 
+    private function resolveCatalogCategories(array $catalogData): array
+    {
+        if (isset($catalogData['categories']) && is_array($catalogData['categories'])) {
+            return $catalogData['categories'];
+        }
+
+        if (isset($catalogData['catalog']) && is_array($catalogData['catalog'])) {
+            $innerCatalog = $catalogData['catalog'];
+            if (isset($innerCatalog['categories']) && is_array($innerCatalog['categories'])) {
+                return $innerCatalog['categories'];
+            }
+        }
+
+        return [];
+    }
+
     private function syncCatalogProducts(string $catalogId, array $products): void
     {
+        $seenProductIds = [];
+
         foreach ($products as $product) {
-            if (!is_array($product) || !isset($product['id'])) {
+            $productId = null;
+            $payloadSource = $product;
+            $position = null;
+            $createdAtExt = null;
+            $updatedAtExt = null;
+
+            if (is_array($product)) {
+                $productId = $product['id'] ?? $product['productId'] ?? null;
+                $position = $product['position']
+                    ?? $product['displayOrder']
+                    ?? $product['index']
+                    ?? null;
+                $createdAtExt = Format::optionalTimestamp($product['createdAt'] ?? $product['createdAtExt'] ?? null);
+                $updatedAtExt = Format::optionalTimestamp($product['updatedAt'] ?? $product['updatedAtExt'] ?? null);
+            } elseif (is_string($product) || is_int($product)) {
+                $productId = (string) $product;
+                $payloadSource = ['id' => $productId];
+            }
+
+            if ($productId === null || $productId === '') {
                 continue;
             }
 
-            $position = $product['position']
-                ?? $product['displayOrder']
-                ?? $product['index']
-                ?? null;
-            $payload = Format::jsonObject($product);
-            $createdAtExt = Format::optionalTimestamp(
-                $product['createdAt'] ?? $product['createdAtExt'] ?? null
-            );
-            $updatedAtExt = Format::optionalTimestamp(
-                $product['updatedAt'] ?? $product['updatedAtExt'] ?? null
-            );
+            $productId = (string) $productId;
+            $seenProductIds[] = $productId;
 
+            $payload = Format::jsonObject($payloadSource);
             $now = (new \DateTimeImmutable('now'))->format('Y-m-d H:i:sP');
 
             try {
@@ -282,7 +341,7 @@ class CatalogService
                         updated_at = EXCLUDED.updated_at',
                     [
                         'catalogId' => $catalogId,
-                        'productId' => $product['id'],
+                        'productId' => $productId,
                         'position'  => $position,
                         'payload'   => $payload,
                         'createdAtExt' => $createdAtExt,
@@ -291,33 +350,41 @@ class CatalogService
                         'updatedAt' => $now,
                     ]
                 );
-
-                $taxes = [];
-                if (isset($product['taxes']) && is_array($product['taxes'])) {
-                    $taxes = $product['taxes'];
-                }
-
-                if (!empty($taxes)) {
-                    $this->syncCatalogProductTaxes($catalogId, $product['id'], $taxes);
-                } else {
-                    $this->purgeCatalogProductTaxes($catalogId, $product['id']);
-                }
             } catch (\Throwable $e) {
                 $this->context->getLog()->error(
-                    sprintf('CatalogService::syncCatalogProducts: failed for catalog %s product %s: %s', $catalogId, $product['id'], $e->getMessage())
+                    sprintf('CatalogService::syncCatalogProducts: failed for catalog %s product %s: %s', $catalogId, $productId, $e->getMessage())
                 );
             }
+
+            $taxes = [];
+            if (is_array($product) && isset($product['taxes']) && is_array($product['taxes'])) {
+                $taxes = $product['taxes'];
+            }
+
+            if (!empty($taxes)) {
+                $this->syncCatalogProductTaxes($catalogId, $productId, $taxes);
+            } else {
+                $this->purgeCatalogProductTaxes($catalogId, $productId);
+            }
         }
+
+        $this->purgeMissingCatalogProducts($catalogId, array_values(array_unique($seenProductIds)));
     }
 
     private function syncCatalogProductTaxes(string $catalogId, string $productId, array $taxes): void
     {
+        $seenTaxIds = [];
+
         foreach ($taxes as $tax) {
             $taxId = null;
             $payloadSource = $tax;
+            $createdAtExt = null;
+            $updatedAtExt = null;
 
             if (is_array($tax)) {
                 $taxId = $tax['id'] ?? $tax['taxId'] ?? null;
+                $createdAtExt = Format::optionalTimestamp($tax['createdAt'] ?? $tax['createdAtExt'] ?? null);
+                $updatedAtExt = Format::optionalTimestamp($tax['updatedAt'] ?? $tax['updatedAtExt'] ?? null);
             } elseif (is_string($tax) || is_int($tax)) {
                 $taxId = (string) $tax;
                 $payloadSource = ['id' => $taxId];
@@ -327,13 +394,10 @@ class CatalogService
                 continue;
             }
 
+            $taxId = (string) $taxId;
+            $seenTaxIds[] = $taxId;
+
             $payload = Format::jsonObject($payloadSource);
-            $createdAtExt = Format::optionalTimestamp(
-                is_array($payloadSource) ? ($payloadSource['createdAt'] ?? $payloadSource['createdAtExt'] ?? null) : null
-            );
-            $updatedAtExt = Format::optionalTimestamp(
-                is_array($payloadSource) ? ($payloadSource['updatedAt'] ?? $payloadSource['updatedAtExt'] ?? null) : null
-            );
             $now = (new \DateTimeImmutable('now'))->format('Y-m-d H:i:sP');
 
             try {
@@ -384,16 +448,34 @@ class CatalogService
                 );
             }
         }
+
+        $this->purgeCatalogProductTaxes($catalogId, $productId, array_values(array_unique($seenTaxIds)));
     }
 
-    private function purgeCatalogProductTaxes(string $catalogId, string $productId): void
+    private function purgeCatalogProductTaxes(string $catalogId, string $productId, array $keepTaxIds = []): void
     {
         try {
+            if (empty($keepTaxIds)) {
+                $this->context->getConn()->executeStatement(
+                    'DELETE FROM catalog_product_tax WHERE catalog_id = :catalogId AND product_id = :productId',
+                    [
+                        'catalogId' => $catalogId,
+                        'productId' => $productId,
+                    ]
+                );
+
+                return;
+            }
+
             $this->context->getConn()->executeStatement(
-                'DELETE FROM catalog_product_tax WHERE catalog_id = :catalogId AND product_id = :productId',
+                'DELETE FROM catalog_product_tax WHERE catalog_id = :catalogId AND product_id = :productId AND tax_id NOT IN (:taxIds)',
                 [
                     'catalogId' => $catalogId,
                     'productId' => $productId,
+                    'taxIds' => $keepTaxIds,
+                ],
+                [
+                    'taxIds' => Connection::PARAM_STR_ARRAY,
                 ]
             );
         } catch (\Throwable $e) {
@@ -450,6 +532,392 @@ class CatalogService
                     sprintf('CatalogService::syncCatalogAvailableDiscounts: failed for catalog %s discount %s: %s', $catalogId, $discountId, $e->getMessage())
                 );
             }
+        }
+    }
+
+    private function syncCatalogCategories(string $catalogId, string $businessId, array $categories): void
+    {
+        $categoryService = new CategoryService($this->context);
+        $taxService = new TaxService($this->context);
+        $seenCategoryIds = [];
+
+        if (empty($categories)) {
+            $this->purgeMissingCategoryRelations($catalogId, []);
+
+            return;
+        }
+
+        foreach ($categories as $category) {
+            if (!is_array($category) || !isset($category['id'])) {
+                continue;
+            }
+
+            $categoryId = (string) $category['id'];
+            if (!isset($category['businessId'])) {
+                $category['businessId'] = $businessId;
+            }
+
+            $seenCategoryIds[] = $categoryId;
+
+            if (!$categoryService->upsert($category)) {
+                $this->context->getLog()->warning(
+                    sprintf('CatalogService::syncCatalogCategories: failed to upsert category %s for catalog %s', $categoryId, $catalogId)
+                );
+            }
+
+            $categoryProducts = $this->resolveCategoryProducts($category);
+            $this->syncCategoryProducts($catalogId, $categoryId, $businessId, $categoryProducts);
+
+            $categoryTaxes = $this->resolveCategoryTaxes($category);
+            $this->syncCategoryTaxes($catalogId, $categoryId, $businessId, $categoryTaxes, $taxService);
+        }
+
+        $this->purgeMissingCategoryRelations($catalogId, array_values(array_unique($seenCategoryIds)));
+    }
+
+    private function resolveCategoryProducts(array $category): array
+    {
+        if (isset($category['products']) && is_array($category['products'])) {
+            return $category['products'];
+        }
+
+        return [];
+    }
+
+    private function resolveCategoryTaxes(array $category): array
+    {
+        if (isset($category['taxes']) && is_array($category['taxes'])) {
+            return $category['taxes'];
+        }
+
+        return [];
+    }
+
+    private function syncCategoryProducts(string $catalogId, string $categoryId, string $businessId, array $products): void
+    {
+        $conn = $this->context->getConn();
+        $seenProductIds = [];
+
+        foreach ($products as $product) {
+            $productId = null;
+            $payloadSource = $product;
+            $position = null;
+            $createdAtExt = null;
+            $updatedAtExt = null;
+
+            if (is_array($product)) {
+                $productId = $product['id'] ?? $product['productId'] ?? null;
+                $position = $product['position']
+                    ?? $product['displayOrder']
+                    ?? $product['index']
+                    ?? null;
+                $createdAtExt = Format::optionalTimestamp($product['createdAt'] ?? $product['createdAtExt'] ?? null);
+                $updatedAtExt = Format::optionalTimestamp($product['updatedAt'] ?? $product['updatedAtExt'] ?? null);
+            } elseif (is_string($product) || is_int($product)) {
+                $productId = (string) $product;
+                $payloadSource = ['id' => $productId];
+            }
+
+            if ($productId === null || $productId === '') {
+                continue;
+            }
+
+            $productId = (string) $productId;
+            $seenProductIds[] = $productId;
+            $payload = Format::jsonObject($payloadSource);
+            $now = (new \DateTimeImmutable('now'))->format('Y-m-d H:i:sP');
+
+            try {
+                $conn->executeStatement(
+                    'INSERT INTO category_product (
+                        catalog_id,
+                        category_id,
+                        product_id,
+                        business_id,
+                        position,
+                        payload,
+                        created_at_ext,
+                        updated_at_ext,
+                        created_at,
+                        updated_at
+                    ) VALUES (
+                        :catalogId,
+                        :categoryId,
+                        :productId,
+                        :businessId,
+                        :position,
+                        :payload,
+                        :createdAtExt,
+                        :updatedAtExt,
+                        :createdAt,
+                        :updatedAt
+                    ) ON CONFLICT (catalog_id, category_id, product_id) DO UPDATE SET
+                        position = EXCLUDED.position,
+                        payload = EXCLUDED.payload,
+                        created_at_ext = EXCLUDED.created_at_ext,
+                        updated_at_ext = EXCLUDED.updated_at_ext,
+                        updated_at = EXCLUDED.updated_at',
+                    [
+                        'catalogId' => $catalogId,
+                        'categoryId' => $categoryId,
+                        'productId' => $productId,
+                        'businessId' => $businessId,
+                        'position' => $position,
+                        'payload' => $payload,
+                        'createdAtExt' => $createdAtExt,
+                        'updatedAtExt' => $updatedAtExt,
+                        'createdAt' => $now,
+                        'updatedAt' => $now,
+                    ]
+                );
+            } catch (\Throwable $e) {
+                $this->context->getLog()->error(
+                    sprintf('CatalogService::syncCategoryProducts: failed for catalog %s category %s product %s: %s', $catalogId, $categoryId, $productId, $e->getMessage())
+                );
+            }
+        }
+
+        $this->purgeMissingCategoryProducts($catalogId, $categoryId, array_values(array_unique($seenProductIds)));
+    }
+
+    private function syncCategoryTaxes(string $catalogId, string $categoryId, string $businessId, array $taxes, TaxService $taxService): void
+    {
+        $conn = $this->context->getConn();
+        $seenTaxIds = [];
+
+        foreach ($taxes as $tax) {
+            $taxId = null;
+            $payloadSource = $tax;
+            $createdAtExt = null;
+            $updatedAtExt = null;
+
+            if (is_array($tax)) {
+                $taxId = $tax['id'] ?? $tax['taxId'] ?? null;
+                if (!isset($tax['businessId'])) {
+                    $tax['businessId'] = $businessId;
+                }
+                $payloadSource = $tax;
+                $createdAtExt = Format::optionalTimestamp($tax['createdAt'] ?? $tax['createdAtExt'] ?? null);
+                $updatedAtExt = Format::optionalTimestamp($tax['updatedAt'] ?? $tax['updatedAtExt'] ?? null);
+            } elseif (is_string($tax) || is_int($tax)) {
+                $taxId = (string) $tax;
+                $payloadSource = ['id' => $taxId, 'businessId' => $businessId];
+            }
+
+            if ($taxId === null || $taxId === '') {
+                continue;
+            }
+
+            $taxId = (string) $taxId;
+            $seenTaxIds[] = $taxId;
+
+            if (is_array($tax)) {
+                $taxService->upsert($tax);
+            }
+
+            $payload = Format::jsonObject($payloadSource);
+            $now = (new \DateTimeImmutable('now'))->format('Y-m-d H:i:sP');
+
+            try {
+                $conn->executeStatement(
+                    'INSERT INTO category_tax (
+                        catalog_id,
+                        category_id,
+                        tax_id,
+                        business_id,
+                        payload,
+                        created_at_ext,
+                        updated_at_ext,
+                        created_at,
+                        updated_at
+                    ) VALUES (
+                        :catalogId,
+                        :categoryId,
+                        :taxId,
+                        :businessId,
+                        :payload,
+                        :createdAtExt,
+                        :updatedAtExt,
+                        :createdAt,
+                        :updatedAt
+                    ) ON CONFLICT (catalog_id, category_id, tax_id) DO UPDATE SET
+                        payload = EXCLUDED.payload,
+                        created_at_ext = EXCLUDED.created_at_ext,
+                        updated_at_ext = EXCLUDED.updated_at_ext,
+                        updated_at = EXCLUDED.updated_at',
+                    [
+                        'catalogId' => $catalogId,
+                        'categoryId' => $categoryId,
+                        'taxId' => $taxId,
+                        'businessId' => $businessId,
+                        'payload' => $payload,
+                        'createdAtExt' => $createdAtExt,
+                        'updatedAtExt' => $updatedAtExt,
+                        'createdAt' => $now,
+                        'updatedAt' => $now,
+                    ]
+                );
+            } catch (\Throwable $e) {
+                $this->context->getLog()->error(
+                    sprintf('CatalogService::syncCategoryTaxes: failed for catalog %s category %s tax %s: %s', $catalogId, $categoryId, $taxId, $e->getMessage())
+                );
+            }
+        }
+
+        $this->purgeMissingCategoryTaxes($catalogId, $categoryId, array_values(array_unique($seenTaxIds)));
+    }
+
+    private function purgeMissingCatalogProducts(string $catalogId, array $productIds): void
+    {
+        try {
+            if (empty($productIds)) {
+                $this->context->getConn()->executeStatement(
+                    'DELETE FROM catalog_product WHERE catalog_id = :catalogId',
+                    ['catalogId' => $catalogId]
+                );
+                $this->context->getConn()->executeStatement(
+                    'DELETE FROM catalog_product_tax WHERE catalog_id = :catalogId',
+                    ['catalogId' => $catalogId]
+                );
+
+                return;
+            }
+
+            $this->context->getConn()->executeStatement(
+                'DELETE FROM catalog_product WHERE catalog_id = :catalogId AND product_id NOT IN (:productIds)',
+                [
+                    'catalogId' => $catalogId,
+                    'productIds' => $productIds,
+                ],
+                [
+                    'productIds' => Connection::PARAM_STR_ARRAY,
+                ]
+            );
+
+            $this->context->getConn()->executeStatement(
+                'DELETE FROM catalog_product_tax WHERE catalog_id = :catalogId AND product_id NOT IN (:productIds)',
+                [
+                    'catalogId' => $catalogId,
+                    'productIds' => $productIds,
+                ],
+                [
+                    'productIds' => Connection::PARAM_STR_ARRAY,
+                ]
+            );
+        } catch (\Throwable $e) {
+            $this->context->getLog()->error(
+                sprintf('CatalogService::purgeMissingCatalogProducts: failed for catalog %s: %s', $catalogId, $e->getMessage())
+            );
+        }
+    }
+
+    private function purgeMissingCategoryProducts(string $catalogId, string $categoryId, array $productIds): void
+    {
+        try {
+            if (empty($productIds)) {
+                $this->context->getConn()->executeStatement(
+                    'DELETE FROM category_product WHERE catalog_id = :catalogId AND category_id = :categoryId',
+                    [
+                        'catalogId' => $catalogId,
+                        'categoryId' => $categoryId,
+                    ]
+                );
+
+                return;
+            }
+
+            $this->context->getConn()->executeStatement(
+                'DELETE FROM category_product WHERE catalog_id = :catalogId AND category_id = :categoryId AND product_id NOT IN (:productIds)',
+                [
+                    'catalogId' => $catalogId,
+                    'categoryId' => $categoryId,
+                    'productIds' => $productIds,
+                ],
+                [
+                    'productIds' => Connection::PARAM_STR_ARRAY,
+                ]
+            );
+        } catch (\Throwable $e) {
+            $this->context->getLog()->error(
+                sprintf('CatalogService::purgeMissingCategoryProducts: failed for catalog %s category %s: %s', $catalogId, $categoryId, $e->getMessage())
+            );
+        }
+    }
+
+    private function purgeMissingCategoryTaxes(string $catalogId, string $categoryId, array $taxIds): void
+    {
+        try {
+            if (empty($taxIds)) {
+                $this->context->getConn()->executeStatement(
+                    'DELETE FROM category_tax WHERE catalog_id = :catalogId AND category_id = :categoryId',
+                    [
+                        'catalogId' => $catalogId,
+                        'categoryId' => $categoryId,
+                    ]
+                );
+
+                return;
+            }
+
+            $this->context->getConn()->executeStatement(
+                'DELETE FROM category_tax WHERE catalog_id = :catalogId AND category_id = :categoryId AND tax_id NOT IN (:taxIds)',
+                [
+                    'catalogId' => $catalogId,
+                    'categoryId' => $categoryId,
+                    'taxIds' => $taxIds,
+                ],
+                [
+                    'taxIds' => Connection::PARAM_STR_ARRAY,
+                ]
+            );
+        } catch (\Throwable $e) {
+            $this->context->getLog()->error(
+                sprintf('CatalogService::purgeMissingCategoryTaxes: failed for catalog %s category %s: %s', $catalogId, $categoryId, $e->getMessage())
+            );
+        }
+    }
+
+    private function purgeMissingCategoryRelations(string $catalogId, array $categoryIds): void
+    {
+        try {
+            if (empty($categoryIds)) {
+                $this->context->getConn()->executeStatement(
+                    'DELETE FROM category_product WHERE catalog_id = :catalogId',
+                    ['catalogId' => $catalogId]
+                );
+                $this->context->getConn()->executeStatement(
+                    'DELETE FROM category_tax WHERE catalog_id = :catalogId',
+                    ['catalogId' => $catalogId]
+                );
+
+                return;
+            }
+
+            $this->context->getConn()->executeStatement(
+                'DELETE FROM category_product WHERE catalog_id = :catalogId AND category_id NOT IN (:categoryIds)',
+                [
+                    'catalogId' => $catalogId,
+                    'categoryIds' => $categoryIds,
+                ],
+                [
+                    'categoryIds' => Connection::PARAM_STR_ARRAY,
+                ]
+            );
+
+            $this->context->getConn()->executeStatement(
+                'DELETE FROM category_tax WHERE catalog_id = :catalogId AND category_id NOT IN (:categoryIds)',
+                [
+                    'catalogId' => $catalogId,
+                    'categoryIds' => $categoryIds,
+                ],
+                [
+                    'categoryIds' => Connection::PARAM_STR_ARRAY,
+                ]
+            );
+        } catch (\Throwable $e) {
+            $this->context->getLog()->error(
+                sprintf('CatalogService::purgeMissingCategoryRelations: failed for catalog %s: %s', $catalogId, $e->getMessage())
+            );
         }
     }
 }

--- a/app/Services/Support/WebhookResourceFetcher.php
+++ b/app/Services/Support/WebhookResourceFetcher.php
@@ -32,6 +32,17 @@ class WebhookResourceFetcher
         $resource = $this->normalizeResourceKey($payload['resource'] ?? $this->inferResourceFromEvent($payload['eventType'] ?? ''));
         $resourceId = $this->resolveResourceId($payload);
         $businessId = $this->extractBusinessId($payload);
+        $eventType = (string)($payload['eventType'] ?? '');
+
+        $normalizedResource = $resource !== null ? strtolower(trim($resource, '/')) : null;
+        $isCatalogResource = $normalizedResource === 'catalog' || $normalizedResource === 'catalogs' || str_starts_with(strtoupper($eventType), 'CATALOG_');
+
+        if ($isCatalogResource) {
+            $catalog = $this->getFullCatalog($payload, $resourceId, $businessId, $eventType);
+            if ($catalog !== null) {
+                return $catalog;
+            }
+        }
 
         if ($resource !== null) {
             $embedded = $this->extractEmbeddedEntity($payload, $resource, $resourceId);
@@ -49,7 +60,6 @@ class WebhookResourceFetcher
             return null;
         }
 
-        $eventType = (string)($payload['eventType'] ?? '');
         $bearer = $this->resolveAuthToken($href, $eventType, $businessId);
         if ($bearer === null) {
             $this->logger->warning('WebhookResourceFetcher: unable to resolve auth token', [
@@ -62,7 +72,162 @@ class WebhookResourceFetcher
             return null;
         }
 
-        return $this->httpGetJson($href, $bearer);
+        $response = $this->requestJson($href, $bearer);
+
+        return $response['status'] === 200 ? $response['data'] : null;
+    }
+
+    private function getFullCatalog(array $payload, ?string $resourceId, ?string $businessId, string $eventType): ?array
+    {
+        $embedded = $this->extractEmbeddedEntity($payload, 'catalog', $resourceId);
+        if ($embedded !== null) {
+            return $this->normalizeCatalogPayload($embedded, $payload, $resourceId, $businessId);
+        }
+
+        $href = $this->findResourceHref($payload);
+        if ($href === null && $resourceId !== null) {
+            $href = $this->buildCatalogFallbackUrl($resourceId, $businessId);
+        }
+
+        if ($href === null) {
+            return null;
+        }
+
+        $catalog = $this->fetchCatalogFromUrl($href, $eventType, $businessId);
+        if ($catalog === null) {
+            return null;
+        }
+
+        return $this->normalizeCatalogPayload($catalog, $payload, $resourceId, $businessId);
+    }
+
+    private function buildCatalogFallbackUrl(string $catalogId, ?string $businessId): ?string
+    {
+        if ($businessId !== null && $businessId !== '') {
+            return sprintf('%s/businesses/%s/catalogs/%s', self::POYNT_BASE_URL, $businessId, $catalogId);
+        }
+
+        return sprintf('%s/catalogs/%s', self::POYNT_BASE_URL, $catalogId);
+    }
+
+    private function fetchCatalogFromUrl(string $url, string $eventType, ?string $businessId): ?array
+    {
+        $isMerchantScoped = $this->isMerchantScopedUrl($url);
+
+        if ($isMerchantScoped && $businessId !== null) {
+            $merchantToken = $this->loadMerchantToken($businessId);
+            if ($merchantToken !== null) {
+                $response = $this->requestJson($url, $merchantToken);
+                if ($response['status'] === 200) {
+                    return $response['data'];
+                }
+
+                if ($response['status'] === 401 || $response['status'] === 403) {
+                    $appToken = $this->loadAppToken($businessId);
+                    if ($appToken !== null) {
+                        $retry = $this->requestJson($url, $appToken);
+                        if ($retry['status'] === 200) {
+                            return $retry['data'];
+                        }
+                    }
+
+                    return null;
+                }
+
+                if ($response['status'] === 200) {
+                    return null;
+                }
+            } else {
+                $this->logger->warning('WebhookResourceFetcher: merchant token unavailable for catalog fetch', [
+                    'businessId' => $businessId,
+                    'url' => $url,
+                ]);
+
+                $appToken = $this->loadAppToken($businessId);
+                if ($appToken !== null) {
+                    $response = $this->requestJson($url, $appToken);
+                    if ($response['status'] === 200) {
+                        return $response['data'];
+                    }
+                }
+
+                return null;
+            }
+
+            return null;
+        }
+
+        $bearer = $this->resolveAuthToken($url, $eventType, $businessId);
+        if ($bearer === null) {
+            $this->logger->warning('WebhookResourceFetcher: unable to resolve auth token', [
+                'businessId' => $businessId,
+                'eventType' => $eventType,
+                'url' => $url,
+            ]);
+
+            return null;
+        }
+
+        $response = $this->requestJson($url, $bearer);
+
+        return $response['status'] === 200 ? $response['data'] : null;
+    }
+
+    private function normalizeCatalogPayload(array $catalogPayload, array $fullPayload, ?string $resourceId, ?string $businessId): array
+    {
+        $catalog = $catalogPayload;
+
+        if (isset($catalogPayload['catalog']) && is_array($catalogPayload['catalog'])) {
+            $catalog = $catalogPayload['catalog'];
+            $catalog = $this->mergeCatalogCollections($catalog, $catalogPayload);
+        }
+
+        if (isset($fullPayload['catalog']) && is_array($fullPayload['catalog']) && empty($catalog)) {
+            $catalog = $fullPayload['catalog'];
+        }
+
+        if (!isset($catalog['products']) && isset($catalogPayload['products']) && is_array($catalogPayload['products'])) {
+            $catalog['products'] = $catalogPayload['products'];
+        }
+
+        if (!isset($catalog['categories']) && isset($catalogPayload['categories']) && is_array($catalogPayload['categories'])) {
+            $catalog['categories'] = $catalogPayload['categories'];
+        }
+
+        if (!isset($catalog['displayMetadata']) && isset($catalogPayload['displayMetadata'])) {
+            $catalog['displayMetadata'] = $catalogPayload['displayMetadata'];
+        }
+
+        if (!isset($catalog['taxes']) && isset($catalogPayload['taxes']) && is_array($catalogPayload['taxes'])) {
+            $catalog['taxes'] = $catalogPayload['taxes'];
+        }
+
+        if (!isset($catalog['availableDiscounts']) && isset($catalogPayload['availableDiscounts']) && is_array($catalogPayload['availableDiscounts'])) {
+            $catalog['availableDiscounts'] = $catalogPayload['availableDiscounts'];
+        }
+
+        $catalog = $this->mergeCatalogCollections($catalog, $fullPayload);
+
+        if ($resourceId !== null && !isset($catalog['id'])) {
+            $catalog['id'] = $resourceId;
+        }
+
+        if ($businessId !== null && !isset($catalog['businessId'])) {
+            $catalog['businessId'] = $businessId;
+        }
+
+        return $catalog;
+    }
+
+    private function mergeCatalogCollections(array $catalog, array $wrapper): array
+    {
+        foreach (['products', 'categories', 'displayMetadata', 'taxes', 'availableDiscounts'] as $key) {
+            if (!isset($catalog[$key]) && isset($wrapper[$key])) {
+                $catalog[$key] = $wrapper[$key];
+            }
+        }
+
+        return $catalog;
     }
 
     private function extractEmbeddedEntity(array $payload, string $resource, ?string $resourceId): ?array
@@ -357,6 +522,16 @@ class WebhookResourceFetcher
 
     public function httpGetJson(string $url, string $bearer): ?array
     {
+        $response = $this->requestJson($url, $bearer);
+
+        return $response['status'] === 200 ? $response['data'] : null;
+    }
+
+    /**
+     * @return array{status:int,data:?array}
+     */
+    private function requestJson(string $url, string $bearer): array
+    {
         $attempt = 0;
         $options = [
             'headers' => [
@@ -373,11 +548,11 @@ class WebhookResourceFetcher
             } catch (GuzzleException $exception) {
                 $this->logger->error('WebhookResourceFetcher: HTTP request failed', [
                     'url' => $url,
-                    'attempt' => $attempt + 1,
+                    'attempt' => $attempt,
                     'error' => $exception->getMessage(),
                 ]);
 
-                return null;
+                break;
             }
 
             $status = $response->getStatusCode();
@@ -385,7 +560,7 @@ class WebhookResourceFetcher
                 $body = (string) $response->getBody();
                 $decoded = json_decode($body, true);
                 if (is_array($decoded)) {
-                    return $decoded;
+                    return ['status' => 200, 'data' => $decoded];
                 }
 
                 $this->logger->error('WebhookResourceFetcher: invalid JSON response', [
@@ -394,7 +569,7 @@ class WebhookResourceFetcher
                     'body' => $body,
                 ]);
 
-                return null;
+                return ['status' => 200, 'data' => null];
             }
 
             if ($status === 404) {
@@ -402,7 +577,7 @@ class WebhookResourceFetcher
                     'url' => $url,
                 ]);
 
-                return null;
+                return ['status' => 404, 'data' => null];
             }
 
             if ($status === 401 || $status === 403) {
@@ -411,7 +586,7 @@ class WebhookResourceFetcher
                     'status' => $status,
                 ]);
 
-                return null;
+                return ['status' => $status, 'data' => null];
             }
 
             if ($status === 429) {
@@ -434,9 +609,9 @@ class WebhookResourceFetcher
                 'status' => $status,
             ]);
 
-            return null;
+            return ['status' => $status, 'data' => null];
         }
 
-        return null;
+        return ['status' => 0, 'data' => null];
     }
 }

--- a/database/migrations/20241128000000_update_catalog_relationships.sql
+++ b/database/migrations/20241128000000_update_catalog_relationships.sql
@@ -1,0 +1,29 @@
+ALTER TABLE catalog
+    ADD COLUMN IF NOT EXISTS metadata JSONB NOT NULL DEFAULT '{}';
+
+CREATE TABLE IF NOT EXISTS category_product (
+    catalog_id VARCHAR(255) NOT NULL,
+    category_id VARCHAR(255) NOT NULL,
+    product_id VARCHAR(255) NOT NULL,
+    business_id VARCHAR(255) NOT NULL,
+    position INTEGER,
+    payload JSONB NOT NULL DEFAULT '{}',
+    created_at_ext TIMESTAMPTZ,
+    updated_at_ext TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (catalog_id, category_id, product_id)
+);
+
+CREATE TABLE IF NOT EXISTS category_tax (
+    catalog_id VARCHAR(255) NOT NULL,
+    category_id VARCHAR(255) NOT NULL,
+    tax_id VARCHAR(255) NOT NULL,
+    business_id VARCHAR(255) NOT NULL,
+    payload JSONB NOT NULL DEFAULT '{}',
+    created_at_ext TIMESTAMPTZ,
+    updated_at_ext TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (catalog_id, category_id, tax_id)
+);

--- a/tests/Services/CatalogServiceTest.php
+++ b/tests/Services/CatalogServiceTest.php
@@ -26,6 +26,9 @@ namespace Services {
         /** @var Connection&\PHPUnit\Framework\MockObject\MockObject */
         private Connection $connection;
 
+        /** @var array<int, array{sql:string,params:array,types:array}> */
+        private array $executedStatements;
+
         protected function setUp(): void
         {
             parent::setUp();
@@ -37,6 +40,19 @@ namespace Services {
             $logger->pushHandler($this->testHandler);
 
             $this->context = new Context($api, $this->connection, $logger);
+            $this->executedStatements = [];
+
+            $this->connection
+                ->method('executeStatement')
+                ->willReturnCallback(function (string $sql, array $params = [], array $types = []) {
+                    $this->executedStatements[] = [
+                        'sql' => $sql,
+                        'params' => $params,
+                        'types' => $types,
+                    ];
+
+                    return 1;
+                });
         }
 
         public function testUpsertPersistsAvailableDiscounts(): void
@@ -51,34 +67,25 @@ namespace Services {
 
             $expectedPayload = Format::jsonObject($catalogData['availableDiscounts'][0]);
 
-            $this->connection
-                ->expects($this->exactly(2))
-                ->method('executeStatement')
-                ->withConsecutive(
-                    [
-                        $this->stringContains('INSERT INTO catalog'),
-                        $this->arrayHasKey('catalogId'),
-                    ],
-                    [
-                        $this->stringContains('INSERT INTO catalog_available_discount'),
-                        $this->callback(function (array $params) use ($expectedPayload): bool {
-                            self::assertSame('catalog-1', $params['catalogId']);
-                            self::assertSame('discount-1', $params['discountId']);
-                            self::assertSame($expectedPayload, $params['payload']);
-
-                            return true;
-                        }),
-                    ],
-                )
-                ->willReturnOnConsecutiveCalls(1, 1);
-
             $service = new CatalogService($this->context, null, $this->createMock(ClientInterface::class));
 
             self::assertTrue($service->upsert($catalogData));
+
+            $catalogInsert = $this->findStatement('INSERT INTO catalog');
+            self::assertNotNull($catalogInsert);
+            self::assertSame('catalog-1', $catalogInsert['params']['catalogId']);
+            self::assertArrayHasKey('metadata', $catalogInsert['params']);
+
+            $discountInsert = $this->findStatement('INSERT INTO catalog_available_discount');
+            self::assertNotNull($discountInsert);
+            self::assertSame('catalog-1', $discountInsert['params']['catalogId']);
+            self::assertSame('discount-1', $discountInsert['params']['discountId']);
+            self::assertSame($expectedPayload, $discountInsert['params']['payload']);
+
             self::assertFalse($this->testHandler->hasErrorRecords());
         }
 
-        public function testUpsertPersistsCatalogProductsWithTimestampsAndTaxes(): void
+        public function testUpsertPersistsCatalogMetadataAndRelations(): void
         {
             $productCreated = '2024-03-01T12:00:00Z';
             $productUpdated = '2024-03-02T12:00:00Z';
@@ -88,6 +95,7 @@ namespace Services {
             $catalogData = [
                 'id' => 'catalog-1',
                 'businessId' => 'biz-1',
+                'displayMetadata' => ['theme' => 'dark'],
                 'products' => [
                     [
                         'id' => 'product-1',
@@ -100,6 +108,26 @@ namespace Services {
                                 'createdAt' => $taxCreated,
                                 'updatedAt' => $taxUpdated,
                                 'amount' => 50,
+                                'businessId' => 'biz-1',
+                            ],
+                        ],
+                    ],
+                ],
+                'categories' => [
+                    [
+                        'id' => 'category-1',
+                        'name' => 'Coffee',
+                        'products' => [
+                            [
+                                'id' => 'product-1',
+                                'position' => 3,
+                            ],
+                        ],
+                        'taxes' => [
+                            [
+                                'id' => 'tax-2',
+                                'rateBp' => 725,
+                                'businessId' => 'biz-1',
                             ],
                         ],
                     ],
@@ -114,59 +142,108 @@ namespace Services {
             $expectedTaxCreatedAtExt = Format::optionalTimestamp($taxCreated);
             $expectedTaxUpdatedAtExt = Format::optionalTimestamp($taxUpdated);
 
-            $this->connection
-                ->expects($this->exactly(3))
-                ->method('executeStatement')
-                ->withConsecutive(
-                    [
-                        $this->stringContains('INSERT INTO catalog'),
-                        $this->arrayHasKey('catalogId'),
-                    ],
-                    [
-                        $this->stringContains('INSERT INTO catalog_product'),
-                        $this->callback(function (array $params) use (
-                            $expectedProductPayload,
-                            $expectedProductCreatedAtExt,
-                            $expectedProductUpdatedAtExt
-                        ): bool {
-                            self::assertSame('catalog-1', $params['catalogId']);
-                            self::assertSame('product-1', $params['productId']);
-                            self::assertSame(7, $params['position']);
-                            self::assertSame($expectedProductPayload, $params['payload']);
-                            self::assertSame($expectedProductCreatedAtExt, $params['createdAtExt']);
-                            self::assertSame($expectedProductUpdatedAtExt, $params['updatedAtExt']);
-                            self::assertArrayHasKey('createdAt', $params);
-                            self::assertArrayHasKey('updatedAt', $params);
+            $service = new CatalogService($this->context, null, $this->createMock(ClientInterface::class));
 
-                            return true;
-                        }),
-                    ],
-                    [
-                        $this->stringContains('INSERT INTO catalog_product_tax'),
-                        $this->callback(function (array $params) use (
-                            $expectedTaxPayload,
-                            $expectedTaxCreatedAtExt,
-                            $expectedTaxUpdatedAtExt
-                        ): bool {
-                            self::assertSame('catalog-1', $params['catalogId']);
-                            self::assertSame('product-1', $params['productId']);
-                            self::assertSame('tax-1', $params['taxId']);
-                            self::assertSame($expectedTaxPayload, $params['payload']);
-                            self::assertSame($expectedTaxCreatedAtExt, $params['createdAtExt']);
-                            self::assertSame($expectedTaxUpdatedAtExt, $params['updatedAtExt']);
-                            self::assertArrayHasKey('createdAt', $params);
-                            self::assertArrayHasKey('updatedAt', $params);
+            self::assertTrue($service->upsert($catalogData));
 
-                            return true;
-                        }),
-                    ]
-                )
-                ->willReturnOnConsecutiveCalls(1, 1, 1);
+            $catalogInsert = $this->findStatement('INSERT INTO catalog');
+            self::assertNotNull($catalogInsert);
+            self::assertSame(Format::jsonObject($catalogData['displayMetadata']), $catalogInsert['params']['metadata']);
+
+            $productInsert = $this->findStatement('INSERT INTO catalog_product');
+            self::assertNotNull($productInsert);
+            self::assertSame('product-1', $productInsert['params']['productId']);
+            self::assertSame(7, $productInsert['params']['position']);
+            self::assertSame($expectedProductPayload, $productInsert['params']['payload']);
+            self::assertSame($expectedProductCreatedAtExt, $productInsert['params']['createdAtExt']);
+            self::assertSame($expectedProductUpdatedAtExt, $productInsert['params']['updatedAtExt']);
+
+            $productTaxInsert = $this->findStatement('INSERT INTO catalog_product_tax');
+            self::assertNotNull($productTaxInsert);
+            self::assertSame($expectedTaxPayload, $productTaxInsert['params']['payload']);
+            self::assertSame($expectedTaxCreatedAtExt, $productTaxInsert['params']['createdAtExt']);
+            self::assertSame($expectedTaxUpdatedAtExt, $productTaxInsert['params']['updatedAtExt']);
+
+            $categoryInsert = $this->findStatement('INSERT INTO category');
+            self::assertNotNull($categoryInsert);
+            self::assertSame('category-1', $categoryInsert['params']['categoryId']);
+
+            $categoryProductInsert = $this->findStatement('INSERT INTO category_product');
+            self::assertNotNull($categoryProductInsert);
+            self::assertSame('category-1', $categoryProductInsert['params']['categoryId']);
+            self::assertSame('product-1', $categoryProductInsert['params']['productId']);
+
+            $categoryTaxInsert = $this->findStatement('INSERT INTO category_tax');
+            self::assertNotNull($categoryTaxInsert);
+            self::assertSame('tax-2', $categoryTaxInsert['params']['taxId']);
+
+            $taxUpsert = $this->findStatement('INSERT INTO tax');
+            self::assertNotNull($taxUpsert);
+
+            self::assertFalse($this->testHandler->hasErrorRecords());
+        }
+
+        public function testUpsertRemovesMissingRelations(): void
+        {
+            $catalogData = [
+                'id' => 'catalog-2',
+                'businessId' => 'biz-2',
+                'products' => [],
+                'categories' => [],
+            ];
 
             $service = new CatalogService($this->context, null, $this->createMock(ClientInterface::class));
 
             self::assertTrue($service->upsert($catalogData));
-            self::assertFalse($this->testHandler->hasErrorRecords());
+
+            $catalogDeletes = $this->findAllStatements('DELETE FROM catalog_product');
+            self::assertNotEmpty($catalogDeletes);
+            self::assertTrue($this->statementContains($catalogDeletes, 'product_id = :productId') || $this->statementContains($catalogDeletes, 'catalog_id = :catalogId'));
+
+            $catalogTaxDeletes = $this->findAllStatements('DELETE FROM catalog_product_tax');
+            self::assertNotEmpty($catalogTaxDeletes);
+
+            $categoryProductDeletes = $this->findAllStatements('DELETE FROM category_product');
+            self::assertNotEmpty($categoryProductDeletes);
+
+            $categoryTaxDeletes = $this->findAllStatements('DELETE FROM category_tax');
+            self::assertNotEmpty($categoryTaxDeletes);
+        }
+
+        private function findStatement(string $needle): ?array
+        {
+            foreach ($this->executedStatements as $statement) {
+                if (str_contains($statement['sql'], $needle)) {
+                    return $statement;
+                }
+            }
+
+            return null;
+        }
+
+        /**
+         * @return array<int, array{sql:string,params:array,types:array}>
+         */
+        private function findAllStatements(string $needle): array
+        {
+            return array_values(array_filter(
+                $this->executedStatements,
+                static fn (array $statement): bool => str_contains($statement['sql'], $needle)
+            ));
+        }
+
+        /**
+         * @param array<int, array{sql:string,params:array,types:array}> $statements
+         */
+        private function statementContains(array $statements, string $fragment): bool
+        {
+            foreach ($statements as $statement) {
+                if (str_contains($statement['sql'], $fragment)) {
+                    return true;
+                }
+            }
+
+            return false;
         }
     }
 }


### PR DESCRIPTION
## Summary
- ensure catalog webhook handling fetches embedded payloads or refetches full catalogs with a merchant token and single app-token retry
- normalise catalog payloads to persist metadata, categories, category-product links, and category taxes with idempotent clean-up
- extend the schema and tests to cover the new catalog/category relations and metadata column

## Testing
- `php -l app/Services/Support/WebhookResourceFetcher.php`
- `php -l app/Services/CatalogService.php`
- `php -l tests/Services/CatalogServiceTest.php`
- `./vendor/bin/phpunit` *(fails: binary missing because composer install requires GitHub token in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914a18ba3648329b616fc57635091dd)