### PR TITLE
Persist registered hooks

### DIFF
--- a/app/Services/WebhookService.php
+++ b/app/Services/WebhookService.php
@@ -81,6 +81,20 @@ class WebhookService
                 'error_message' => null,
             ]);
 
+            if (is_array($responseData)) {
+                $responseData['businessId'] = $responseData['businessId'] ?? $businessId;
+
+                if (!isset($responseData['eventTypes']) && isset($payload['eventTypes'])) {
+                    $responseData['eventTypes'] = $payload['eventTypes'];
+                }
+
+                if (!isset($responseData['deliveryUrl']) && isset($payload['deliveryUrl'])) {
+                    $responseData['deliveryUrl'] = $payload['deliveryUrl'];
+                }
+
+                $this->upsert($responseData);
+            }
+
             $this->context->getLog()->info("Webhook registered successfully", $responseData);
             return $responseData;
 


### PR DESCRIPTION
## Summary
- persist webhook registration responses to the hook table using existing upsert logic
- fall back to payload data when the registration response omits identifying fields

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6927270cf5a4833184f85b1d3b1e1b88)