### PR TITLE
Drop tenant tables during business purge

### DIFF
--- a/app/Services/CallbackService.php
+++ b/app/Services/CallbackService.php
@@ -1060,9 +1060,10 @@ class CallbackService
     }
 
     /**
-     * Remove all local data for a business.
+     * Remove all local data for a business by dropping tenant tables and clearing registry rows.
      *
-     * Tokens are preserved by default so a subsequent reinstall can reuse them.
+     * Token tables are part of the tenant schema and will be dropped as well; the $preserveTokens
+     * flag is retained for compatibility and only controls informational logging.
      */
     public function purgeBusiness(string $businessId, bool $preserveTokens = true): void
     {
@@ -1074,37 +1075,35 @@ class CallbackService
         $conn = $this->context->getConn();
         $transactionStarted = false;
 
+        $dropResult = $this->tenantProvisioningService->dropTenant($businessId);
+
+        if (!($dropResult['success'] ?? false)) {
+            $this->context->getLog()->error(
+                sprintf(
+                    'CallbackService::purgeBusinessInstallation failed to drop tenant tables for business %s: %s',
+                    $businessId,
+                    $dropResult['message'] ?? 'unknown error'
+                )
+            );
+
+            return;
+        }
+
+        if ($preserveTokens) {
+            $this->context->getLog()->info(
+                sprintf(
+                    'CallbackService::purgeBusinessInstallation dropping tenant tables removes stored tokens for business %s.',
+                    $businessId
+                )
+            );
+        }
+
         try {
             $conn->beginTransaction();
             $transactionStarted = true;
 
-            $conn->executeStatement('DELETE FROM token_refresh_log WHERE business_id = :biz', ['biz' => $businessId]);
-            $conn->executeStatement('DELETE FROM hook_delivery WHERE business_id = :biz', ['biz' => $businessId]);
-            $conn->executeStatement('DELETE FROM hook WHERE business_id = :biz', ['biz' => $businessId]);
-            $conn->executeStatement('DELETE FROM paylink WHERE business_id = :biz', ['biz' => $businessId]);
-            $conn->executeStatement('DELETE FROM "order" WHERE business_id = :biz', ['biz' => $businessId]);
-            $conn->executeStatement('DELETE FROM transaction WHERE business_id = :biz', ['biz' => $businessId]);
-            $conn->executeStatement('DELETE FROM subscription WHERE business_id = :biz', ['biz' => $businessId]);
-            $conn->executeStatement('DELETE FROM catalog_available_discount WHERE catalog_id IN (SELECT catalog_id FROM catalog WHERE business_id = :biz)', ['biz' => $businessId]);
-            $conn->executeStatement('DELETE FROM catalog_product WHERE catalog_id IN (SELECT catalog_id FROM catalog WHERE business_id = :biz)', ['biz' => $businessId]);
-            $conn->executeStatement('DELETE FROM catalog WHERE business_id = :biz', ['biz' => $businessId]);
-            $conn->executeStatement('DELETE FROM variant_inventory WHERE business_id = :biz', ['biz' => $businessId]);
-            $conn->executeStatement('DELETE FROM inventory WHERE business_id = :biz', ['biz' => $businessId]);
-            $conn->executeStatement('DELETE FROM inventory_summary WHERE business_id = :biz', ['biz' => $businessId]);
-            $conn->executeStatement('DELETE FROM product_variant WHERE product_id IN (SELECT product_id FROM product WHERE business_id = :biz)', ['biz' => $businessId]);
-            $conn->executeStatement('DELETE FROM product WHERE business_id = :biz', ['biz' => $businessId]);
-            $conn->executeStatement('DELETE FROM category WHERE business_id = :biz', ['biz' => $businessId]);
-            $conn->executeStatement('DELETE FROM tax WHERE business_id = :biz', ['biz' => $businessId]);
-            $conn->executeStatement('DELETE FROM customer WHERE business_id = :biz', ['biz' => $businessId]);
-            $conn->executeStatement('DELETE FROM business_user WHERE business_id = :biz', ['biz' => $businessId]);
-            $conn->executeStatement('DELETE FROM terminal WHERE store_id IN (SELECT store_id FROM store WHERE business_id = :biz)', ['biz' => $businessId]);
-            $conn->executeStatement('DELETE FROM store WHERE business_id = :biz', ['biz' => $businessId]);
-
-            if (!$preserveTokens) {
-                $conn->executeStatement('DELETE FROM merchant_token WHERE business_id = :biz', ['biz' => $businessId]);
-                $conn->executeStatement('DELETE FROM app_token WHERE business_id = :biz', ['biz' => $businessId]);
-            }
-
+            $conn->executeStatement('DELETE FROM tenant_table_registry WHERE business_id = :biz', ['biz' => $businessId]);
+            $conn->executeStatement('DELETE FROM tenant_schema_version WHERE tenant_id = :biz', ['biz' => $businessId]);
             $conn->executeStatement('DELETE FROM business WHERE business_id = :biz', ['biz' => $businessId]);
 
             $conn->commit();

--- a/app/Services/Tenant/Provisioner.php
+++ b/app/Services/Tenant/Provisioner.php
@@ -207,6 +207,12 @@ class Provisioner
             }
 
             $this->conn->executeStatement(
+                'DELETE FROM tenant_table_registry WHERE business_id = ?',
+                [$tenantId],
+                [ParameterType::STRING]
+            );
+
+            $this->conn->executeStatement(
                 'DELETE FROM tenant_schema_version WHERE tenant_id = ?',
                 [$tenantId],
                 [ParameterType::STRING]

--- a/app/Services/Tenant/TenantProvisioningService.php
+++ b/app/Services/Tenant/TenantProvisioningService.php
@@ -74,6 +74,51 @@ class TenantProvisioningService
         return $response;
     }
 
+    /**
+     * Drop all tenant-scoped tables for the given business identifier.
+     *
+     * @param string $businessId
+     * @return array{success: bool, status: string, tenantId?: string, templateVersion?: int, message?: string}
+     */
+    public function dropTenant(string $businessId): array
+    {
+        $tenantId = strtolower(trim($businessId));
+
+        if (!$this->ensureCoreSchemaExists()) {
+            return [
+                'success' => false,
+                'status' => 'failed',
+                'message' => 'Failed to prepare core schema for tenant teardown',
+            ];
+        }
+
+        if ($tenantId === '') {
+            return [
+                'success' => false,
+                'status' => 'invalid',
+                'message' => 'Missing tenant identifier',
+            ];
+        }
+
+        $dropResult = $this->provisioner->drop($tenantId);
+
+        $response = [
+            'success' => $dropResult['success'],
+            'status' => $dropResult['success'] ? 'dropped' : 'failed',
+            'tenantId' => $tenantId,
+        ];
+
+        if (isset($dropResult['templateVersion'])) {
+            $response['templateVersion'] = $dropResult['templateVersion'];
+        }
+
+        if (!$dropResult['success'] && isset($dropResult['error'])) {
+            $response['message'] = $dropResult['error'];
+        }
+
+        return $response;
+    }
+
     private function ensureCoreSchemaExists(): bool
     {
         $conn = $this->context->getConn();

--- a/tests/Services/Tenant/ProvisionerTest.php
+++ b/tests/Services/Tenant/ProvisionerTest.php
@@ -117,7 +117,8 @@ class ProvisionerTest extends TestCase
 
         self::assertSame('SELECT pg_advisory_xact_lock(hashtext(?))', $statements[0]);
         self::assertStringStartsWith('DROP TABLE IF EXISTS public."demotenant_transaction_receipt"', $statements[1]);
-        self::assertStringStartsWith('DROP TABLE IF EXISTS public."demotenant_store"', $statements[count($statements) - 2]);
+        self::assertStringStartsWith('DROP TABLE IF EXISTS public."demotenant_store"', $statements[count($statements) - 3]);
+        self::assertStringContainsString('DELETE FROM tenant_table_registry', $statements[count($statements) - 2]);
         self::assertStringContainsString('DELETE FROM tenant_schema_version', end($statements));
     }
 


### PR DESCRIPTION
## Summary
- drop tenant-scoped tables through the provisioning service when purging a business
- add a TenantProvisioningService helper for teardown and log token removal warnings
- clear tenant table registry entries during drops and update related tests

## Testing
- ./vendor/bin/phpunit --filter ProvisionerTest *(fails: No such file or directory; phpunit not installed in vendor)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693182239c6c8331800de3756894a6c4)