### PR TITLE
Add delete handlers for webhook resource services

### DIFF
--- a/app/Services/BusinessUserService.php
+++ b/app/Services/BusinessUserService.php
@@ -161,4 +161,46 @@ class BusinessUserService
             return false;
         }
     }
+
+    public function delete(string $id, ?string $businessId = null): bool
+    {
+        $userId = Format::optionalInt($id);
+        if ($userId === null) {
+            $this->context->getLog()->error('BusinessUserService::delete: user id must be numeric');
+
+            return false;
+        }
+
+        if ($businessId === null) {
+            $businessId = $this->businessId;
+        }
+
+        if ($businessId === null) {
+            $this->context->getLog()->error('BusinessUserService::delete: missing businessId');
+
+            return false;
+        }
+
+        try {
+            $deleted = $this->context->getConn()->executeStatement(
+                'DELETE FROM business_user WHERE business_id = :businessId AND user_id = :userId',
+                [
+                    'businessId' => $businessId,
+                    'userId' => $userId,
+                ]
+            );
+
+            $this->context->getLog()->info(
+                sprintf('BusinessUserService::delete: deleted %d rows for user %d', $deleted, $userId)
+            );
+
+            return true;
+        } catch (\Throwable $exception) {
+            $this->context->getLog()->error(
+                sprintf('BusinessUserService::delete: failed for user %d: %s', $userId, $exception->getMessage())
+            );
+
+            return false;
+        }
+    }
 }

--- a/app/Services/CatalogService.php
+++ b/app/Services/CatalogService.php
@@ -943,4 +943,66 @@ class CatalogService
             );
         }
     }
+
+    public function delete(string $id, ?string $businessId = null): bool
+    {
+        $conn = $this->context->getConn();
+
+        try {
+            $conn->beginTransaction();
+
+            $conn->executeStatement(
+                'DELETE FROM catalog_product_tax WHERE catalog_id = :catalogId',
+                ['catalogId' => $id]
+            );
+
+            $conn->executeStatement(
+                'DELETE FROM catalog_product WHERE catalog_id = :catalogId',
+                ['catalogId' => $id]
+            );
+
+            $conn->executeStatement(
+                'DELETE FROM catalog_available_discount WHERE catalog_id = :catalogId',
+                ['catalogId' => $id]
+            );
+
+            $conn->executeStatement(
+                'DELETE FROM category_product WHERE catalog_id = :catalogId',
+                ['catalogId' => $id]
+            );
+
+            $conn->executeStatement(
+                'DELETE FROM category_tax WHERE catalog_id = :catalogId',
+                ['catalogId' => $id]
+            );
+
+            $params = ['catalogId' => $id];
+            $condition = 'catalog_id = :catalogId';
+            if ($businessId !== null) {
+                $condition .= ' AND business_id = :businessId';
+                $params['businessId'] = $businessId;
+            }
+
+            $conn->executeStatement(
+                sprintf('DELETE FROM catalog WHERE %s', $condition),
+                $params
+            );
+
+            $conn->commit();
+
+            $this->context->getLog()->info(
+                sprintf('CatalogService::delete: removed catalog %s and related records', $id)
+            );
+
+            return true;
+        } catch (\Throwable $exception) {
+            $conn->rollBack();
+
+            $this->context->getLog()->error(
+                sprintf('CatalogService::delete: failed for catalog %s: %s', $id, $exception->getMessage())
+            );
+
+            return false;
+        }
+    }
 }

--- a/app/Services/CategoryService.php
+++ b/app/Services/CategoryService.php
@@ -308,4 +308,56 @@ class CategoryService
             return false;
         }
     }
+
+    public function delete(string $id, ?string $businessId = null): bool
+    {
+        $conn = $this->context->getConn();
+
+        try {
+            $conn->beginTransaction();
+
+            $conn->executeStatement(
+                'DELETE FROM category_product WHERE category_id = :categoryId',
+                ['categoryId' => $id]
+            );
+
+            $conn->executeStatement(
+                'DELETE FROM category_tax WHERE category_id = :categoryId',
+                ['categoryId' => $id]
+            );
+
+            $params = ['categoryId' => $id];
+            $condition = 'category_id = :categoryId';
+            if ($businessId !== null) {
+                $condition .= ' AND business_id = :businessId';
+                $params['businessId'] = $businessId;
+            }
+
+            $conn->executeStatement(
+                sprintf('UPDATE product SET category_id = NULL WHERE %s', $condition),
+                $params
+            );
+
+            $conn->executeStatement(
+                sprintf('DELETE FROM category WHERE %s', $condition),
+                $params
+            );
+
+            $conn->commit();
+
+            $this->context->getLog()->info(
+                sprintf('CategoryService::delete: removed category %s and related records', $id)
+            );
+
+            return true;
+        } catch (\Throwable $exception) {
+            $conn->rollBack();
+
+            $this->context->getLog()->error(
+                sprintf('CategoryService::delete: failed for category %s: %s', $id, $exception->getMessage())
+            );
+
+            return false;
+        }
+    }
 }

