### PR TITLE
Handle pagination without count metadata

### DIFF
--- a/app/Services/Support/PaginatedRequest.php
+++ b/app/Services/Support/PaginatedRequest.php
@@ -32,14 +32,23 @@ final class PaginatedRequest
             $items = $initialData[$entityKey];
         }
 
-        $totalCount = self::extractCount($initialData);
-        if ($totalCount === null || $totalCount <= count($items)) {
-            return $initialData;
-        }
-
         $origin = self::buildOrigin($initialUrl);
         $visited = [];
         $nextUrl = self::extractNextUrl($initialData, $origin);
+
+        $totalCount = self::extractCount($initialData);
+        $shouldPaginate = $nextUrl !== null;
+        if ($totalCount !== null && $totalCount > count($items)) {
+            $shouldPaginate = true;
+        }
+
+        if ($shouldPaginate === false) {
+            if ($totalCount !== null) {
+                $initialData['count'] = $totalCount;
+            }
+
+            return $initialData;
+        }
 
         while ($nextUrl !== null) {
             if (isset($visited[$nextUrl])) {

--- a/tests/Services/Support/PaginatedRequestTest.php
+++ b/tests/Services/Support/PaginatedRequestTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Services\Support;
+
+use App\Services\Support\PaginatedRequest;
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Promise\PromiseInterface;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+class PaginatedRequestTest extends TestCase
+{
+    public function testCollectsNextPageWhenCountIsMissing(): void
+    {
+        $initialData = [
+            'links' => [
+                [
+                    'href' => '/businesses/biz-123/products?page=2',
+                    'rel' => 'next',
+                    'method' => 'GET',
+                ],
+            ],
+            'products' => [
+                ['id' => 'product-id-1'],
+            ],
+        ];
+
+        $nextPage = [
+            'products' => [
+                ['id' => 'product-id-2'],
+            ],
+        ];
+
+        $client = new PaginatedRequestTestHttpClient([
+            new Response(200, [], json_encode($nextPage, JSON_THROW_ON_ERROR)),
+        ]);
+
+        $result = PaginatedRequest::collect(
+            $client,
+            $initialData,
+            'https://api.example.com/businesses/biz-123/products',
+            [],
+            'products'
+        );
+
+        self::assertSame([
+            'https://api.example.com/businesses/biz-123/products?page=2',
+        ], $client->requestedUrls);
+
+        self::assertArrayNotHasKey('count', $result);
+        self::assertCount(2, $result['products']);
+        self::assertSame('product-id-1', $result['products'][0]['id']);
+        self::assertSame('product-id-2', $result['products'][1]['id']);
+    }
+}
+
+class PaginatedRequestTestHttpClient implements ClientInterface
+{
+    /** @var ResponseInterface[] */
+    private array $responses;
+
+    /** @var string[] */
+    public array $requestedUrls = [];
+
+    /**
+     * @param ResponseInterface[] $responses
+     */
+    public function __construct(array $responses)
+    {
+        $this->responses = $responses;
+    }
+
+    public function request($method, $uri = '', array $options = []): ResponseInterface
+    {
+        if (strtoupper((string) $method) !== 'GET') {
+            throw new \BadMethodCallException('Only GET is supported in tests');
+        }
+
+        return $this->get($uri, $options);
+    }
+
+    public function requestAsync($method, $uri = '', array $options = []): PromiseInterface
+    {
+        throw new \BadMethodCallException('Not implemented in tests');
+    }
+
+    public function getConfig(?string $option = null): mixed
+    {
+        return null;
+    }
+
+    public function send(RequestInterface $request, array $options = []): ResponseInterface
+    {
+        return $this->request($request->getMethod(), (string) $request->getUri(), $options);
+    }
+
+    public function sendAsync(RequestInterface $request, array $options = []): PromiseInterface
+    {
+        throw new \BadMethodCallException('Not implemented in tests');
+    }
+
+    public function get($uri, array $options = []): ResponseInterface
+    {
+        $this->requestedUrls[] = $uri;
+
+        if ($this->responses === []) {
+            throw new \RuntimeException('No responses available');
+        }
+
+        return array_shift($this->responses);
+    }
+}


### PR DESCRIPTION
## Summary
- ensure paginated collections continue when count metadata is missing but next links exist
- add unit test covering pagination for product listings without count values

## Testing
- phpunit tests/Services/Support/PaginatedRequestTest.php *(fails: vendor/bin/phpunit missing in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691f3af9f39c8331a855f1597ce02af6)