### PR TITLE
Provision tenant tables before saving tokens

### DIFF
--- a/app/Services/CallbackService.php
+++ b/app/Services/CallbackService.php
@@ -70,6 +70,8 @@ class CallbackService
             ];
         }
 
+        $handler->storeTokens($tokenResult['appToken'] ?? [], $tokenResult['merchantToken'] ?? []);
+
         $workflowSucceeded = $this->runBusinessWorkflow(
             $handler->getBusinessId(),
             $handler->getStoreId(),
@@ -171,14 +173,10 @@ class CallbackService
             ];
         }
 
-        $appToken = $tokenResponse['data']['appAccessToken'] ?? [];
-        $merchantToken = $tokenResponse['data']['merchantAccessToken'] ?? [];
-        $handler->storeTokens($appToken, $merchantToken);
-
         return [
             'success' => true,
-            'appToken' => $appToken,
-            'merchantToken' => $merchantToken,
+            'appToken' => $tokenResponse['data']['appAccessToken'] ?? [],
+            'merchantToken' => $tokenResponse['data']['merchantAccessToken'] ?? [],
         ];
     }
 


### PR DESCRIPTION
## Summary
- retrieve OAuth tokens before provisioning and persist them only after tenant storage is prepared
- keep token persistence after provisioning to avoid missing tenant-scoped tables

## Testing
- ./vendor/bin/phpunit

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69315ee16b9c83319dd24f7721011b60)