### PR TITLE
Allow forcing shared log scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,52 @@ The OAuth callback flow provisions and validates tenant storage before running t
   php scripts/delete_subscriptions.php --business=<BUSINESS_ID> [--dry-run]
   ```
 
+## Logging to shared vs. per-tenant tables
+`LoggerFactory::create()` wires a Monolog logger with `CustomPDOHandler`, which automatically picks the shared `log` table or a tenant-prefixed log table based on the context. Example usage:
+
+```php
+use App\Services\Support\LoggerFactory;
+
+[$logger] = LoggerFactory::create($primaryConn, $logConn);
+
+// Shared log table: omit the tenant identifier in the context
+$logger->info('Shared audit event', [
+    'type' => 'audit',
+    'details' => ['action' => 'ping'],
+]);
+
+// Per-tenant log table: include businessId/business_id/merchant in the context
+$logger->info('Tenant-scoped event', [
+    'businessId' => 'tenant_123',
+    'type' => 'webhook',
+    'details' => ['event' => 'subscription.updated'],
+]);
+
+// Service example: log to the shared table from a tenant-aware workflow
+// Keep the tenant identifier out of the top-level context keys
+// (businessId/business_id/merchant) so TableNamer picks the shared `log` table.
+// If processors add a tenant ID by default, set log_scope => 'shared' to override.
+if (!($dropResult['success'] ?? false)) {
+    $this->context->getLog()->error(
+        sprintf(
+            'CallbackService::purgeBusinessInstallation failed to drop tenant tables for business %s: %s',
+            $businessId,
+            $dropResult['message'] ?? 'unknown error'
+        ),
+        [
+            'log_scope' => 'shared',
+            'type' => 'maintenance',
+            'details' => [
+                'businessId' => $businessId,
+                'dropResult' => $dropResult,
+            ],
+        ]
+    );
+
+    return;
+}
+```
+
 ## Testing
 Run the PHPUnit suite after installing dependencies:
 ```bash

--- a/app/Services/CallbackService.php
+++ b/app/Services/CallbackService.php
@@ -1083,7 +1083,15 @@ class CallbackService
                     'CallbackService::purgeBusinessInstallation failed to drop tenant tables for business %s: %s',
                     $businessId,
                     $dropResult['message'] ?? 'unknown error'
-                )
+                ),
+                [
+                    'log_scope' => 'shared',
+                    'type' => 'maintenance',
+                    'details' => [
+                        'businessId' => $businessId,
+                        'dropResult' => $dropResult,
+                    ],
+                ]
             );
 
             return;

--- a/app/Services/CustomPDOHandler.php
+++ b/app/Services/CustomPDOHandler.php
@@ -71,6 +71,11 @@ class CustomPDOHandler extends AbstractProcessingHandler
     {
         $context = $record['context'] ?? [];
 
+        $logScope = $context['log_scope'] ?? $context['logScope'] ?? null;
+        if (is_string($logScope) && strtolower($logScope) === 'shared') {
+            return null;
+        }
+
         foreach (['businessId', 'business_id', 'merchant'] as $key) {
             if (isset($context[$key]) && is_string($context[$key]) && $context[$key] !== '') {
                 return $context[$key];


### PR DESCRIPTION
## Summary
- allow CustomPDOHandler to honor `log_scope => 'shared'` when resolving the log table
- log tenant drop failures from CallbackService with shared scope metadata
- document the shared-scope override in README examples

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936b84bce148329b6ded59d1efa59f9)