### PR TITLE
Allow tenant provisioning without existing business row

### DIFF
--- a/app/Services/Tenant/TenantProvisioningService.php
+++ b/app/Services/Tenant/TenantProvisioningService.php
@@ -46,14 +46,6 @@ class TenantProvisioningService
             ];
         }
 
-        if (!$this->tenantRowExists($tenantId)) {
-            return [
-                'success' => false,
-                'status' => 'not_found',
-                'message' => sprintf('Tenant row for %s not found', $tenantId),
-            ];
-        }
-
         $provisioningResult = $this->provisioner->provision($tenantId, $templates);
         $response = [
             'success' => $provisioningResult['success'],
@@ -90,15 +82,5 @@ class TenantProvisioningService
         }
 
         return $normalized;
-    }
-
-    private function tenantRowExists(string $tenantId): bool
-    {
-        $existing = $this->context->getConn()->fetchOne(
-            'SELECT 1 FROM business WHERE business_id = ? LIMIT 1',
-            [$tenantId]
-        );
-
-        return $existing !== false;
     }
 }


### PR DESCRIPTION
## Summary
- remove the business row existence check before provisioning tenant schemas so onboarding can proceed even before the business is stored

## Testing
- not run (phpunit not available in the environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6931687dbdc48331a94cd893373db5ab)