### PR TITLE
Provision tenant storage during callback onboarding

### DIFF
--- a/app/Services/CallbackService.php
+++ b/app/Services/CallbackService.php
@@ -6,6 +6,7 @@ use App\Core\Context;
 use App\Core\Response;
 use App\Modules\OAuth\PlatformRegistry;
 use App\Modules\OAuth\OAuthHandlerInterface;
+use App\Services\Tenant\TenantProvisioningService;
 use RuntimeException;
 use Throwable;
 
@@ -14,15 +15,18 @@ class CallbackService
     private Context $context;
     private PlatformRegistry $platformRegistry;
     private ServiceFactory $serviceFactory;
+    private TenantProvisioningService $tenantProvisioningService;
 
     public function __construct(
         Context $context,
         PlatformRegistry $platformRegistry,
-        ?ServiceFactory $serviceFactory = null
+        ?ServiceFactory $serviceFactory = null,
+        ?TenantProvisioningService $tenantProvisioningService = null
     ) {
         $this->context = $context;
         $this->platformRegistry = $platformRegistry;
         $this->serviceFactory = $serviceFactory ?? new ServiceFactory($context);
+        $this->tenantProvisioningService = $tenantProvisioningService ?? new TenantProvisioningService($context);
     }
 
     /**
@@ -58,6 +62,14 @@ class CallbackService
         $requestedPlanId = $this->normalizePlanParameter($this->context->getApi()->getParam('planId'));
         $requestedPlanName = $this->normalizePlanParameter($this->context->getApi()->getParam('planName'));
 
+        if (!$this->prepareTenantStorage($handler->getBusinessId())) {
+            return [
+                'success' => false,
+                'status' => Response::STATUS_INTERNAL_SERVER_ERROR,
+                'error' => 'Failed to prepare tenant storage for onboarding.',
+            ];
+        }
+
         $workflowSucceeded = $this->runBusinessWorkflow(
             $handler->getBusinessId(),
             $handler->getStoreId(),
@@ -82,6 +94,44 @@ class CallbackService
             'status' => Response::STATUS_OK,
             'message' => 'Callback handled',
         ];
+    }
+
+    private function prepareTenantStorage(?string $businessId): bool
+    {
+        if ($businessId === null || $businessId === '') {
+            $this->context->getLog()->error('CallbackService::prepareTenantStorage missing business identifier.');
+
+            return false;
+        }
+
+        $businessService = $this->serviceFactory->business($businessId);
+
+        if (!$this->syncResourceCollection($businessId, $businessService, get_class($businessService))) {
+            $this->context->getLog()->warning(
+                sprintf('CallbackService::prepareTenantStorage failed to sync business record for %s.', $businessId)
+            );
+
+            return false;
+        }
+
+        $provisioning = $this->tenantProvisioningService->provisionTenant($businessId);
+        if (!($provisioning['success'] ?? false)) {
+            $this->context->getLog()->error(
+                sprintf('CallbackService::prepareTenantStorage failed provisioning for %s: %s', $businessId, $provisioning['message'] ?? 'Unknown error')
+            );
+
+            return false;
+        }
+
+        $this->context->getLog()->info(
+            sprintf(
+                'CallbackService::prepareTenantStorage provisioned tenant %s with templates: %s',
+                $businessId,
+                implode(',', $provisioning['templates'] ?? [])
+            )
+        );
+
+        return true;
     }
 
     /**

--- a/tests/Services/CallbackServiceTest.php
+++ b/tests/Services/CallbackServiceTest.php
@@ -8,6 +8,7 @@ use App\Core\Context;
 use App\Modules\OAuth\PlatformRegistry;
 use App\Services\CallbackService;
 use App\Services\ServiceFactory;
+use App\Services\Tenant\TenantProvisioningService;
 use Doctrine\DBAL\Connection;
 use Monolog\Logger;
 use PHPUnit\Framework\TestCase;
@@ -317,5 +318,94 @@ class CallbackServiceTest extends TestCase
         $method->setAccessible(true);
 
         $this->assertSame('plan-pro', $method->invoke($callbackService, $plans, 'PRO'));
+    }
+
+    public function testPrepareTenantStorageSyncsBusinessBeforeProvisioning(): void
+    {
+        $logger = $this->createMock(Logger::class);
+        $context = $this->createMock(Context::class);
+        $context->method('getLog')->willReturn($logger);
+
+        $businessService = new class {
+            public array $upserted = [];
+
+            public function fetchByBusinessId(?string $businessId = null): array
+            {
+                return [['id' => $businessId, 'legalName' => 'Example Biz']];
+            }
+
+            public function upsert(array $payload): bool
+            {
+                $this->upserted[] = $payload;
+
+                return true;
+            }
+        };
+
+        $serviceFactory = $this->createMock(ServiceFactory::class);
+        $serviceFactory->method('business')->willReturn($businessService);
+
+        $tenantProvisioningService = $this->createMock(TenantProvisioningService::class);
+        $tenantProvisioningService->expects($this->once())
+            ->method('provisionTenant')
+            ->with('biz-123')
+            ->willReturn(['success' => true, 'templates' => ['store']]);
+
+        $callbackService = new CallbackService(
+            $context,
+            $this->createMock(PlatformRegistry::class),
+            $serviceFactory,
+            $tenantProvisioningService
+        );
+
+        $method = new ReflectionMethod($callbackService, 'prepareTenantStorage');
+        $method->setAccessible(true);
+
+        $this->assertTrue($method->invoke($callbackService, 'biz-123'));
+        $this->assertCount(1, $businessService->upserted);
+    }
+
+    public function testPrepareTenantStorageHaltsWhenProvisioningFails(): void
+    {
+        $logger = $this->createMock(Logger::class);
+        $logger->expects($this->once())
+            ->method('error')
+            ->with($this->stringContains('failed provisioning'));
+
+        $context = $this->createMock(Context::class);
+        $context->method('getLog')->willReturn($logger);
+
+        $businessService = new class {
+            public function fetchByBusinessId(?string $businessId = null): array
+            {
+                return [['id' => $businessId, 'legalName' => 'Example Biz']];
+            }
+
+            public function upsert(array $payload): bool
+            {
+                return true;
+            }
+        };
+
+        $serviceFactory = $this->createMock(ServiceFactory::class);
+        $serviceFactory->method('business')->willReturn($businessService);
+
+        $tenantProvisioningService = $this->createMock(TenantProvisioningService::class);
+        $tenantProvisioningService->expects($this->once())
+            ->method('provisionTenant')
+            ->with('biz-123')
+            ->willReturn(['success' => false, 'message' => 'boom']);
+
+        $callbackService = new CallbackService(
+            $context,
+            $this->createMock(PlatformRegistry::class),
+            $serviceFactory,
+            $tenantProvisioningService
+        );
+
+        $method = new ReflectionMethod($callbackService, 'prepareTenantStorage');
+        $method->setAccessible(true);
+
+        $this->assertFalse($method->invoke($callbackService, 'biz-123'));
     }
 }


### PR DESCRIPTION
## Summary
- prepare tenant storage before onboarding by syncing the business record and provisioning tenant tables from the callback flow
- integrate the tenant provisioning service into the OAuth callback handler prior to the business workflow
- add tests covering successful provisioning and failure handling in tenant preparation

## Testing
- not run (dependencies not installed in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6930240b5be48331ad40e7cebe683f99)