--- a/app/Services/InventoryService.php
+++ b/app/Services/InventoryService.php
@@ -729,4 +729,53 @@ class InventoryService
 
         return [$businessId, $productId];
     }
+
+    public function delete(string $id, ?string $businessId = null): bool
+    {
+        if ($businessId === null) {
+            $businessId = $this->businessId;
+        }
+
+        if ($businessId === null) {
+            $this->context->getLog()->error('InventoryService::delete: missing businessId');
+
+            return false;
+        }
+
+        $params = [
+            'businessId' => $businessId,
+            'productId' => $id,
+        ];
+
+        try {
+            $conn = $this->context->getConn();
+
+            $conn->executeStatement(
+                'DELETE FROM variant_inventory WHERE business_id = :businessId AND product_id = :productId',
+                $params
+            );
+
+            $conn->executeStatement(
+                'DELETE FROM inventory WHERE business_id = :businessId AND product_id = :productId',
+                $params
+            );
+
+            $conn->executeStatement(
+                'DELETE FROM inventory_summary WHERE business_id = :businessId AND product_id = :productId',
+                $params
+            );
+
+            $this->context->getLog()->info(
+                sprintf('InventoryService::delete: removed inventory for product %s', $id)
+            );
+
+            return true;
+        } catch (\Throwable $exception) {
+            $this->context->getLog()->error(
+                sprintf('InventoryService::delete: failed for product %s: %s', $id, $exception->getMessage())
+            );
+
+            return false;
+        }
+    }
 }

--- a/app/Services/OrderService.php
+++ b/app/Services/OrderService.php
@@ -525,6 +525,36 @@ class OrderService
         }
     }
 
