### PR TITLE
Honor shared log scope even with tenant context

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,52 @@ The OAuth callback flow provisions and validates tenant storage before running t
   php scripts/delete_subscriptions.php --business=<BUSINESS_ID> [--dry-run]
   ```
 
+## Logging to shared vs. per-tenant tables
+`LoggerFactory::create()` wires a Monolog logger with `CustomPDOHandler`, which automatically picks the shared `log` table or a tenant-prefixed log table based on the context. Example usage:
+
+```php
+use App\Services\Support\LoggerFactory;
+
+[$logger] = LoggerFactory::create($primaryConn, $logConn);
+
+// Shared log table: omit the tenant identifier in the context
+$logger->info('Shared audit event', [
+    'type' => 'audit',
+    'details' => ['action' => 'ping'],
+]);
+
+// Per-tenant log table: include businessId/business_id/merchant in the context
+$logger->info('Tenant-scoped event', [
+    'businessId' => 'tenant_123',
+    'type' => 'webhook',
+    'details' => ['event' => 'subscription.updated'],
+]);
+
+// Service example: log to the shared table from a tenant-aware workflow
+// Keep the tenant identifier out of the top-level context keys
+// (businessId/business_id/merchant) so TableNamer picks the shared `log` table.
+// If processors add a tenant ID by default, set log_scope => 'shared' to override.
+if (!($dropResult['success'] ?? false)) {
+    $this->context->getLog()->error(
+        sprintf(
+            'CallbackService::purgeBusinessInstallation failed to drop tenant tables for business %s: %s',
+            $businessId,
+            $dropResult['message'] ?? 'unknown error'
+        ),
+        [
+            'log_scope' => 'shared',
+            'type' => 'maintenance',
+            'details' => [
+                'businessId' => $businessId,
+                'dropResult' => $dropResult,
+            ],
+        ]
+    );
+
+    return;
+}
+```
+
 ## Testing
 Run the PHPUnit suite after installing dependencies:
 ```bash

--- a/app/Services/CallbackService.php
+++ b/app/Services/CallbackService.php
@@ -1083,7 +1083,15 @@ class CallbackService
                     'CallbackService::purgeBusinessInstallation failed to drop tenant tables for business %s: %s',
                     $businessId,
                     $dropResult['message'] ?? 'unknown error'
-                )
+                ),
+                [
+                    'log_scope' => 'shared',
+                    'type' => 'maintenance',
+                    'details' => [
+                        'businessId' => $businessId,
+                        'dropResult' => $dropResult,
+                    ],
+                ]
             );
 
             return;

--- a/app/Services/CustomPDOHandler.php
+++ b/app/Services/CustomPDOHandler.php
@@ -46,7 +46,9 @@ class CustomPDOHandler extends AbstractProcessingHandler
             $connection->connect();
         }
 
-        $tableName = $this->tableNamer->for($this->resolveBusinessId($record), 'log');
+        $businessId = $this->resolveBusinessId($record);
+
+        $tableName = $this->tableNamer->for($businessId, 'log');
 
         $this->ensureLogTableExists($connection, $tableName);
 
@@ -70,14 +72,42 @@ class CustomPDOHandler extends AbstractProcessingHandler
     private function resolveBusinessId(array $record): ?string
     {
         $context = $record['context'] ?? [];
+        $extra = $record['extra'] ?? [];
+
+        if ($this->isSharedScope($context, $extra)) {
+            return null;
+        }
 
         foreach (['businessId', 'business_id', 'merchant'] as $key) {
             if (isset($context[$key]) && is_string($context[$key]) && $context[$key] !== '') {
                 return $context[$key];
             }
+
+            if (isset($extra[$key]) && is_string($extra[$key]) && $extra[$key] !== '') {
+                return $extra[$key];
+            }
         }
 
         return null;
+    }
+
+    private function isSharedScope(array $context, array $extra): bool
+    {
+        $logScope = $context['log_scope'] ?? $context['logScope'] ?? $extra['log_scope'] ?? $extra['logScope'] ?? null;
+
+        if ($logScope === null) {
+            return false;
+        }
+
+        if (is_bool($logScope)) {
+            return $logScope === true;
+        }
+
+        if (is_string($logScope) && strtolower(trim($logScope)) === 'shared') {
+            return true;
+        }
+
+        return false;
     }
 
     private function ensureLogTableExists(Connection $connection, string $tableName): void


### PR DESCRIPTION
## Summary
- ensure CustomPDOHandler ignores tenant identifiers when log_scope marks a record as shared
- allow log_scope/tenant context in Monolog `extra` data to opt into shared logging

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936b84bce148329b6ded59d1efa59f9)