### PR TITLE
Add tenant provisioning controller and service

### DIFF
--- a/app/Controllers/TenantController.php
+++ b/app/Controllers/TenantController.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Controllers;
+
+use App\Core\Api;
+use App\Core\Context;
+use App\Core\Response;
+use App\Services\Tenant\TenantProvisioningService;
+
+class TenantController extends Controller
+{
+    private TenantProvisioningService $tenantProvisioningService;
+
+    public function __construct(Context $context)
+    {
+        parent::__construct($context);
+        $this->tenantProvisioningService = new TenantProvisioningService($context);
+    }
+
+    public function provision(): void
+    {
+        $tenantId = (string) $this->api->getParam('tenantId');
+        $templates = $this->api->getParam('templates', []);
+        $templates = is_array($templates) ? $templates : [];
+
+        $result = $this->tenantProvisioningService->provisionTenant($tenantId, $templates);
+        $statusCode = $result['success'] ? Response::STATUS_OK : Response::STATUS_BAD_REQUEST;
+
+        Api::response($statusCode, $result);
+    }
+
+    public function setTenantProvisioningService(TenantProvisioningService $tenantProvisioningService): void
+    {
+        $this->tenantProvisioningService = $tenantProvisioningService;
+    }
+}

--- a/app/Core/Api.php
+++ b/app/Core/Api.php
@@ -297,6 +297,9 @@ class Api
         $router->get('/subscriptions/status', ['App\Controllers\SubscriptionController', 'status']);
         $router->post('/subscriptions/start-trial', ['App\Controllers\SubscriptionController', 'startTrial']);
 
+        // Tenant provisioning
+        $router->post('/tenants/provision', ['App\Controllers\TenantController', 'provision']);
+
         // Developer utilities
         $router->get('/sanity-check', ['App\Controllers\SanityCheckController', 'index']);
 

--- a/app/Services/Tenant/Provisioner.php
+++ b/app/Services/Tenant/Provisioner.php
@@ -65,14 +65,28 @@ class Provisioner
         $this->templatePath = $templatePath ?? $this->getDefaultTemplatePath();
     }
 
-    public function provision(string $businessId): bool
+    /**
+     * @param string   $businessId        Tenant identifier
+     * @param string[] $tableBaseNames    Optional subset of template base names to register
+     *
+     * @return array{success: bool, templateVersion?: int, registeredTables?: string[], error?: string}
+     */
+    public function provision(string $businessId, array $tableBaseNames = self::TABLE_BASE_NAMES): array
     {
         $tenantId = trim($businessId);
+        $tableBaseNames = $this->normalizeTableBaseNames($tableBaseNames);
+
+        if ($tableBaseNames === []) {
+            $tableBaseNames = self::TABLE_BASE_NAMES;
+        }
 
         if ($tenantId === '') {
             $this->context->getLog()->error('Provisioner::provision: missing business id');
 
-            return false;
+            return [
+                'success' => false,
+                'error' => 'Missing business id',
+            ];
         }
 
         try {
@@ -85,7 +99,11 @@ class Provisioner
                     ]
                 );
 
-                return true;
+                return [
+                    'success' => true,
+                    'templateVersion' => self::TEMPLATE_VERSION,
+                    'registeredTables' => $tableBaseNames,
+                ];
             }
 
             $statements = $this->renderStatements($tenantId);
@@ -96,7 +114,7 @@ class Provisioner
                 $this->conn->executeStatement($statement);
             }
 
-            $this->registerTenantTables($tenantId);
+            $this->registerTenantTables($tenantId, $tableBaseNames);
 
             $this->conn->commit();
 
@@ -106,27 +124,42 @@ class Provisioner
                     'businessId' => $tenantId,
                     'templateVersion' => self::TEMPLATE_VERSION,
                     'statementCount' => count($statements),
-                    'registeredTables' => count(self::TABLE_BASE_NAMES),
+                    'registeredTables' => count($tableBaseNames),
                 ]
             );
 
-            return true;
+            return [
+                'success' => true,
+                'templateVersion' => self::TEMPLATE_VERSION,
+                'registeredTables' => $tableBaseNames,
+            ];
         } catch (\Throwable $exception) {
             if ($this->conn->isTransactionActive()) {
                 $this->conn->rollBack();
             }
 
-            $this->context->getLog()->error(
-                sprintf(
-                    'Provisioner::provision: failed to provision tenant %s with template %s: %s',
-                    $tenantId,
-                    self::TEMPLATE_VERSION,
-                    $exception->getMessage()
-                )
+            $message = sprintf(
+                'Provisioner::provision: failed to provision tenant %s with template %s: %s',
+                $tenantId,
+                self::TEMPLATE_VERSION,
+                $exception->getMessage()
             );
 
-            return false;
+            $this->context->getLog()->error($message);
+
+            return [
+                'success' => false,
+                'error' => $message,
+            ];
         }
+    }
+
+    /**
+     * @return string[]
+     */
+    public static function getTemplateBaseNames(): array
+    {
+        return self::TABLE_BASE_NAMES;
     }
 
     private function tenantAlreadyProvisioned(string $businessId): bool
