### PR TITLE
Align token and store persistence with tenant tables

### DIFF
--- a/app/Services/BackgroundJobService.php
+++ b/app/Services/BackgroundJobService.php
@@ -39,27 +39,27 @@ class BackgroundJobService
      */
     private function refreshAppTokens(): void
     {
-        try {
-            $tokens = $this->tokenService->findExpiringAppTokens();
-        } catch (\Throwable $e) {
-            $this->log->error('Failed to fetch expiring app tokens: ' . $e->getMessage());
-            return;
-        }
-
-        foreach ($tokens as $token) {
-            $bizId = $token['business_id'];
-
+        foreach ($this->fetchActiveTenantIds() as $bizId) {
             try {
-                $newToken = $this->oauthService->exchangeJwtForToken();
-                if (HelperService::validateTokenResponse($newToken)) {
-                    $this->tokenService->saveAppToken($bizId, $newToken);
-                    $this->tokenService->logRefreshAttempt($bizId, 'app', true);
-                } else {
-                    $this->tokenService->logRefreshAttempt($bizId, 'app', false, 'invalid token response');
-                }
+                $tokens = $this->tokenService->findExpiringAppTokens($bizId);
             } catch (\Throwable $e) {
-                $this->log->error("Failed to refresh app token for business_id={$bizId}: " . $e->getMessage());
-                $this->tokenService->logRefreshAttempt($bizId, 'app', false, $e->getMessage());
+                $this->log->error("Failed to fetch expiring app tokens for tenant={$bizId}: " . $e->getMessage());
+                continue;
+            }
+
+            foreach ($tokens as $token) {
+                try {
+                    $newToken = $this->oauthService->exchangeJwtForToken();
+                    if (HelperService::validateTokenResponse($newToken)) {
+                        $this->tokenService->saveAppToken($bizId, $newToken);
+                        $this->tokenService->logRefreshAttempt($bizId, 'app', true);
+                    } else {
+                        $this->tokenService->logRefreshAttempt($bizId, 'app', false, 'invalid token response');
+                    }
+                } catch (\Throwable $e) {
+                    $this->log->error("Failed to refresh app token for tenant={$bizId}: " . $e->getMessage());
+                    $this->tokenService->logRefreshAttempt($bizId, 'app', false, $e->getMessage());
+                }
             }
         }
     }
@@ -69,29 +69,48 @@ class BackgroundJobService
      */
     private function refreshMerchantTokens(): void
     {
-        try {
-            $tokens = $this->tokenService->findExpiringMerchantTokens();
-        } catch (\Throwable $e) {
-            $this->log->error('Failed to fetch expiring merchant tokens: ' . $e->getMessage());
-            return;
-        }
-
-        foreach ($tokens as $token) {
-            $bizId = $token['business_id'];
-            $refreshToken = $token['refresh_token'];
-
+        foreach ($this->fetchActiveTenantIds() as $bizId) {
             try {
-                $newToken = $this->oauthService->refreshMerchantToken($refreshToken);
-                if ($newToken && HelperService::validateTokenResponse($newToken)) {
-                    $this->tokenService->saveMerchantToken($bizId, $newToken);
-                    $this->tokenService->logRefreshAttempt($bizId, 'merchant', true);
-                } else {
-                    $this->tokenService->logRefreshAttempt($bizId, 'merchant', false, 'invalid token response');
-                }
+                $tokens = $this->tokenService->findExpiringMerchantTokens($bizId);
             } catch (\Throwable $e) {
-                $this->log->error("Failed to refresh merchant token for business_id={$bizId}: " . $e->getMessage());
-                $this->tokenService->logRefreshAttempt($bizId, 'merchant', false, $e->getMessage());
+                $this->log->error("Failed to fetch expiring merchant tokens for tenant={$bizId}: " . $e->getMessage());
+                continue;
             }
+
+            foreach ($tokens as $token) {
+                $refreshToken = $token['refresh_token'];
+
+                try {
+                    $newToken = $this->oauthService->refreshMerchantToken($refreshToken);
+                    if ($newToken && HelperService::validateTokenResponse($newToken)) {
+                        $this->tokenService->saveMerchantToken($bizId, $newToken);
+                        $this->tokenService->logRefreshAttempt($bizId, 'merchant', true);
+                    } else {
+                        $this->tokenService->logRefreshAttempt($bizId, 'merchant', false, 'invalid token response');
+                    }
+                } catch (\Throwable $e) {
+                    $this->log->error("Failed to refresh merchant token for tenant={$bizId}: " . $e->getMessage());
+                    $this->tokenService->logRefreshAttempt($bizId, 'merchant', false, $e->getMessage());
+                }
+            }
+        }
+    }
+
+    /**
+     * @return string[]
+     */
+    private function fetchActiveTenantIds(): array
+    {
+        try {
+            $rows = $this->context->getConn()->fetchFirstColumn(
+                'SELECT business_id FROM business WHERE active = TRUE'
+            );
+
+            return array_map('strval', $rows ?: []);
+        } catch (\Throwable $e) {
+            $this->log->error('Failed to load active tenants: ' . $e->getMessage());
+
+            return [];
         }
     }
 }

--- a/app/Services/BusinessService.php
+++ b/app/Services/BusinessService.php
@@ -5,6 +5,7 @@ namespace App\Services;
 use App\Core\Context;
 use App\Services\Support\FetchResponseLogger;
 use App\Services\Support\PoyntDataFormatter as Format;
+use App\Services\Support\TableNamer;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\GuzzleException;
 
@@ -13,6 +14,7 @@ class BusinessService {
     private Context $context;
     private ClientInterface $httpClient;
     private ?string $businessId = null;
+    private TableNamer $tableNamer;
 
     const POYNT_ENDPOINT_API_BUSINESS = 'https://services.poynt.net/businesses';
 
@@ -20,6 +22,7 @@ class BusinessService {
     {
         $this->context = $context;
         $this->httpClient = $httpClient ?? $context->getHttpClient();
+        $this->tableNamer = new TableNamer($context->getConn());
         if ($businessId !== null) {
             $this->businessId = $businessId;
         }
@@ -316,11 +319,13 @@ class BusinessService {
             return true;
         }
 
+        $storeTable = $this->tableNamer->for($this->businessId, 'store');
+
         $sql = <<<SQL
-        INSERT INTO store
-            (store_id, business_id, name, metadata, created_at, updated_at)
+        INSERT INTO {$storeTable}
+            (store_id, name, metadata, created_at, updated_at)
         VALUES
-            (:storeId, :businessId, :name, :metadata, :createdAt, :updatedAt)
+            (:storeId, :name, :metadata, :createdAt, :updatedAt)
         ON CONFLICT (store_id) DO UPDATE SET
             name       = EXCLUDED.name,
             metadata   = EXCLUDED.metadata,
@@ -333,25 +338,21 @@ class BusinessService {
             $now = (new \DateTime('now'))->format('Y-m-d H:i:sP');
 
             foreach ($stores as $store) {
-                if (
-                    !isset($store['id'], $store['businessId'], $store['displayName'])
-                ) {
+                if (!isset($store['id'], $store['displayName'])) {
                     $this->context->getLog()->error(
                         'BusinessService::insertStores: missing required store fields '
-                        . '(id, businessId, or displayName)'
+                        . '(id or displayName)'
                     );
                     return false;
                 }
 
                 $storeId    = $store['id'];
-                $businessId = $store['businessId'];
                 $name       = $store['displayName'];
 
                 $metadata = Format::jsonObject($store);
 
                 $stmt->executeStatement([
                     'storeId'    => $storeId,
-                    'businessId' => $businessId,
                     'name'       => $name,
                     'metadata'   => $metadata,
                     'createdAt'  => $now,

--- a/app/Services/StoreService.php
+++ b/app/Services/StoreService.php
@@ -101,20 +101,17 @@ class StoreService
         $sql = <<<SQL
         INSERT INTO {$storeTable} (
             store_id,
-            business_id,
             name,
             metadata,
             created_at,
             updated_at
         ) VALUES (
             :storeId,
-            :businessId,
             :name,
             :metadata,
             :createdAt,
             :updatedAt
         ) ON CONFLICT (store_id) DO UPDATE SET
-            business_id = EXCLUDED.business_id,
             name        = EXCLUDED.name,
             metadata    = EXCLUDED.metadata,
             updated_at  = EXCLUDED.updated_at
@@ -123,7 +120,6 @@ class StoreService
         try {
             $this->context->getConn()->executeStatement($sql, [
                 'storeId'    => $storeId,
-                'businessId' => $businessId,
                 'name'       => $name,
                 'metadata'   => $metadata,
                 'createdAt'  => $now,
@@ -157,46 +153,24 @@ class StoreService
             $terminalTable = $this->table('terminal', $businessId);
             $storeTable = $this->table('store', $businessId);
 
-            $inventoryParams = ['storeId' => $id];
-            if ($businessId !== null) {
-                $inventoryParams['businessId'] = $businessId;
+            $conn->executeStatement(
+                sprintf('DELETE FROM %s WHERE store_id = :storeId', $inventoryTable),
+                ['storeId' => $id]
+            );
 
-                $conn->executeStatement(
-                    sprintf('DELETE FROM %s WHERE business_id = :businessId AND store_id = :storeId', $inventoryTable),
-                    $inventoryParams
-                );
-
-                $conn->executeStatement(
-                    sprintf('DELETE FROM %s WHERE business_id = :businessId AND store_id = :storeId', $variantInventoryTable),
-                    $inventoryParams
-                );
-            } else {
-                $conn->executeStatement(
-                    sprintf('DELETE FROM %s WHERE store_id = :storeId', $inventoryTable),
-                    ['storeId' => $id]
-                );
-
-                $conn->executeStatement(
-                    sprintf('DELETE FROM %s WHERE store_id = :storeId', $variantInventoryTable),
-                    ['storeId' => $id]
-                );
-            }
+            $conn->executeStatement(
+                sprintf('DELETE FROM %s WHERE store_id = :storeId', $variantInventoryTable),
+                ['storeId' => $id]
+            );
 
             $conn->executeStatement(
                 sprintf('DELETE FROM %s WHERE store_id = :storeId', $terminalTable),
                 ['storeId' => $id]
             );
 
-            $storeParams = ['storeId' => $id];
-            $condition = 'store_id = :storeId';
-            if ($businessId !== null) {
-                $condition .= ' AND business_id = :businessId';
-                $storeParams['businessId'] = $businessId;
-            }
-
             $conn->executeStatement(
-                sprintf('DELETE FROM %s WHERE %s', $storeTable, $condition),
-                $storeParams
+                sprintf('DELETE FROM %s WHERE store_id = :storeId', $storeTable),
+                ['storeId' => $id]
             );
 
             $conn->commit();

--- a/app/Services/TokenService.php
+++ b/app/Services/TokenService.php
@@ -32,10 +32,10 @@ class TokenService {
     // ────────────────────────────────────────────────────────────────────────────────
 
     /**
-     * Insert or update the app-level token row for a given business_id.
+     * Insert or update the app-level token row for a given tenant.
      *
-     * @param string $businessId
-     * @param array $token
+     * @param string $businessId Tenant identifier used to resolve the table name
+     * @param array  $token
      * @return void
      * @throws \DateMalformedIntervalStringException
      */
@@ -56,9 +56,9 @@ class TokenService {
         $appTokenTable = $this->tableNamer->for($businessId, 'app_token');
         $sql = <<<SQL
         INSERT INTO {$appTokenTable}
-            (business_id, access_token, refresh_token, expires_at)
-        VALUES (:biz, :access, :refresh, :exp)
-        ON CONFLICT (business_id) DO UPDATE SET
+            (app_token_id, access_token, refresh_token, expires_at)
+        VALUES (1, :access, :refresh, :exp)
+        ON CONFLICT (app_token_id) DO UPDATE SET
             access_token  = EXCLUDED.access_token,
             refresh_token = EXCLUDED.refresh_token,
             expires_at    = EXCLUDED.expires_at,
@@ -68,14 +68,13 @@ class TokenService {
         try {
             $stmt = $this->context->getConn()->prepare($sql);
             $stmt->executeStatement([
-                'biz'     => $businessId,
                 'access'  => $token['accessToken'],
                 'refresh' => $token['refreshToken'],
                 'exp'     => $token['expiresIn']->format('Y-m-d H:i:sP'),
             ]);
         } catch (\Exception $e) {
             throw new \RuntimeException(
-                "Failed to save app token for business_id={$businessId}: " . $e->getMessage(),
+                "Failed to save app token for tenant={$businessId}: " . $e->getMessage(),
                 (int)$e->getCode(),
                 $e
             );
@@ -83,9 +82,9 @@ class TokenService {
     }
 
     /**
-     * Fetch the current app-level token (access, refresh, expires_at) for a given business_id.
+     * Fetch the current app-level token (access, refresh, expires_at) for a given tenant.
      *
-     * @param string $businessId
+     * @param string $businessId Tenant identifier used to resolve the table name
      * @param bool $array
      * @return array|null  ['access_token'=>string, 'refresh_token'=>string, 'expires_at'=>string] or null if not found
      */
@@ -97,13 +96,11 @@ class TokenService {
         $sql = <<<SQL
         SELECT access_token, refresh_token, expires_at
           FROM {$appTokenTable}
-         WHERE business_id = :biz
          LIMIT 1
         SQL;
 
         try {
             $row = $this->context->getConn()->fetchAssociative($sql, [
-                'biz' => $businessId
             ]);
 
             if ($array) {
@@ -113,7 +110,7 @@ class TokenService {
             return $row === false ? null : $row['access_token'];
         } catch (\Exception $e) {
             throw new \RuntimeException(
-                "Failed to fetch app token for business_id={$businessId}: " . $e->getMessage(),
+                "Failed to fetch app token for tenant={$businessId}: " . $e->getMessage(),
                 (int)$e->getCode(),
                 $e
             );
@@ -121,22 +118,23 @@ class TokenService {
     }
 
     /**
-     * Find all app-level tokens that expire within the next $minutes minutes.
+     * Find all app-level tokens that expire within the next $minutes minutes for a tenant.
      *
-     * @param int $minutes  Look-ahead window in minutes (defaults to 30).
-     * @return array[]      Each element: ['business_id'=>..., 'access_token'=>..., 'refresh_token'=>..., 'expires_at'=>...]
+     * @param string $businessId Tenant identifier used to resolve the table name
+     * @param int    $minutes     Look-ahead window in minutes (defaults to 30).
+     * @return array[]      Each element: ['access_token'=>..., 'refresh_token'=>..., 'expires_at'=>...]
      * @throws Exception on SQL error
      */
-    public function findExpiringAppTokens(int $minutes = 30): array
+    public function findExpiringAppTokens(string $businessId, int $minutes = 30): array
     {
         $this->resetFailedTransactionIfNeeded();
 
         // Safely interpolate $minutes into the INTERVAL clause
         $intervalSql = "NOW() + INTERVAL '{$minutes} minutes'";
 
-        $appTokenTable = $this->tableNamer->for(null, 'app_token');
+        $appTokenTable = $this->tableNamer->for($businessId, 'app_token');
         $sql = <<<SQL
-        SELECT business_id, access_token, refresh_token, expires_at
+        SELECT access_token, refresh_token, expires_at
           FROM {$appTokenTable}
          WHERE expires_at <= {$intervalSql}
         SQL;
@@ -146,7 +144,7 @@ class TokenService {
             return $stmt->executeQuery()->fetchAllAssociative();
         } catch (\Exception $e) {
             throw new \RuntimeException(
-                "Failed to query expiring app tokens (next {$minutes} minutes): " . $e->getMessage(),
+                "Failed to query expiring app tokens for tenant={$businessId} (next {$minutes} minutes): " . $e->getMessage(),
                 (int)$e->getCode(),
                 $e
             );
@@ -158,10 +156,10 @@ class TokenService {
     // ────────────────────────────────────────────────────────────────────────────────
 
     /**
-     * Insert or update the merchant-level token row for a given business_id.
+     * Insert or update the merchant-level token row for a given tenant.
      *
-     * @param string $businessId
-     * @param array $token
+     * @param string $businessId Tenant identifier used to resolve the table name
+     * @param array  $token
      * @return void
      * @throws \DateMalformedIntervalStringException
      */
@@ -180,9 +178,9 @@ class TokenService {
         $merchantTokenTable = $this->tableNamer->for($businessId, 'merchant_token');
         $sql = <<<SQL
         INSERT INTO {$merchantTokenTable}
-            (business_id, access_token, refresh_token, expires_at)
-        VALUES (:biz, :access, :refresh, :exp)
-        ON CONFLICT (business_id) DO UPDATE SET
+            (merchant_token_id, access_token, refresh_token, expires_at)
+        VALUES (1, :access, :refresh, :exp)
+        ON CONFLICT (merchant_token_id) DO UPDATE SET
             access_token  = EXCLUDED.access_token,
             refresh_token = EXCLUDED.refresh_token,
             expires_at    = EXCLUDED.expires_at,
@@ -192,14 +190,13 @@ class TokenService {
         try {
             $stmt = $this->context->getConn()->prepare($sql);
             $stmt->executeStatement([
-                'biz'     => $businessId,
                 'access'  => $token['accessToken'],
                 'refresh' => $token['refreshToken'],
                 'exp'     => $token['expiresIn']->format('Y-m-d H:i:sP'),
             ]);
         } catch (\Exception $e) {
             throw new \RuntimeException(
-                "Failed to save merchant token for business_id={$businessId}: " . $e->getMessage(),
+                "Failed to save merchant token for tenant={$businessId}: " . $e->getMessage(),
                 (int)$e->getCode(),
                 $e
             );
@@ -207,9 +204,9 @@ class TokenService {
     }
 
     /**
-     * Fetch the current merchant-level token for a given business_id.
+     * Fetch the current merchant-level token for a given tenant.
      *
-     * @param string $businessId
+     * @param string $businessId Tenant identifier used to resolve the table name
      * @param bool $array
      * @return array|null   ['access_token'=>string, 'refresh_token'=>string, 'expires_at'=>string] or null if not found
      */
@@ -221,13 +218,11 @@ class TokenService {
         $sql = <<<SQL
         SELECT access_token, refresh_token, expires_at
           FROM {$merchantTokenTable}
-         WHERE business_id = :biz
          LIMIT 1
         SQL;
 
         try {
             $row = $this->context->getConn()->fetchAssociative($sql, [
-                'biz' => $businessId
             ]);
 
             if ($array) {
@@ -237,7 +232,7 @@ class TokenService {
             return $row === false ? null : $row['access_token'];
         } catch (\Exception $e) {
             throw new \RuntimeException(
-                "Failed to fetch merchant token for business_id={$businessId}: " . $e->getMessage(),
+                "Failed to fetch merchant token for tenant={$businessId}: " . $e->getMessage(),
                 (int)$e->getCode(),
                 $e
             );
@@ -245,21 +240,22 @@ class TokenService {
     }
 
     /**
-     * Find all merchant-level tokens that are expiring within the next $minutes minutes.
+     * Find all merchant-level tokens that are expiring within the next $minutes minutes for a tenant.
      *
-     * @param int $minutes  Look-ahead window in minutes (defaults to 30).
-     * @return array[]      Each element: ['business_id'=>..., 'access_token'=>..., 'refresh_token'=>..., 'expires_at'=>...]
+     * @param string $businessId Tenant identifier used to resolve the table name
+     * @param int    $minutes  Look-ahead window in minutes (defaults to 30).
+     * @return array[]      Each element: ['access_token'=>..., 'refresh_token'=>..., 'expires_at'=>...]
      * @throws Exception on SQL error
      */
-    public function findExpiringMerchantTokens(int $minutes = 30): array
+    public function findExpiringMerchantTokens(string $businessId, int $minutes = 30): array
     {
         $this->resetFailedTransactionIfNeeded();
 
         $intervalSql = "NOW() + INTERVAL '{$minutes} minutes'";
 
-        $merchantTokenTable = $this->tableNamer->for(null, 'merchant_token');
+        $merchantTokenTable = $this->tableNamer->for($businessId, 'merchant_token');
         $sql = <<<SQL
-        SELECT business_id, access_token, refresh_token, expires_at
+        SELECT access_token, refresh_token, expires_at
           FROM {$merchantTokenTable}
          WHERE expires_at <= {$intervalSql}
         SQL;
@@ -269,7 +265,7 @@ class TokenService {
             return $stmt->executeQuery()->fetchAllAssociative();
         } catch (\Exception $e) {
             throw new \RuntimeException(
-                "Failed to query expiring merchant tokens (next {$minutes} minutes): " . $e->getMessage(),
+                "Failed to query expiring merchant tokens for tenant={$businessId} (next {$minutes} minutes): " . $e->getMessage(),
                 (int)$e->getCode(),
                 $e
             );
@@ -304,7 +300,7 @@ class TokenService {
     /**
      * Persist an attempt to refresh a token.
      *
-     * @param string      $businessId
+     * @param string      $businessId Tenant identifier used to resolve the table name
      * @param string      $type     'app' or 'merchant'
      * @param bool        $success
      * @param string|null $message
@@ -316,21 +312,20 @@ class TokenService {
 
         $refreshLogTable = $this->tableNamer->for($businessId, 'token_refresh_log');
         $sql = <<<SQL
-        INSERT INTO {$refreshLogTable} (business_id, token_type, attempted_at, success, message)
-        VALUES (:biz, :type, NOW(), :success, :message)
+        INSERT INTO {$refreshLogTable} (token_type, attempted_at, success, message)
+        VALUES (:type, NOW(), :success, :message)
         SQL;
 
         try {
             $stmt = $this->context->getConn()->prepare($sql);
             $stmt->executeStatement([
-                'biz'     => $businessId,
                 'type'    => $type,
                 'success' => $success,
                 'message' => $message,
             ]);
         } catch (\Exception $e) {
             $this->context->getLog()->error(
-                "Failed to log token refresh attempt for business_id={$businessId}: " . $e->getMessage()
+                "Failed to log token refresh attempt for tenant={$businessId}: " . $e->getMessage()
             );
         }
     }


### PR DESCRIPTION
## Summary
- update token persistence to work with per-tenant tables and remove reliance on business_id columns
- adjust background job refresh flow to iterate active tenants and use tenant-scoped token lookups
- align store/business persistence with tenant table naming

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69303b1d348883318315a71343d8ebc8)