### PR TITLE
Handle duplicate webhooks and streamline fetch

### DIFF
--- a/app/Services/WebhookService.php
+++ b/app/Services/WebhookService.php
@@ -591,6 +591,14 @@ class WebhookService
             return false;
         }
 
+        if (!is_string($merchantToken) || $merchantToken === '') {
+            $this->context->getLog()->error(
+                sprintf('WebhookService::fetchByBusinessId: missing merchant access token for business %s', $businessId)
+            );
+
+            return false;
+        }
+
         try {
             $hooks = $this->fetchAllHooks($businessId, $appToken);
             if ($hooks === false) {
@@ -603,53 +611,7 @@ class WebhookService
                 return false;
             }
 
-            $deliveries = $this->fetchDeliveriesForBusiness($businessId, $merchantToken);
-
-            $orgBusinessId = ConfigApp::$orgId ?? '';
-            if (
-                is_string($orgBusinessId)
-                && $orgBusinessId !== ''
-                && $orgBusinessId !== $businessId
-            ) {
-                $orgDeliveries = $this->fetchDeliveriesForBusiness($orgBusinessId, $merchantToken);
-                if ($orgDeliveries !== []) {
-                    $deliveries = array_merge($deliveries, $orgDeliveries);
-                }
-            }
-            $deliveriesByHook = [];
-            $deliveriesMissingHookId = [];
-            foreach ($deliveries as $delivery) {
-                if (!is_array($delivery)) {
-                    continue;
-                }
-
-                $deliveryHookId = $delivery['hookId'] ?? null;
-                if ((!is_string($deliveryHookId) || $deliveryHookId === '') && isset($delivery['hook']) && is_array($delivery['hook'])) {
-                    $candidate = $delivery['hook']['id'] ?? $delivery['hook']['hookId'] ?? null;
-                    if (!is_string($candidate) || $candidate === '') {
-                        $candidate = $delivery['hook']['hook']['id'] ?? $delivery['hook']['hook']['hookId'] ?? null;
-                    }
-
-                    if (is_string($candidate) && $candidate !== '') {
-                        $deliveryHookId = $candidate;
-                    }
-                }
-
-                if (!is_string($deliveryHookId) || $deliveryHookId === '') {
-                    $deliveriesMissingHookId[] = $delivery;
-                    continue;
-                }
-
-                if (!isset($deliveriesByHook[$deliveryHookId])) {
-                    $deliveriesByHook[$deliveryHookId] = [];
-                }
-
-                if (!isset($delivery['hookId'])) {
-                    $delivery['hookId'] = $deliveryHookId;
-                }
-
-                $deliveriesByHook[$deliveryHookId][] = $delivery;
-            }
+            $hooks = $this->deleteDuplicateHooks($hooks, $businessId, $merchantToken);
 
             $hooksById = [];
             foreach ($hooks as $hook) {
@@ -662,7 +624,6 @@ class WebhookService
                     continue;
                 }
 
-                $hook['deliveries'] = [];
                 $hooksById[$hookId] = $hook;
             }
 
@@ -675,43 +636,7 @@ class WebhookService
                 ]
             );
 
-            $deliveriesByHookKeys = array_keys($deliveriesByHook);
-            $this->context->getLog()->info(
-                'WebhookService::fetchByBusinessId deliveries grouped by hookId',
-                [
-                    'businessId' => $businessId,
-                    'hookIds' => $deliveriesByHookKeys,
-                ]
-            );
-
-            $unknownHookIds = array_values(array_diff($deliveriesByHookKeys, $hookIds));
-            $this->context->getLog()->info(
-                'WebhookService::fetchByBusinessId deliveries referencing unknown hookIds',
-                [
-                    'businessId' => $businessId,
-                    'hookIds' => $unknownHookIds,
-                ]
-            );
-
-            foreach ($deliveriesByHook as $hookId => $hookDeliveries) {
-                if (isset($hooksById[$hookId])) {
-                    $hooksById[$hookId]['deliveries'] = $hookDeliveries;
-                }
-            }
-
             $hooks = array_values($hooksById);
