### PR TITLE
Quote tenant table names

### DIFF
--- a/app/Services/Support/TableNamer.php
+++ b/app/Services/Support/TableNamer.php
@@ -4,10 +4,13 @@ namespace App\Services\Support;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\ParameterType;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
 
 class TableNamer
 {
     private Connection $conn;
+
+    private AbstractPlatform $platform;
 
     private bool $tenantConnectionScoped;
 
@@ -19,6 +22,7 @@ class TableNamer
     public function __construct(Connection $conn, ?bool $tenantConnectionScoped = null)
     {
         $this->conn = $conn;
+        $this->platform = $conn->getDatabasePlatform();
         $this->tenantConnectionScoped = $tenantConnectionScoped ?? $this->resolveTenantConnectionScope();
     }
 
@@ -31,7 +35,7 @@ class TableNamer
         }
 
         if ($this->tenantConnectionScoped || $businessId === null || $businessId === '') {
-            return $baseName;
+            return $this->quoteIdentifier($baseName);
         }
 
         $cacheKey = sprintf('%s:%s', $businessId, $baseName);
@@ -52,15 +56,16 @@ class TableNamer
             ]
         );
 
-        if (is_string($registered) && $registered !== '') {
-            $this->cache[$cacheKey] = $registered;
+        $resolvedName = $defaultName;
 
-            return $registered;
+        if (is_string($registered) && $registered !== '') {
+            $resolvedName = $registered;
         }
 
-        $this->cache[$cacheKey] = $defaultName;
+        $quotedName = $this->quoteIdentifier($resolvedName);
+        $this->cache[$cacheKey] = $quotedName;
 
-        return $defaultName;
+        return $quotedName;
     }
 
     private function resolveTenantConnectionScope(): bool
@@ -72,5 +77,10 @@ class TableNamer
         }
 
         return filter_var($flag, FILTER_VALIDATE_BOOLEAN);
+    }
+
+    private function quoteIdentifier(string $identifier): string
+    {
+        return $this->platform->quoteIdentifier($identifier);
     }
 }