@@ -139,15 +172,30 @@ class Provisioner
         return $existing !== false;
     }
 
-    private function registerTenantTables(string $businessId): void
+    private function registerTenantTables(string $businessId, array $tableBaseNames): void
     {
-        foreach (self::TABLE_BASE_NAMES as $baseName) {
+        foreach ($tableBaseNames as $baseName) {
             $this->conn->insert('tenant_table_registry', [
                 'business_id' => $businessId,
                 'table_name' => $this->tableName($businessId, $baseName),
                 'template_version' => self::TEMPLATE_VERSION,
             ]);
         }
+    }
+
+    /**
+     * @param string[] $tableBaseNames
+     *
+     * @return string[]
+     */
+    private function normalizeTableBaseNames(array $tableBaseNames): array
+    {
+        $normalized = array_values(array_unique(array_filter(array_map(
+            static fn (string $name): string => trim($name),
+            array_map('strval', $tableBaseNames)
+        ), static fn (string $name): bool => $name !== '')));
+
+        return $normalized;
     }
 
     /**

--- a/app/Services/Tenant/TenantProvisioningService.php
+++ b/app/Services/Tenant/TenantProvisioningService.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace App\Services\Tenant;
+
+use App\Core\Context;
+
+class TenantProvisioningService
+{
+    private Context $context;
+
+    private Provisioner $provisioner;
+
+    public function __construct(Context $context, ?Provisioner $provisioner = null)
+    {
+        $this->context = $context;
+        $this->provisioner = $provisioner ?? new Provisioner($context);
+    }
+
+    /**
+     * Trigger tenant schema provisioning after the tenant row is created.
+     *
+     * @param string   $businessId Tenant identifier
+     * @param string[] $templates  Template base names requested by the caller
+     *
+     * @return array{success: bool, status: string, tenantId?: string, templates?: string[], templateVersion?: int, message?: string}
+     */
+    public function provisionTenant(string $businessId, array $templates = []): array
+    {
+        $tenantId = trim($businessId);
+        $templates = $this->normalizeTemplates($templates);
+
+        if ($tenantId === '') {
+            return [
+                'success' => false,
+                'status' => 'invalid',
+                'message' => 'Missing tenant identifier',
+            ];
+        }
+
+        if (!$this->tenantRowExists($tenantId)) {
+            return [
+                'success' => false,
+                'status' => 'not_found',
+                'message' => sprintf('Tenant row for %s not found', $tenantId),
+            ];
+        }
+
+        $provisioningResult = $this->provisioner->provision($tenantId, $templates);
+        $response = [
+            'success' => $provisioningResult['success'],
+            'status' => $provisioningResult['success'] ? 'provisioned' : 'failed',
+            'tenantId' => $tenantId,
+            'templates' => $provisioningResult['registeredTables'] ?? $templates,
+        ];
+
+        if (isset($provisioningResult['templateVersion'])) {
+            $response['templateVersion'] = $provisioningResult['templateVersion'];
+        }
+
+        if (!$provisioningResult['success'] && isset($provisioningResult['error'])) {
+            $response['message'] = $provisioningResult['error'];
+        }
+
+        return $response;
+    }
+
+    /**
+     * @param string[] $templates
+     *
+     * @return string[]
+     */
+    private function normalizeTemplates(array $templates): array
+    {
+        $normalized = array_values(array_unique(array_filter(array_map(
+            static fn (string $template): string => trim($template),
+            array_map('strval', $templates)
+        ), static fn (string $template): bool => $template !== '')));
+
+        if ($normalized === []) {
+            return Provisioner::getTemplateBaseNames();
+        }
+
+        return $normalized;
+    }
+
+    private function tenantRowExists(string $tenantId): bool
+    {
+        $existing = $this->context->getConn()->fetchOne(
+            'SELECT 1 FROM business WHERE business_id = ? LIMIT 1',
+            [$tenantId]
+        );
+
+        return $existing !== false;
+    }
+}

