### PR TITLE
Account for event types when reusing webhooks

### DIFF
--- a/app/Services/WebhookService.php
+++ b/app/Services/WebhookService.php
@@ -430,16 +430,14 @@ class WebhookService
 
             $normalizedHookEvents = $this->normalizeEventTypes($hookEvents);
 
-            if ($hookUrl === $targetDeliveryUrl && $normalizedHookEvents === $normalizedTargetEvents && $this->isHookActive($hook, $status)) {
-                return $hook;
-            }
+            if ($hookUrl === $targetDeliveryUrl && $normalizedHookEvents === $normalizedTargetEvents) {
+                if ($this->isHookActive($hook, $status)) {
+                    return $hook;
+                }
 
-            if ($hookUrl === $targetDeliveryUrl && $status === 'ACTIVE') {
-                return $hook;
-            }
-
-            if ($oldHook === null) {
-                $oldHook = $hook;
+                if ($oldHook === null) {
+                    $oldHook = $hook;
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- ensure webhook reuse checks both delivery URL and event types before returning existing hooks
- avoid marking unrelated hooks for deletion when registering new webhooks

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69272f6d11888331a1f71c1f2e3a5dac)