+    public function delete(string $id, ?string $businessId = null): bool
+    {
+        $params = ['orderId' => $id];
+        $condition = 'order_id = :orderId';
+
+        if ($businessId !== null) {
+            $condition .= ' AND business_id = :businessId';
+            $params['businessId'] = $businessId;
+        }
+
+        try {
+            $deleted = $this->context->getConn()->executeStatement(
+                sprintf('DELETE FROM "order" WHERE %s', $condition),
+                $params
+            );
+
+            $this->context->getLog()->info(
+                sprintf('OrderService::delete: deleted %d rows for order %s', $deleted, $id)
+            );
+
+            return true;
+        } catch (\Throwable $exception) {
+            $this->context->getLog()->error(
+                sprintf('OrderService::delete: failed for order %s: %s', $id, $exception->getMessage())
+            );
+
+            return false;
+        }
+    }
+
     /**
      * @param array<mixed> $data
      * @param array<int, array<int, string>> $paths

--- a/app/Services/ProductService.php
+++ b/app/Services/ProductService.php
@@ -445,4 +445,83 @@ class ProductService
             return false;
         }
     }
+
+    public function delete(string $id, ?string $businessId = null): bool
+    {
+        $conn = $this->context->getConn();
+
+        try {
+            $conn->beginTransaction();
+
+            $conn->executeStatement(
+                'DELETE FROM product_variant WHERE product_id = :productId',
+                ['productId' => $id]
+            );
+
+            $conn->executeStatement(
+                'DELETE FROM catalog_product_tax WHERE product_id = :productId',
+                ['productId' => $id]
+            );
+
+            $conn->executeStatement(
+                'DELETE FROM catalog_product WHERE product_id = :productId',
+                ['productId' => $id]
+            );
+
+            $conn->executeStatement(
+                'DELETE FROM category_product WHERE product_id = :productId',
+                ['productId' => $id]
+            );
+
+            if ($businessId !== null) {
+                $inventoryParams = [
+                    'businessId' => $businessId,
+                    'productId' => $id,
+                ];
+
+                $conn->executeStatement(
+                    'DELETE FROM variant_inventory WHERE business_id = :businessId AND product_id = :productId',
+                    $inventoryParams
+                );
+
+                $conn->executeStatement(
+                    'DELETE FROM inventory WHERE business_id = :businessId AND product_id = :productId',
+                    $inventoryParams
+                );
+
+                $conn->executeStatement(
+                    'DELETE FROM inventory_summary WHERE business_id = :businessId AND product_id = :productId',
+                    $inventoryParams
+                );
+            }
+
+            $params = ['productId' => $id];
+            $condition = 'product_id = :productId';
+            if ($businessId !== null) {
+                $condition .= ' AND business_id = :businessId';
+                $params['businessId'] = $businessId;
+            }
+
+            $conn->executeStatement(
+                sprintf('DELETE FROM product WHERE %s', $condition),
+                $params
+            );
+
+            $conn->commit();
+
+            $this->context->getLog()->info(
+                sprintf('ProductService::delete: removed product %s and related records', $id)
+            );
+
+            return true;
+        } catch (\Throwable $exception) {
+            $conn->rollBack();
+
+            $this->context->getLog()->error(
+                sprintf('ProductService::delete: failed for product %s: %s', $id, $exception->getMessage())
+            );
+
+            return false;
+        }
+    }
 }

--- a/app/Services/StoreService.php
+++ b/app/Services/StoreService.php
@@ -140,4 +140,71 @@ class StoreService
 
         return true;
     }
+
+    public function delete(string $id, ?string $businessId = null): bool
+    {
+        $conn = $this->context->getConn();
+
+        try {
+            $conn->beginTransaction();
+
+            $inventoryParams = ['storeId' => $id];
+            if ($businessId !== null) {
+                $inventoryParams['businessId'] = $businessId;
+
+                $conn->executeStatement(
+                    'DELETE FROM inventory WHERE business_id = :businessId AND store_id = :storeId',
+                    $inventoryParams
+                );
+
+                $conn->executeStatement(
+                    'DELETE FROM variant_inventory WHERE business_id = :businessId AND store_id = :storeId',
+                    $inventoryParams
+                );
+            } else {
+                $conn->executeStatement(
+                    'DELETE FROM inventory WHERE store_id = :storeId',
+                    ['storeId' => $id]
+                );
+
+                $conn->executeStatement(
+                    'DELETE FROM variant_inventory WHERE store_id = :storeId',
+                    ['storeId' => $id]
+                );
+            }
+
+            $conn->executeStatement(
+                'DELETE FROM terminal WHERE store_id = :storeId',
+                ['storeId' => $id]
+            );
+
+            $storeParams = ['storeId' => $id];
+            $condition = 'store_id = :storeId';
+            if ($businessId !== null) {
+                $condition .= ' AND business_id = :businessId';
+                $storeParams['businessId'] = $businessId;
+            }
+
+            $conn->executeStatement(
+                sprintf('DELETE FROM store WHERE %s', $condition),
+                $storeParams
+            );
+
+            $conn->commit();
+
+            $this->context->getLog()->info(
+                sprintf('StoreService::delete: removed store %s and related records', $id)
+            );
+
+            return true;
+        } catch (\Throwable $exception) {
+            $conn->rollBack();
+
+            $this->context->getLog()->error(
+                sprintf('StoreService::delete: failed for store %s: %s', $id, $exception->getMessage())
+            );
+
+            return false;
+        }
+    }
 }

--- a/app/Services/TaxService.php
+++ b/app/Services/TaxService.php
@@ -151,4 +151,58 @@ class TaxService
             return false;
         }
     }
+
+    public function delete(string $id, ?string $businessId = null): bool
+    {
+        if ($businessId === null) {
+            $businessId = $this->businessId;
+        }
+
+        if ($businessId === null) {
+            $this->context->getLog()->error('TaxService::delete: missing businessId');
+
+            return false;
+        }
+
+        $params = [
+            'taxId' => $id,
+            'businessId' => $businessId,
+        ];
+
+        try {
+            $conn = $this->context->getConn();
+            $conn->beginTransaction();
+
+            $conn->executeStatement(
+                'DELETE FROM catalog_product_tax WHERE tax_id = :taxId',
+                ['taxId' => $id]
+            );
+
+            $conn->executeStatement(
+                'DELETE FROM category_tax WHERE tax_id = :taxId AND business_id = :businessId',
+                $params
+            );
+
+            $conn->executeStatement(
+                'DELETE FROM tax WHERE tax_id = :taxId AND business_id = :businessId',
+                $params
+            );
+
+            $conn->commit();
+
+            $this->context->getLog()->info(
+                sprintf('TaxService::delete: removed tax %s and related records', $id)
+            );
+
+            return true;
+        } catch (\Throwable $exception) {
+            $conn->rollBack();
+
+            $this->context->getLog()->error(
+                sprintf('TaxService::delete: failed for tax %s: %s', $id, $exception->getMessage())
+            );
+
+            return false;
+        }
+    }
 }

--- a/app/Services/TransactionService.php
+++ b/app/Services/TransactionService.php
@@ -420,5 +420,42 @@ class TransactionService
 
         return true;
     }
+
+    public function delete(string $id, ?string $businessId = null): bool
+    {
+        $params = ['transactionId' => $id];
+        $condition = 'transaction_id = :transactionId';
+
+        if ($businessId !== null) {
+            $condition .= ' AND business_id = :businessId';
+            $params['businessId'] = $businessId;
+        }
+
+        try {
+            $conn = $this->context->getConn();
+
+            $conn->executeStatement(
+                'DELETE FROM transaction_receipt WHERE transaction_id = :transactionId',
+                ['transactionId' => $id]
+            );
+
+            $deleted = $conn->executeStatement(
+                sprintf('DELETE FROM transaction WHERE %s', $condition),
+                $params
+            );
+
+            $this->context->getLog()->info(
+                sprintf('TransactionService::delete: deleted %d rows for transaction %s', $deleted, $id)
+            );
+
+            return true;
+        } catch (\Throwable $exception) {
+            $this->context->getLog()->error(
+                sprintf('TransactionService::delete: failed for transaction %s: %s', $id, $exception->getMessage())
+            );
+
+            return false;
+        }
+    }
 }
 


### PR DESCRIPTION
## Summary
- add delete methods to all webhook resource services to clean up related records
- clear related child tables and relationships when catalogs, products, categories, or taxes are removed
- support deletion of inventory, store, order, and transaction data on webhook delete events

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69298447245c83319b5bb12e38ecbb44)