### PR TITLE
Add poynt v3 clean schema DDL

### DIFF
--- a/SQL/poynt-v3.sql
+++ b/SQL/poynt-v3.sql
@@ -1,0 +1,570 @@
+-- POYNT v3 SCHEMA (clean DDL)
+
+-- CORE ENTITIES
+CREATE TABLE IF NOT EXISTS business (
+    business_id VARCHAR(255) PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    metadata JSONB NOT NULL DEFAULT '{}',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    active BOOLEAN NOT NULL DEFAULT FALSE
+);
+
+CREATE TABLE IF NOT EXISTS store (
+    store_id VARCHAR(255) PRIMARY KEY,
+    business_id VARCHAR(255) NOT NULL,
+    name VARCHAR(255) NOT NULL,
+    metadata JSONB NOT NULL DEFAULT '{}',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS terminal (
+    terminal_id VARCHAR(255) PRIMARY KEY,
+    store_id VARCHAR(255) NOT NULL,
+    metadata JSONB NOT NULL DEFAULT '{}',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS app_token (
+    business_id VARCHAR(255) PRIMARY KEY,
+    access_token TEXT NOT NULL,
+    refresh_token TEXT NOT NULL,
+    expires_at TIMESTAMPTZ NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_app_token_expires_at ON app_token (expires_at);
+
+CREATE TABLE IF NOT EXISTS merchant_token (
+    business_id VARCHAR(255) PRIMARY KEY,
+    access_token TEXT NOT NULL,
+    refresh_token TEXT NOT NULL,
+    expires_at TIMESTAMPTZ NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_merchant_token_expires_at ON merchant_token (expires_at);
+
+CREATE TABLE IF NOT EXISTS subscription (
+    subscription_id VARCHAR(255) PRIMARY KEY,
+    business_id VARCHAR(255) NOT NULL,
+    store_id VARCHAR(255) NOT NULL,
+    plan_id VARCHAR(255) NOT NULL,
+    status VARCHAR(50) NOT NULL,
+    phase VARCHAR(50) NOT NULL,
+    trial_start_at TIMESTAMPTZ,
+    trial_end_at TIMESTAMPTZ,
+    start_at TIMESTAMPTZ NOT NULL,
+    current_period_end TIMESTAMPTZ,
+    end_at TIMESTAMPTZ,
+    cancel_at_period_end BOOLEAN NOT NULL DEFAULT FALSE,
+    canceled_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_subscription_current_period_end ON subscription (current_period_end);
+CREATE INDEX IF NOT EXISTS idx_subscription_store_status ON subscription (store_id, status);
+
+CREATE TABLE IF NOT EXISTS webhook_audit (
+    id SERIAL PRIMARY KEY,
+    event_type VARCHAR(100) NOT NULL,
+    payload JSONB NOT NULL DEFAULT '{}',
+    headers JSONB NOT NULL DEFAULT '{}',
+    received_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    processed BOOLEAN NOT NULL DEFAULT FALSE,
+    error_message TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_webhook_audit_event_type ON webhook_audit (event_type);
+CREATE INDEX IF NOT EXISTS idx_webhook_audit_received_at ON webhook_audit (received_at);
+
+CREATE TABLE IF NOT EXISTS log (
+    id SERIAL PRIMARY KEY,
+    request_id UUID NOT NULL,
+    type TEXT,
+    timestamp TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    level SMALLINT,
+    channel VARCHAR(64),
+    message TEXT,
+    merchant VARCHAR(64),
+    url TEXT,
+    details JSONB NOT NULL DEFAULT '{}'
+);
+CREATE INDEX IF NOT EXISTS idx_log_request_id ON log (request_id);
+CREATE INDEX IF NOT EXISTS idx_log_type ON log (type);
+CREATE INDEX IF NOT EXISTS idx_log_timestamp ON log (timestamp);
+CREATE INDEX IF NOT EXISTS idx_log_channel ON log (channel);
+CREATE INDEX IF NOT EXISTS idx_log_level ON log (level);
+CREATE INDEX IF NOT EXISTS idx_log_details_jsonb ON log USING GIN (details);
+
+CREATE TABLE IF NOT EXISTS token_refresh_log (
+    id SERIAL PRIMARY KEY,
+    business_id VARCHAR(255) NOT NULL,
+    token_type VARCHAR(20) NOT NULL,
+    attempted_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    success BOOLEAN NOT NULL,
+    message TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_token_refresh_log_lookup ON token_refresh_log (business_id, token_type, attempted_at);
+
+-- CUSTOMERS & USERS
+CREATE TABLE IF NOT EXISTS customer (
+    customer_id BIGINT PRIMARY KEY,
+    business_id VARCHAR(255) NOT NULL,
+    first_name VARCHAR(255),
+    last_name VARCHAR(255),
+    emails_json JSONB NOT NULL DEFAULT '[]',
+    phones_json JSONB NOT NULL DEFAULT '[]',
+    attributes JSONB NOT NULL DEFAULT '{}',
+    raw_payload JSONB NOT NULL DEFAULT '{}',
+    created_at_ext TIMESTAMPTZ,
+    updated_at_ext TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_customer_business_updated ON customer (business_id, updated_at_ext);
+
+CREATE TABLE IF NOT EXISTS business_user (
+    business_id VARCHAR(255) NOT NULL,
+    user_id BIGINT NOT NULL,
+    first_name VARCHAR(255),
+    last_name VARCHAR(255),
+    role VARCHAR(64),
+    status VARCHAR(32),
+    credentials JSONB NOT NULL DEFAULT '[]',
+    employment JSONB NOT NULL DEFAULT '{}',
+    raw_payload JSONB NOT NULL DEFAULT '{}',
+    created_at_ext TIMESTAMPTZ,
+    updated_at_ext TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (business_id, user_id)
+);
+CREATE INDEX IF NOT EXISTS idx_user_business ON business_user (business_id, role);
+
+-- PRODUCTS & INVENTORY
+CREATE TABLE IF NOT EXISTS product (
+    product_id VARCHAR(255) PRIMARY KEY,
+    business_id VARCHAR(255) NOT NULL,
+    name VARCHAR(255) NOT NULL,
+    sku VARCHAR(255),
+    price_minor BIGINT,
+    currency VARCHAR(3),
+    category_id VARCHAR(255),
+    is_active BOOLEAN,
+    attributes JSONB NOT NULL DEFAULT '{}',
+    raw_payload JSONB NOT NULL DEFAULT '{}',
+    created_at_ext TIMESTAMPTZ,
+    updated_at_ext TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_product_business_updated ON product (business_id, updated_at_ext);
+
+CREATE TABLE IF NOT EXISTS product_variant (
+    product_id VARCHAR(255) NOT NULL,
+    variant_id VARCHAR(255) NOT NULL,
+    name VARCHAR(255),
+    sku VARCHAR(255),
+    price_minor BIGINT,
+    attributes JSONB NOT NULL DEFAULT '{}',
+    raw_payload JSONB NOT NULL DEFAULT '{}',
+    created_at_ext TIMESTAMPTZ,
+    updated_at_ext TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (product_id, variant_id)
+);
+
+CREATE TABLE IF NOT EXISTS inventory_summary (
+    business_id VARCHAR(255) NOT NULL,
+    product_id VARCHAR(255) NOT NULL,
+    total_on_hand NUMERIC(18,3),
+    total_reserved NUMERIC(18,3),
+    updated_at_ext TIMESTAMPTZ,
+    payload JSONB NOT NULL DEFAULT '{}',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (business_id, product_id)
+);
+
+CREATE TABLE IF NOT EXISTS inventory (
+    business_id VARCHAR(255) NOT NULL,
+    store_id VARCHAR(255) NOT NULL,
+    product_id VARCHAR(255) NOT NULL,
+    on_hand NUMERIC(18,3),
+    reserved NUMERIC(18,3),
+    updated_at_ext TIMESTAMPTZ,
+    payload JSONB NOT NULL DEFAULT '{}',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (business_id, store_id, product_id)
+);
+
+CREATE TABLE IF NOT EXISTS variant_inventory (
+    business_id VARCHAR(255) NOT NULL,
+    store_id VARCHAR(255) NOT NULL,
+    product_id VARCHAR(255) NOT NULL,
+    variant_id VARCHAR(255) NOT NULL,
+    on_hand NUMERIC(18,3),
+    reserved NUMERIC(18,3),
+    updated_at_ext TIMESTAMPTZ,
+    payload JSONB NOT NULL DEFAULT '{}',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (business_id, store_id, product_id, variant_id)
+);
+
+-- CATALOGS & CATEGORIES
+CREATE TABLE IF NOT EXISTS catalog (
+    catalog_id VARCHAR(255) PRIMARY KEY,
+    business_id VARCHAR(255) NOT NULL,
+    name VARCHAR(255),
+    device_id VARCHAR(255),
+    metadata JSONB NOT NULL DEFAULT '{}',
+    raw_payload JSONB NOT NULL DEFAULT '{}',
+    created_at_ext TIMESTAMPTZ,
+    updated_at_ext TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS catalog_product (
+    catalog_id VARCHAR(255) NOT NULL,
+    product_id VARCHAR(255) NOT NULL,
+    position INTEGER,
+    payload JSONB NOT NULL DEFAULT '{}',
+    created_at_ext TIMESTAMPTZ,
+    updated_at_ext TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (catalog_id, product_id)
+);
+
+CREATE TABLE IF NOT EXISTS catalog_product_tax (
+    catalog_id VARCHAR(255) NOT NULL,
+    product_id VARCHAR(255) NOT NULL,
+    tax_id VARCHAR(255) NOT NULL,
+    payload JSONB NOT NULL DEFAULT '{}',
+    created_at_ext TIMESTAMPTZ,
+    updated_at_ext TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (catalog_id, product_id, tax_id)
+);
+
+CREATE TABLE IF NOT EXISTS catalog_available_discount (
+    catalog_id VARCHAR(255) NOT NULL,
+    discount_id VARCHAR(255) NOT NULL,
+    payload JSONB NOT NULL DEFAULT '{}',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (catalog_id, discount_id)
+);
+
+CREATE TABLE IF NOT EXISTS category (
+    category_id VARCHAR(255) PRIMARY KEY,
+    business_id VARCHAR(255) NOT NULL,
+    name VARCHAR(255),
+    parent_id VARCHAR(255),
+    raw_payload JSONB NOT NULL DEFAULT '{}',
+    created_at_ext TIMESTAMPTZ,
+    updated_at_ext TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS category_product (
+    catalog_id VARCHAR(255) NOT NULL,
+    category_id VARCHAR(255) NOT NULL,
+    product_id VARCHAR(255) NOT NULL,
+    business_id VARCHAR(255) NOT NULL,
+    position INTEGER,
+    payload JSONB NOT NULL DEFAULT '{}',
+    created_at_ext TIMESTAMPTZ,
+    updated_at_ext TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (catalog_id, category_id, product_id)
+);
+
+CREATE TABLE IF NOT EXISTS category_tax (
+    catalog_id VARCHAR(255) NOT NULL,
+    category_id VARCHAR(255) NOT NULL,
+    tax_id VARCHAR(255) NOT NULL,
+    business_id VARCHAR(255) NOT NULL,
+    payload JSONB NOT NULL DEFAULT '{}',
+    created_at_ext TIMESTAMPTZ,
+    updated_at_ext TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (catalog_id, category_id, tax_id)
+);
+
+-- TAXES
+CREATE TABLE IF NOT EXISTS tax (
+    tax_id VARCHAR(255) PRIMARY KEY,
+    business_id VARCHAR(255) NOT NULL,
+    name VARCHAR(255),
+    rate_bp INTEGER,
+    scope VARCHAR(64),
+    active BOOLEAN,
+    raw_payload JSONB NOT NULL DEFAULT '{}',
+    created_at_ext TIMESTAMPTZ,
+    updated_at_ext TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_tax_business ON tax (business_id, active);
+
+-- PAYLINKS
+CREATE TABLE IF NOT EXISTS paylink (
+    paylink_id VARCHAR(255) PRIMARY KEY,
+    business_id VARCHAR(255) NOT NULL,
+    url TEXT,
+    vanity_url TEXT,
+    domain VARCHAR(255),
+    title TEXT,
+    description TEXT,
+    status VARCHAR(32),
+    amount_minor BIGINT,
+    currency VARCHAR(3),
+    metadata JSONB NOT NULL DEFAULT '{}',
+    expires_at_ext TIMESTAMPTZ,
+    created_at_ext TIMESTAMPTZ,
+    updated_at_ext TIMESTAMPTZ,
+    raw_payload JSONB NOT NULL DEFAULT '{}',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS paylink_item (
+    paylink_id VARCHAR(255) NOT NULL,
+    business_id VARCHAR(255) NOT NULL,
+    item_ref VARCHAR(64) NOT NULL,
+    item_id VARCHAR(255),
+    name VARCHAR(255),
+    description TEXT,
+    amount_minor BIGINT,
+    currency VARCHAR(3),
+    quantity NUMERIC(18,3),
+    metadata JSONB NOT NULL DEFAULT '{}',
+    payload JSONB NOT NULL DEFAULT '{}',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (paylink_id, item_ref)
+);
+CREATE INDEX IF NOT EXISTS idx_paylink_item_business ON paylink_item (business_id);
+
+CREATE TABLE IF NOT EXISTS paylink_payment (
+    paylink_id VARCHAR(255) NOT NULL,
+    business_id VARCHAR(255) NOT NULL,
+    payment_ref VARCHAR(64) NOT NULL,
+    payment_id VARCHAR(255),
+    status VARCHAR(64),
+    amount_minor BIGINT,
+    currency VARCHAR(3),
+    processed_at_ext TIMESTAMPTZ,
+    payload JSONB NOT NULL DEFAULT '{}',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (paylink_id, payment_ref)
+);
+CREATE INDEX IF NOT EXISTS idx_paylink_payment_business ON paylink_payment (business_id);
+
+CREATE TABLE IF NOT EXISTS paylink_link (
+    paylink_id VARCHAR(255) NOT NULL,
+    business_id VARCHAR(255) NOT NULL,
+    link_ref VARCHAR(64) NOT NULL,
+    rel VARCHAR(128),
+    href TEXT,
+    method VARCHAR(16),
+    payload JSONB NOT NULL DEFAULT '{}',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (paylink_id, link_ref)
+);
+CREATE INDEX IF NOT EXISTS idx_paylink_link_business ON paylink_link (business_id);
+
+-- HOOKS
+CREATE TABLE IF NOT EXISTS hook (
+    hook_id VARCHAR(255) PRIMARY KEY,
+    business_id VARCHAR(255) NOT NULL,
+    url TEXT,
+    event_types TEXT[],
+    status VARCHAR(32),
+    raw_payload JSONB NOT NULL DEFAULT '{}',
+    created_at_ext TIMESTAMPTZ,
+    updated_at_ext TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS hook_delivery (
+    delivery_id VARCHAR(255) PRIMARY KEY,
+    hook_id VARCHAR(255) NOT NULL,
+    business_id VARCHAR(255) NOT NULL,
+    event_type VARCHAR(128),
+    delivered_at_ext TIMESTAMPTZ,
+    status VARCHAR(32),
+    http_status INTEGER,
+    retry_count INTEGER,
+    raw_payload JSONB NOT NULL DEFAULT '{}',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- ORDERS
+CREATE TABLE IF NOT EXISTS "order" (
+    order_id VARCHAR(255) PRIMARY KEY,
+    business_id VARCHAR(255) NOT NULL,
+    store_id VARCHAR(255),
+    currency VARCHAR(3),
+    status VARCHAR(32),
+    fulfillment_status VARCHAR(32),
+    transaction_status_summary VARCHAR(32),
+    subtotal_minor BIGINT,
+    discount_total_minor BIGINT,
+    tax_total_minor BIGINT,
+    tip_total_minor BIGINT,
+    fee_total_minor BIGINT,
+    shipping_total_minor BIGINT,
+    net_total_minor BIGINT,
+    tax_exempted BOOLEAN,
+    valid BOOLEAN,
+    accepted BOOLEAN,
+    notes TEXT,
+    customer_user_id BIGINT,
+    employee_user_id BIGINT,
+    store_device_id VARCHAR(255),
+    source VARCHAR(32),
+    source_app VARCHAR(128),
+    customer_json JSONB NOT NULL DEFAULT '{}',
+    transactions_json JSONB NOT NULL DEFAULT '[]',
+    amounts_json JSONB NOT NULL DEFAULT '{}',
+    context_json JSONB NOT NULL DEFAULT '{}',
+    raw_payload JSONB NOT NULL DEFAULT '{}',
+    created_at_ext TIMESTAMPTZ,
+    updated_at_ext TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_order_business_updated ON "order" (business_id, updated_at_ext);
+CREATE INDEX IF NOT EXISTS idx_order_store_status ON "order" (store_id, status);
+
+CREATE TABLE IF NOT EXISTS order_item (
+    order_id VARCHAR(255) NOT NULL REFERENCES "order"(order_id) ON DELETE CASCADE,
+    order_item_id VARCHAR(255) NOT NULL,
+    product_id VARCHAR(255),
+    name VARCHAR(255),
+    sku VARCHAR(255),
+    category_id VARCHAR(255),
+    quantity NUMERIC(18,3),
+    unit_price_minor BIGINT,
+    discount_minor BIGINT,
+    tax_minor BIGINT,
+    fee_minor BIGINT,
+    unit_of_measure VARCHAR(32),
+    status VARCHAR(32),
+    taxes_json JSONB NOT NULL DEFAULT '[]',
+    raw_payload JSONB NOT NULL DEFAULT '{}',
+    created_at_ext TIMESTAMPTZ,
+    updated_at_ext TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (order_id, order_item_id)
+);
+CREATE INDEX IF NOT EXISTS idx_order_item_product ON order_item (product_id);
+
+CREATE TABLE IF NOT EXISTS order_history (
+    order_id VARCHAR(255) NOT NULL REFERENCES "order"(order_id) ON DELETE CASCADE,
+    event VARCHAR(64),
+    ts_ext TIMESTAMPTZ,
+    payload JSONB NOT NULL DEFAULT '{}',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (order_id, event, ts_ext)
+);
+
+CREATE TABLE IF NOT EXISTS order_shipment (
+    order_id VARCHAR(255) NOT NULL REFERENCES "order"(order_id) ON DELETE CASCADE,
+    shipment_id VARCHAR(255) NOT NULL,
+    status VARCHAR(32),
+    amount_minor BIGINT,
+    carrier VARCHAR(64),
+    tracking_no VARCHAR(128),
+    fulfill_at_ext TIMESTAMPTZ,
+    shipped_at_ext TIMESTAMPTZ,
+    delivered_at_ext TIMESTAMPTZ,
+    payload JSONB NOT NULL DEFAULT '{}',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (order_id, shipment_id)
+);
+
+-- TRANSACTIONS
+CREATE TABLE IF NOT EXISTS transaction (
+    transaction_id VARCHAR(255) PRIMARY KEY,
+    business_id VARCHAR(255) NOT NULL,
+    store_id VARCHAR(255),
+    store_device_id VARCHAR(255),
+    employee_user_id BIGINT,
+    signature_required BOOLEAN,
+    signature_captured BOOLEAN,
+    pin_captured BOOLEAN,
+    adjusted BOOLEAN,
+    amounts_adjusted BOOLEAN,
+    auth_only BOOLEAN,
+    partially_approved BOOLEAN,
+    action_void BOOLEAN,
+    voided BOOLEAN,
+    settled BOOLEAN,
+    reversal_void BOOLEAN,
+    action VARCHAR(32),
+    status VARCHAR(32),
+    settlement_status VARCHAR(32),
+    transaction_instruction VARCHAR(64),
+    source VARCHAR(32),
+    source_app VARCHAR(255),
+    mcc VARCHAR(16),
+    customer_user_id BIGINT,
+    customer_language VARCHAR(16),
+    customer_opted_no_tip BOOLEAN,
+    txn_amount_minor BIGINT,
+    order_amount_minor BIGINT,
+    tip_amount_minor BIGINT,
+    cashback_amount_minor BIGINT,
+    currency VARCHAR(3),
+    approved_amount_minor BIGINT,
+    processor VARCHAR(64),
+    acquirer VARCHAR(64),
+    processor_status VARCHAR(64),
+    processor_code VARCHAR(32),
+    approval_code VARCHAR(32),
+    retrieval_ref VARCHAR(64),
+    batch_id VARCHAR(64),
+    processor_transaction_id VARCHAR(255),
+    references_json JSONB NOT NULL DEFAULT '[]',
+    links_json JSONB NOT NULL DEFAULT '[]',
+    funding_source JSONB NOT NULL DEFAULT '{}',
+    context_json JSONB NOT NULL DEFAULT '{}',
+    processor_options JSONB NOT NULL DEFAULT '{}',
+    processor_response JSONB NOT NULL DEFAULT '{}',
+    amounts_json JSONB NOT NULL DEFAULT '{}',
+    raw_payload JSONB NOT NULL DEFAULT '{}',
+    created_at_ext TIMESTAMPTZ,
+    updated_at_ext TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_tx_business_updated ON transaction (business_id, updated_at_ext);
+CREATE INDEX IF NOT EXISTS idx_tx_status ON transaction (status);
+CREATE INDEX IF NOT EXISTS idx_tx_action ON transaction (action);
+
+CREATE TABLE IF NOT EXISTS transaction_receipt (
+    transaction_id VARCHAR(255) PRIMARY KEY REFERENCES transaction(transaction_id) ON DELETE CASCADE,
+    html TEXT,
+    payload JSONB NOT NULL DEFAULT '{}',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);


### PR DESCRIPTION
## Summary
- add a new `poynt-v3.sql` containing the latest clean DDL for all tables and indexes

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692ed48718c8833192c9ae2c04121c8d)