-
-            if (!empty($deliveriesMissingHookId)) {
-                FetchResponseLogger::info(
-                    $this->context->getLog(),
-                    'WebhookService::fetchByBusinessId deliveries missing hookId',
-                    [
-                        'businessId' => $businessId,
-                        'entity' => 'deliveries',
-                        'payload' => $deliveriesMissingHookId,
-                    ]
-                );
-            }
 
             FetchResponseLogger::info(
                 $this->context->getLog(),
@@ -849,6 +774,90 @@ class WebhookService
         }
 
         return $allDeleted;
+    }
+
+    /**
+     * Remove duplicate hooks by delivery URL, deleting redundant entries via the Poynt API.
+     *
+     * @param array<int, mixed> $hooks
+     * @return array<int, mixed>
+     */
+    private function deleteDuplicateHooks(array $hooks, string $businessId, string $merchantToken): array
+    {
+        $uniqueHooks = [];
+        $seenDeliveryUrls = [];
+
+        foreach ($hooks as $hook) {
+            if (!is_array($hook)) {
+                $uniqueHooks[] = $hook;
+                continue;
+            }
+
+            $hookId = $hook['id'] ?? $hook['hookId'] ?? null;
+            $deliveryUrl = $hook['deliveryUrl'] ?? $hook['destinationUrl'] ?? $hook['url'] ?? null;
+
+            if (!is_string($hookId) || $hookId === '' || !is_string($deliveryUrl) || $deliveryUrl === '') {
+                $uniqueHooks[] = $hook;
+                continue;
+            }
+
+            if (!isset($seenDeliveryUrls[$deliveryUrl])) {
+                $seenDeliveryUrls[$deliveryUrl] = true;
+                $uniqueHooks[] = $hook;
+                continue;
+            }
+
+            $hookBusinessId = $hook['businessId'] ?? $businessId;
+            if (!is_string($hookBusinessId) || $hookBusinessId === '') {
+                $hookBusinessId = $businessId;
+            }
+
+            $eventTypes = $hook['eventTypes'] ?? [];
+            if (!is_array($eventTypes)) {
+                $eventTypes = [$eventTypes];
+            }
+
+            if ($this->eventsRequireOrgId($eventTypes)) {
+                $orgId = ConfigApp::$orgId ?? '';
+                if (is_string($orgId) && $orgId !== '') {
+                    $hookBusinessId = $orgId;
+                }
+            }
+
+            try {
+                $this->httpClient->delete(
+                    self::POYNT_WEBHOOK_URL . '/' . rawurlencode($hookId),
+                    [
+                        'headers' => [
+                            'Authorization' => 'Bearer ' . $merchantToken,
+                        ],
+                        'query' => [
+                            'businessId' => $hookBusinessId,
+                        ],
+                    ]
+                );
+
+                $this->context->getLog()->info(
+                    'WebhookService::fetchByBusinessId: deleted duplicate hook',
+                    [
+                        'hookId' => $hookId,
+                        'businessId' => $hookBusinessId,
+                        'deliveryUrl' => $deliveryUrl,
+                    ]
+                );
+            } catch (BadResponseException|GuzzleException $e) {
+                $this->context->getLog()->error(
+                    sprintf(
+                        'WebhookService::fetchByBusinessId: failed deleting duplicate hook %s for business %s: %s',
+                        $hookId,
+                        $hookBusinessId,
+                        $e->getMessage()
+                    )
+                );
+            }
+        }
+
+        return $uniqueHooks;
     }
 
     /**

--- a/tests/Services/WebhookServiceTest.php
+++ b/tests/Services/WebhookServiceTest.php
@@ -160,7 +160,7 @@ namespace Tests\Services {
             $this->assertSame(['id' => 'hook-2'], $result);
         }
 
-        public function testFetchByBusinessIdFetchesOrgDeliveriesForSubscriptionHooks(): void
+        public function testFetchByBusinessIdDeletesDuplicateHooks(): void
         {
             ConfigApp::$orgId = 'org-456';
             ConfigApp::$appId = 'app-456';
@@ -188,25 +188,9 @@ namespace Tests\Services {
             $context->method('getConn')->willReturn($connection);
             $context->method('getLog')->willReturn($logger);
 
-            $hookPayload = [
-                'count' => 1,
-                'hooks' => [
-                    [
-                        'id' => 'hook-sub',
-                        'eventTypes' => ['APPLICATION_SUBSCRIPTION_END'],
-                        'deliveryUrl' => 'https://example.test/webhooks',
-                        'businessId' => 'business-123',
-                        'applicationId' => 'urn:aid:' . ConfigApp::$appId,
-                        'status' => 'ACTIVE',
-                        'createdAt' => '2024-01-01T00:00:00Z',
-                        'updatedAt' => '2024-01-01T00:00:00Z',
-                    ],
-                ],
-            ];
-
             $httpClient = $this->createMock(ClientInterface::class);
             $httpClient
-                ->expects($this->exactly(4))
+                ->expects($this->exactly(2))
                 ->method('get')
                 ->withConsecutive(
                     [
@@ -223,20 +207,36 @@ namespace Tests\Services {
                             'query' => ['businessId' => ConfigApp::$orgId],
                         ],
                     ],
-                    [
-                        'https://services.poynt.net/businesses/business-123/deliveries',
-                        ['headers' => ['Authorization' => 'Bearer merchant-token']],
-                    ],
-                    [
-                        'https://services.poynt.net/businesses/' . ConfigApp::$orgId . '/deliveries',
-                        ['headers' => ['Authorization' => 'Bearer merchant-token']],
-                    ]
                 )
                 ->willReturnOnConsecutiveCalls(
-                    new Response(200, [], json_encode(['hooks' => []])),
-                    new Response(200, [], json_encode($hookPayload)),
-                    new Response(200, [], json_encode(['deliveries' => []])),
-                    new Response(200, [], json_encode(['deliveries' => []]))
+                    new Response(200, [], json_encode([
+                        'hooks' => [
+                            [
+                                'id' => 'hook-primary',
+                                'eventTypes' => ['ORDER_COMPLETED'],
+                                'deliveryUrl' => 'https://example.test/webhooks',
+                                'businessId' => 'business-123',
+                            ],
+                            [
+                                'id' => 'hook-duplicate',
+                                'eventTypes' => ['ORDER_COMPLETED'],
+                                'deliveryUrl' => 'https://example.test/webhooks',
+                                'businessId' => 'business-123',
+                            ],
+                        ],
+                    ])),
+                    new Response(200, [], json_encode(['hooks' => []]))
+                );
+
+            $httpClient
+                ->expects($this->once())
+                ->method('delete')
+                ->with(
+                    WebhookService::POYNT_WEBHOOK_URL . '/hook-duplicate',
+                    [
+                        'headers' => ['Authorization' => 'Bearer merchant-token'],
+                        'query' => ['businessId' => 'business-123'],
+                    ]
                 );
 
             $service = new WebhookService($context, 'business-123', $httpClient);
@@ -245,8 +245,8 @@ namespace Tests\Services {
 
             $this->assertIsArray($result);
             $this->assertCount(1, $result);
-            $this->assertSame('hook-sub', $result[0]['id']);
-            $this->assertSame(ConfigApp::$orgId, $result[0]['businessId']);
+            $this->assertSame('hook-primary', $result[0]['id']);
+            $this->assertSame('business-123', $result[0]['businessId']);
         }
 
         public function testDeleteAllByBusinessIdUsesHookSpecificBusinessIds(): void


### PR DESCRIPTION
## Summary
- delete duplicate webhook registrations based on delivery URL before returning hooks
- remove delivery lookups from webhook fetch flow and require merchant tokens for duplicate cleanup
- update webhook service tests to cover duplicate deletion behaviour

## Testing
- composer test -- --filter=WebhookServiceTest *(fails: command not defined in this project)*
- ./vendor/bin/phpunit tests/Services/WebhookServiceTest.php *(fails: phpunit binary not installed)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6927163db3c08331ae4d5c34e8cbab41)