### PR TITLE
Drop tenant tables during purge workflow

### DIFF
--- a/app/Services/CallbackService.php
+++ b/app/Services/CallbackService.php
@@ -1011,6 +1011,29 @@ class CallbackService
         $transactionStarted = false;
 
         try {
+            try {
+                $dropResult = $this->tenantProvisioningService->dropTenant($businessId);
+
+                if (!($dropResult['success'] ?? false)) {
+                    $this->context->getLog()->warning(
+                        sprintf(
+                            'CallbackService::purgeBusinessInstallation failed to drop tenant tables for business %s: %s',
+                            $businessId,
+                            $dropResult['error'] ?? 'Unknown error'
+                        )
+                    );
+                }
+            } catch (Throwable $dropException) {
+                $this->context->getLog()->error(
+                    sprintf(
+                        'CallbackService::purgeBusinessInstallation drop failed for business %s: %s',
+                        $businessId,
+                        $dropException->getMessage()
+                    ),
+                    ['exception' => $dropException]
+                );
+            }
+
             $conn->beginTransaction();
             $transactionStarted = true;
 

--- a/app/Services/Tenant/TenantProvisioningService.php
+++ b/app/Services/Tenant/TenantProvisioningService.php
@@ -74,6 +74,23 @@ class TenantProvisioningService
         return $response;
     }
 
+    /**
+     * @return array{success: bool, templateVersion?: int, error?: string}
+     */
+    public function dropTenant(string $businessId): array
+    {
+        $tenantId = strtolower(trim($businessId));
+
+        if ($tenantId === '') {
+            return [
+                'success' => false,
+                'error' => 'Missing tenant identifier',
+            ];
+        }
+
+        return $this->provisioner->drop($tenantId);
+    }
+
     private function ensureCoreSchemaExists(): bool
     {
         $conn = $this->context->getConn();

--- a/tests/Services/CallbackServiceTest.php
+++ b/tests/Services/CallbackServiceTest.php
@@ -17,12 +17,14 @@ use ReflectionMethod;
 
 class CallbackServiceTest extends TestCase
 {
-    private function createCallbackService(Context $context): CallbackService
-    {
+    private function createCallbackService(
+        Context $context,
+        ?TenantProvisioningService $tenantProvisioningService = null
+    ): CallbackService {
         $platformRegistry = $this->createMock(PlatformRegistry::class);
         $serviceFactory = $this->createMock(ServiceFactory::class);
 
-        return new CallbackService($context, $platformRegistry, $serviceFactory);
+        return new CallbackService($context, $platformRegistry, $serviceFactory, $tenantProvisioningService);
     }
 
     public function testNormalizeResourceItemsSeparatesLinksFromItems(): void
@@ -158,10 +160,17 @@ class CallbackServiceTest extends TestCase
 
         $context->method('getConn')->willReturn($connection);
 
+        $tenantProvisioningService = $this->createMock(TenantProvisioningService::class);
+        $tenantProvisioningService->expects($this->once())
+            ->method('dropTenant')
+            ->with('business-123')
+            ->willReturn(['success' => true]);
+
         $callbackService = new CallbackService(
             $context,
             $this->createMock(PlatformRegistry::class),
-            $this->createMock(ServiceFactory::class)
+            $this->createMock(ServiceFactory::class),
+            $tenantProvisioningService
         );
 
         $callbackService->purgeBusiness('business-123', false);
@@ -191,10 +200,17 @@ class CallbackServiceTest extends TestCase
 
         $context->method('getConn')->willReturn($connection);
 
+        $tenantProvisioningService = $this->createMock(TenantProvisioningService::class);
+        $tenantProvisioningService->expects($this->once())
+            ->method('dropTenant')
+            ->with('business-123')
+            ->willReturn(['success' => true]);
+
         $callbackService = new CallbackService(
             $context,
             $this->createMock(PlatformRegistry::class),
-            $this->createMock(ServiceFactory::class)
+            $this->createMock(ServiceFactory::class),
+            $tenantProvisioningService
         );
 
         $callbackService->purgeBusiness('business-123');


### PR DESCRIPTION
## Summary
- invoke tenant table teardown during business purge to clear tenant schemas
- expose a dropTenant helper on the provisioning service for reuse
- update purge workflow tests to expect tenant schema cleanup

## Testing
- ./vendor/bin/phpunit tests/Services/CallbackServiceTest.php (fails: vendor binaries not available in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69317660575c8331a2410d96fea32ecb)