### PR TITLE
Add timestamps to product variant schema

### DIFF
--- a/SQL/poynt-v2.sql
+++ b/SQL/poynt-v2.sql
@@ -402,6 +402,8 @@ CREATE TABLE product_variant (
   raw_payload     JSONB NOT NULL DEFAULT '{}',
   created_at_ext  TIMESTAMPTZ,
   updated_at_ext  TIMESTAMPTZ,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   PRIMARY KEY (product_id, variant_id)
 );
 


### PR DESCRIPTION
## Summary
- add created_at and updated_at defaults to the product_variant definition in poynt-v2.sql so inserts referencing those fields succeed

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914d6b48eb883299fcaf510223e722b)