--- a/app/Services/Tenant/Provisioner.php
+++ b/app/Services/Tenant/Provisioner.php
@@ -5,6 +5,7 @@ namespace App\Services\Tenant;
 use App\Core\Context;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\ParameterType;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
 
 class Provisioner
 {
@@ -56,6 +57,8 @@ class Provisioner
 
     private Connection $conn;
 
+    private AbstractPlatform $platform;
+
     private string $templatePath;
 
     /**
@@ -67,6 +70,7 @@ class Provisioner
     {
         $this->context = $context;
         $this->conn = $context->getConn();
+        $this->platform = $this->conn->getDatabasePlatform();
         $this->templatePath = $templatePath ?? $this->getDefaultTemplatePath();
     }
 
@@ -195,7 +199,10 @@ class Provisioner
 
             foreach (self::DROP_ORDER as $baseName) {
                 $this->conn->executeStatement(
-                    sprintf('DROP TABLE IF EXISTS public.%s_%s CASCADE', $tenantId, $baseName)
+                    sprintf(
+                        'DROP TABLE IF EXISTS public.%s CASCADE',
+                        $this->quoteIdentifier(sprintf('%s_%s', $tenantId, $baseName))
+                    )
                 );
             }
 
@@ -276,11 +283,15 @@ class Provisioner
         $templateStatements = $this->extractTemplateStatements($templateSql, $tableBaseNames);
 
         $renderedStatements = array_map(
-            static fn (string $statement): string => (string) preg_replace(
-                '/([A-Za-z0-9_]+)_template/',
-                sprintf('%s_\1', $businessId),
-                $statement
-            ),
+            function (string $statement) use ($businessId): string {
+                return (string) preg_replace_callback(
+                    '/([A-Za-z0-9_]+)_template/',
+                    function (array $matches) use ($businessId): string {
+                        return $this->quoteIdentifier(sprintf('%s_%s', $businessId, $matches[1]));
+                    },
+                    $statement
+                );
+            },
             $templateStatements
         );
 
@@ -342,6 +353,11 @@ class Provisioner
     private function normalizeTenantId(string $businessId): string
     {
         return strtolower(trim($businessId));
+    }
+
+    private function quoteIdentifier(string $identifier): string
+    {
+        return $this->platform->quoteIdentifier($identifier);
     }
 
     private function resolveRequestedBaseNames(array $tableBaseNames): array

--- a/tests/Services/Support/TableNamerTest.php
+++ b/tests/Services/Support/TableNamerTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Services\Support;
+
+use App\Services\Support\TableNamer;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use PHPUnit\Framework\TestCase;
+
+class TableNamerTest extends TestCase
+{
+    public function testQuotesTenantTableWhenRegistryMissing(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->method('getDatabasePlatform')->willReturn(new PostgreSQLPlatform());
+        $connection->method('fetchOne')->willReturn(false);
+
+        $namer = new TableNamer($connection);
+
+        self::assertSame(
+            '"3fb53611-061a-4464-8ca7-0b91ca7c98cf_app_token"',
+            $namer->for('3fb53611-061a-4464-8ca7-0b91ca7c98cf', 'app_token')
+        );
+    }
+
+    public function testUsesRegistryTableNameAndCachesQuotedIdentifier(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->method('getDatabasePlatform')->willReturn(new PostgreSQLPlatform());
+        $connection->expects(self::once())
+            ->method('fetchOne')
+            ->willReturn('registered_app_token_v2');
+
+        $namer = new TableNamer($connection);
+
+        self::assertSame('"registered_app_token_v2"', $namer->for('demo', 'app_token'));
+        self::assertSame('"registered_app_token_v2"', $namer->for('demo', 'app_token'));
+    }
+}

--- a/tests/Services/Tenant/ProvisionerTest.php
+++ b/tests/Services/Tenant/ProvisionerTest.php
@@ -7,6 +7,7 @@ namespace Tests\Services\Tenant;
 use App\Core\Context;
 use App\Services\Tenant\Provisioner;
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Monolog\Handler\NullHandler;
 use Monolog\Logger;
 use PHPUnit\Framework\TestCase;
@@ -68,9 +69,9 @@ class ProvisionerTest extends TestCase
         self::assertSame(
             [
                 'SELECT pg_advisory_xact_lock(hashtext(?))',
-                'CREATE TABLE IF NOT EXISTS demotenant_store (store_id INT)',
-                'CREATE INDEX idx_demotenant_store_id ON demotenant_store (store_id)',
-                'CREATE TABLE IF NOT EXISTS demotenant_terminal (terminal_id INT REFERENCES demotenant_store(store_id))',
+                'CREATE TABLE IF NOT EXISTS "demotenant_store" (store_id INT)',
+                'CREATE INDEX "demotenant_idx_store_id" ON "demotenant_store" (store_id)',
+                'CREATE TABLE IF NOT EXISTS "demotenant_terminal" (terminal_id INT REFERENCES "demotenant_store"(store_id))',
                 'DELETE FROM tenant_table_registry WHERE business_id = ?',
             ],
             array_slice($statements, 0, 5)
@@ -115,8 +116,8 @@ class ProvisionerTest extends TestCase
         self::assertSame(2025120201, $result['templateVersion']);
 
         self::assertSame('SELECT pg_advisory_xact_lock(hashtext(?))', $statements[0]);
-        self::assertStringStartsWith('DROP TABLE IF EXISTS public.demotenant_transaction_receipt', $statements[1]);
-        self::assertStringStartsWith('DROP TABLE IF EXISTS public.demotenant_store', $statements[count($statements) - 2]);
+        self::assertStringStartsWith('DROP TABLE IF EXISTS public."demotenant_transaction_receipt"', $statements[1]);
+        self::assertStringStartsWith('DROP TABLE IF EXISTS public."demotenant_store"', $statements[count($statements) - 2]);
         self::assertStringContainsString('DELETE FROM tenant_schema_version', end($statements));
     }
 
@@ -132,6 +133,7 @@ class ProvisionerTest extends TestCase
         $logger->pushHandler(new NullHandler());
 
         $connection = $this->createMock(Connection::class);
+        $connection->method('getDatabasePlatform')->willReturn(new PostgreSQLPlatform());
         $connection->method('beginTransaction')->willReturn(true);
         $connection->method('commit')->willReturn(true);
         $connection->method('rollBack')->willReturn(null);


### PR DESCRIPTION
## Summary
- quote tenant table names through TableNamer to support tenant IDs that require identifier quoting
- render and drop tenant-scoped tables with quoted identifiers during provisioning
- add tests covering identifier quoting and updated provisioning expectations

## Testing
- ./vendor/bin/phpunit --filter ProvisionerTest,TableNamerTest (fails: phpunit vendor binary missing)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69315c93ee4483319e510625f0b5c79c)