--- a/public/index.php
+++ b/public/index.php
@@ -72,6 +72,7 @@ $appContainer->add('App\Controllers\TokenController')->addArgument('CONTEXT');
 $appContainer->add('App\Controllers\WebhooksController')->addArgument('CONTEXT');
 $appContainer->add('App\Controllers\SubscriptionController')->addArgument('CONTEXT');
 $appContainer->add('App\Controllers\SanityCheckController')->addArgument('CONTEXT');
+$appContainer->add('App\Controllers\TenantController')->addArgument('CONTEXT');
 
 $resolver = new RouterResolver($appContainer);
 

--- a/tests/Controllers/ApiEndpointsTest.php
+++ b/tests/Controllers/ApiEndpointsTest.php
@@ -17,6 +17,7 @@ namespace Controllers {
 
     use App\Controllers\OAuthController;
     use App\Controllers\SubscriptionController;
+    use App\Controllers\TenantController;
     use App\Controllers\TokenController;
     use App\Controllers\WebhooksController;
     use App\Core\Api;
@@ -32,6 +33,8 @@ namespace Controllers {
     use App\Services\ProductService;
     use App\Services\ServiceFactory;
     use App\Services\SubscriptionService;
+    use App\Services\Tenant\Provisioner;
+    use App\Services\Tenant\TenantProvisioningService;
     use App\Services\TransactionService;
     use Doctrine\DBAL\Connection;
     use League\Container\Container;
@@ -293,6 +296,87 @@ namespace Controllers {
                 'subscriptionId' => 'sub-456',
                 'status' => 'free_trial',
             ], $result);
+        }
+
+        public function testTenantProvisionEndpointReturnsProvisionResult(): void
+        {
+            $api = $this->createApi([
+                'tenantId' => 'biz-123',
+                'templates' => ['store', 'subscription'],
+            ], 'POST');
+            $context = $this->createContext($api);
+
+            $service = $this->getMockBuilder(TenantProvisioningService::class)
+                ->disableOriginalConstructor()
+                ->onlyMethods(['provisionTenant'])
+                ->getMock();
+
+            $service->expects(self::once())
+                ->method('provisionTenant')
+                ->with('biz-123', ['store', 'subscription'])
+                ->willReturn([
+                    'success' => true,
+                    'status' => 'provisioned',
+                    'tenantId' => 'biz-123',
+                    'templates' => ['store', 'subscription'],
+                    'templateVersion' => 2025120201,
+                ]);
+
+            $controller = new TenantController($context);
+            $controller->setTenantProvisioningService($service);
+
+            $controller->provision();
+            $last = Api::getLastResponse();
+
+            self::assertNotNull($last);
+            self::assertSame(Response::STATUS_OK, $last['status']);
+            self::assertSame([
+                'success' => true,
+                'status' => 'provisioned',
+                'tenantId' => 'biz-123',
+                'templates' => ['store', 'subscription'],
+                'templateVersion' => 2025120201,
+            ], $last['response']);
+        }
+
+        public function testTenantProvisionEndpointSurfacesErrors(): void
+        {
+            $api = $this->createApi([
+                'tenantId' => 'biz-404',
+            ], 'POST');
+            $context = $this->createContext($api);
+
+            $service = $this->getMockBuilder(TenantProvisioningService::class)
+                ->disableOriginalConstructor()
+                ->onlyMethods(['provisionTenant'])
+                ->getMock();
+
+            $service->expects(self::once())
+                ->method('provisionTenant')
+                ->with('biz-404', [])
+                ->willReturn([
+                    'success' => false,
+                    'status' => 'failed',
+                    'tenantId' => 'biz-404',
+                    'templates' => Provisioner::getTemplateBaseNames(),
+                    'message' => 'DDL failure',
+                ]);
+
+            $controller = new TenantController($context);
+            $controller->setTenantProvisioningService($service);
+
+            $controller->provision();
+            $last = Api::getLastResponse();
+
+            self::assertNotNull($last);
+            self::assertSame(Response::STATUS_BAD_REQUEST, $last['status']);
+            self::assertSame([
+                'success' => false,
+                'status' => 'failed',
+                'tenantId' => 'biz-404',
+                'templates' => Provisioner::getTemplateBaseNames(),
+                'message' => 'DDL failure',
+            ], $last['response']);
         }
 
         public function testWebhookEndpointProcessesSubscriptionStartEvent(): void


### PR DESCRIPTION
## Summary
- add a tenant provisioning endpoint and container registration for invoking schema setup after tenant creation
- extend the Provisioner to accept a template list, normalize inputs, and return detailed status/error information
- add a dedicated tenant provisioning service and controller tests covering success and failure responses

## Testing
- ./vendor/bin/phpunit --filter ApiEndpointsTest *(fails: phpunit not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692f0c22f4d08331aeee76efb0565a53)