### PR TITLE
Prevent deleting unrelated webhooks

### DIFF
--- a/app/Services/WebhookService.php
+++ b/app/Services/WebhookService.php
@@ -443,7 +443,7 @@ class WebhookService
                 return $hook;
             }
 
-            if ($oldHook === null) {
+            if ($hookUrl === $targetDeliveryUrl && ($oldHook === null || $this->isHookActive($hook, $status))) {
                 $oldHook = $hook;
             }
         }


### PR DESCRIPTION
## Summary
- ensure webhook replacement only targets hooks for the same delivery URL
- avoid deleting unrelated webhook registrations when registering new hooks

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69283d85d164833183c527197d2aee35)