### PR TITLE
Add business trial window enforcement and audit logging

### DIFF
--- a/SQL/poynt-v3.sql
+++ b/SQL/poynt-v3.sql
@@ -7,7 +7,10 @@ CREATE TABLE IF NOT EXISTS business (
     metadata JSONB NOT NULL DEFAULT '{}',
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    active BOOLEAN NOT NULL DEFAULT FALSE
+    active BOOLEAN NOT NULL DEFAULT FALSE,
+    initial_gathering BOOLEAN NOT NULL DEFAULT FALSE,
+    trial_eligible BOOLEAN NOT NULL DEFAULT FALSE,
+    trial_expires_at TIMESTAMPTZ
 );
 
 CREATE TABLE IF NOT EXISTS store (
@@ -66,6 +69,19 @@ CREATE TABLE IF NOT EXISTS subscription (
 );
 CREATE INDEX IF NOT EXISTS idx_subscription_current_period_end ON subscription (current_period_end);
 CREATE INDEX IF NOT EXISTS idx_subscription_store_status ON subscription (store_id, status);
+
+CREATE TABLE IF NOT EXISTS subscription_plan_audit (
+    id SERIAL PRIMARY KEY,
+    business_id VARCHAR(255) NOT NULL,
+    store_id VARCHAR(255),
+    plan_id VARCHAR(255) NOT NULL,
+    decided_by VARCHAR(255) NOT NULL,
+    decision_reason TEXT NOT NULL,
+    decided_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    metadata JSONB NOT NULL DEFAULT '{}'::jsonb
+);
+CREATE INDEX IF NOT EXISTS idx_subscription_plan_audit_business ON subscription_plan_audit (business_id);
+CREATE INDEX IF NOT EXISTS idx_subscription_plan_audit_store ON subscription_plan_audit (store_id);
 
 CREATE TABLE IF NOT EXISTS webhook_audit (
     id SERIAL PRIMARY KEY,

--- a/app/Services/BusinessService.php
+++ b/app/Services/BusinessService.php
@@ -8,6 +8,7 @@ use App\Services\Support\PoyntDataFormatter as Format;
 use App\Services\Support\TableNamer;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\GuzzleException;
+use DateTimeInterface;
 
 class BusinessService {
 
@@ -35,6 +36,8 @@ class BusinessService {
      *                             - 'businessId' (string),
      *                             - 'storeId'    (string),
      *                             - 'name'       (string),
+     *                             - 'trialEligible' (bool, optional),
+     *                             - 'trialExpiresAt' (DateTimeInterface|string, optional)
      *
      * @return bool  True on success, false on failure.
      */
@@ -54,6 +57,9 @@ class BusinessService {
         // 1.a) Decide on "active". If the payload does not include it, default to true.
         $active = !isset($businessData['active']) || (bool)$businessData['active'];
 
+        $trialEligible = $businessData['trialEligible'] ?? null;
+        $trialExpiresAt = $this->normalizeTrialExpiry($businessData['trialExpiresAt'] ?? null);
+
         // 2) Prepare the full payload as JSON for the metadata column
         $metadata = Format::jsonObject($businessData);
 
@@ -67,33 +73,40 @@ class BusinessService {
                 [$businessId]
             );
 
+            $insertPayload = [
+                'business_id' => $businessId,
+                'name' => $name,
+                'metadata' => $metadata,
+                'created_at' => $now,
+                'updated_at' => $now,
+                'active' => $active,
+            ];
+
+            $updatePayload = [
+                'name' => $name,
+                'metadata' => $metadata,
+                'updated_at' => $now,
+                'active' => $active,
+            ];
+
+            if ($trialEligible !== null) {
+                $insertPayload['trial_eligible'] = (bool) $trialEligible;
+                $updatePayload['trial_eligible'] = (bool) $trialEligible;
+            }
+
+            if ($trialExpiresAt !== null) {
+                $insertPayload['trial_expires_at'] = $trialExpiresAt;
+                $updatePayload['trial_expires_at'] = $trialExpiresAt;
+            }
+
             if ($existing) {
                 // 5a) UPDATE path (include 'active' here)
-                $this->context->getConn()->update(
-                    'business',
-                    [
-                        'name' => $name,
-                        'metadata' => $metadata,
-                        'updated_at' => $now,
-                        'active' => $active,
-                    ],
-                    ['business_id' => $businessId]
-                );
+                $this->context->getConn()->update('business', $updatePayload, ['business_id' => $businessId]);
 
                 $this->context->getLog()->info("BusinessService::upsert: updated business {$businessId}");
             } else {
                 // 5b) INSERT path (include 'active' here, too)
-                $this->context->getConn()->insert(
-                    'business',
-                    [
-                        'business_id' => $businessId,
-                        'name' => $name,
-                        'metadata' => $metadata,
-                        'created_at' => $now,
-                        'updated_at' => $now,
-                        'active' => $active,
-                    ]
-                );
+                $this->context->getConn()->insert('business', $insertPayload);
 
                 $this->context->getLog()->info("BusinessService::upsert: inserted new business {$businessId}");
             }
@@ -253,6 +266,95 @@ class BusinessService {
 
         return false;
 
+    }
+
+    public function getTrialState(?string $businessId = null): array
+    {
+        if ($businessId === null) {
+            $businessId = $this->businessId;
+        }
+
+        if (!$businessId) {
+            return [
+                'eligible' => false,
+                'expiresAt' => null,
+            ];
+        }
+
+        $sql = 'SELECT trial_eligible, trial_expires_at FROM business WHERE business_id = ? ORDER BY updated_at DESC LIMIT 1';
+
+        try {
+            $row = $this->context->getConn()->fetchAssociative($sql, [$businessId]);
+        } catch (\Throwable $e) {
+            $this->context->getLog()->error(
+                sprintf('BusinessService::getTrialState failed for business %s: %s', $businessId, $e->getMessage())
+            );
+
+            return [
+                'eligible' => false,
+                'expiresAt' => null,
+            ];
+        }
+
+        if (!$row) {
+            return [
+                'eligible' => false,
+                'expiresAt' => null,
+            ];
+        }
+
+        return [
+            'eligible' => (bool) ($row['trial_eligible'] ?? false),
+            'expiresAt' => $row['trial_expires_at'] ?? null,
+        ];
+    }
+
+    public function setTrialWindow(string $businessId, bool $eligible, ?DateTimeInterface $expiresAt): bool
+    {
+        $normalizedExpiry = $this->normalizeTrialExpiry($expiresAt);
+
+        try {
+            $updated = $this->context->getConn()->executeStatement(
+                'UPDATE business SET trial_eligible = :eligible, trial_expires_at = :expires, updated_at = NOW() WHERE business_id = :business',
+                [
+                    'eligible' => $eligible,
+                    'expires' => $normalizedExpiry,
+                    'business' => $businessId,
+                ]
+            );
+
+            return $updated > 0;
+        } catch (\Throwable $e) {
+            $this->context->getLog()->error(
+                sprintf('BusinessService::setTrialWindow failed for business %s: %s', $businessId, $e->getMessage())
+            );
+
+            return false;
+        }
+    }
+
+    private function normalizeTrialExpiry(mixed $value): ?string
+    {
+        if ($value instanceof DateTimeInterface) {
+            return $value->format('Y-m-d H:i:sP');
+        }
+
+        if (is_string($value)) {
+            $trimmed = trim($value);
+            if ($trimmed === '') {
+                return null;
+            }
+
+            try {
+                $date = new \DateTime($trimmed);
+
+                return $date->format('Y-m-d H:i:sP');
+            } catch (\Throwable) {
+                return null;
+            }
+        }
+
+        return null;
     }
 
 

--- a/app/Services/CallbackService.php
+++ b/app/Services/CallbackService.php
@@ -8,6 +8,12 @@ use App\Modules\OAuth\PlatformRegistry;
 use App\Modules\OAuth\OAuthHandlerInterface;
 use App\Services\Tenant\TenantProvisioningService;
 use App\Services\BusinessService;
+use App\Services\SubscriptionService;
+use App\Services\Support\PoyntDataFormatter as Format;
+use DateInterval;
+use DateTimeImmutable;
+use DateTimeInterface;
+use DateTimeZone;
 use RuntimeException;
 use Throwable;
 
@@ -247,14 +253,15 @@ class CallbackService
                 ]
             );
 
-//            $this->upsertBusinessRecord($businessId);
+            $trialExpiresAt = $this->bootstrapBusinessTrial($businessId, $storeId);
 
             if (!$this->synchronizeStoresAndSubscriptions(
                 $businessId,
                 $appAccessToken,
                 $merchantAccessToken,
                 $requestedPlanId,
-                $requestedPlanName
+                $requestedPlanName,
+                $trialExpiresAt
             )) {
                 throw new RuntimeException(
                     sprintf('Failed to synchronize stores or subscriptions for business %s.', $businessId)
@@ -333,6 +340,53 @@ class CallbackService
         $this->context->getLog()->info(
             sprintf('CallbackService::runBusinessWorkflow upserted business %s.', $businessId)
         );
+    }
+
+    private function bootstrapBusinessTrial(string $businessId, ?string $storeId): ?DateTimeImmutable
+    {
+        /** @var BusinessService $businessService */
+        $businessService = $this->serviceFactory->business($businessId);
+        $trialState = $businessService->getTrialState($businessId);
+        $existingExpiry = $this->normalizeTrialExpiry($trialState['expiresAt'] ?? null);
+
+        if ($existingExpiry !== null) {
+            return $existingExpiry;
+        }
+
+        $trialExpiry = (new DateTimeImmutable('now', new DateTimeZone('UTC')))
+            ->add(new DateInterval(sprintf('P%dD', SubscriptionService::DEFAULT_TRIAL_DAYS)));
+
+        $payload = $businessService->fetchBusiness($businessId);
+        if (!is_array($payload)) {
+            $this->context->getLog()->warning(
+                sprintf('Using fallback business payload while initializing trial for %s.', $businessId)
+            );
+
+            $payload = [
+                'id' => $businessId,
+                'legalName' => $businessId,
+            ];
+        }
+
+        $payload['trialEligible'] = true;
+        $payload['trialExpiresAt'] = $trialExpiry;
+
+        if (!$businessService->upsert($payload)) {
+            throw new RuntimeException(
+                sprintf('Failed to upsert business %s while initializing trial window.', $businessId)
+            );
+        }
+
+        $this->recordPlanDecision(
+            $businessId,
+            $storeId,
+            'free_trial',
+            'CallbackService',
+            'Initialized business-level trial window.',
+            ['trialExpiresAt' => $trialExpiry->format(DateTimeInterface::ATOM)]
+        );
+
+        return $trialExpiry;
     }
 
     private function logWorkflowFailureRootCause(?string $businessId, Throwable $exception): void
@@ -451,7 +505,8 @@ class CallbackService
         ?string $appAccessToken,
         ?string $merchantAccessToken,
         ?string $requestedPlanId,
-        ?string $requestedPlanName
+        ?string $requestedPlanName,
+        ?DateTimeImmutable $businessTrialExpiresAt
     ): bool {
         $storeService = $this->serviceFactory->store($businessId);
         $storesPayload = $storeService->fetchByBusinessId($businessId);
@@ -520,7 +575,8 @@ class CallbackService
                 $storeId,
                 $appAccessToken,
                 $merchantAccessToken,
-                $planId
+                $planId,
+                $businessTrialExpiresAt
             )) {
                 return false;
             }
@@ -534,7 +590,8 @@ class CallbackService
         string $storeId,
         ?string $appAccessToken,
         ?string $merchantAccessToken,
-        ?string $defaultPlanId
+        ?string $defaultPlanId,
+        ?DateTimeImmutable $businessTrialExpiresAt
     ): bool {
         $subscriptionService = $this->serviceFactory->subscription($businessId, $storeId);
 
@@ -568,12 +625,87 @@ class CallbackService
             $localSubscriptions
         );
 
-        if (!empty($matchingSubscriptions)) {
+        $trialExpiry = $businessTrialExpiresAt;
+        $now = new DateTimeImmutable('now', new DateTimeZone('UTC'));
+        $trialActive = $trialExpiry !== null && $trialExpiry > $now;
+        $trialExpired = $trialExpiry !== null && $trialExpiry <= $now;
+
+        if (!empty($matchingSubscriptions) || !empty($localSubscriptions)) {
+            if ($trialActive) {
+                $planId = $this->resolvePlanIdFromSubscriptions($matchingSubscriptions, $localSubscriptions) ?? 'free_trial';
+                $this->recordPlanDecision(
+                    $businessId,
+                    $storeId,
+                    $planId,
+                    'CallbackService',
+                    'Business trial active; retaining existing subscription.',
+                    ['trialExpiresAt' => $trialExpiry?->format(DateTimeInterface::ATOM)]
+                );
+            }
+
             return true;
         }
 
-        if (!empty($localSubscriptions)) {
+        if ($trialActive) {
+            try {
+                $subscriptionId = $subscriptionService->startFreeTrial($businessId, $storeId, 'free_trial', $trialExpiry);
+                $this->recordPlanDecision(
+                    $businessId,
+                    $storeId,
+                    'free_trial',
+                    'CallbackService',
+                    'Business trial active; assigning free trial plan to store.',
+                    ['subscriptionId' => $subscriptionId, 'trialExpiresAt' => $trialExpiry->format(DateTimeInterface::ATOM)]
+                );
+            } catch (Throwable $e) {
+                $this->context->getLog()->error(
+                    sprintf(
+                        'Failed to start business-aligned free trial for business %s store %s: %s',
+                        $businessId,
+                        $storeId,
+                        $e->getMessage()
+                    )
+                );
+
+                return false;
+            }
+
             return true;
+        }
+
+        if ($trialExpired) {
+            $this->recordPlanDecision(
+                $businessId,
+                $storeId,
+                $defaultPlanId ?? 'none',
+                'CallbackService',
+                'Business trial expired; blocking until paid plan is provided.',
+                ['trialExpiresAt' => $trialExpiry->format(DateTimeInterface::ATOM)]
+            );
+
+            if (!$defaultPlanId) {
+                $this->context->getLog()->warning(
+                    sprintf(
+                        'Business %s store %s cannot continue: trial expired and no plan specified.',
+                        $businessId,
+                        $storeId
+                    )
+                );
+
+                return false;
+            }
+        }
+
+        if ($trialExpired && (!$appAccessToken || !$merchantAccessToken)) {
+            $this->context->getLog()->warning(
+                sprintf(
+                    'Business %s store %s cannot create paid subscription: tokens missing after trial expiry.',
+                    $businessId,
+                    $storeId
+                )
+            );
+
+            return false;
         }
 
         if (!$appAccessToken || !$merchantAccessToken || !$defaultPlanId) {
@@ -586,7 +718,7 @@ class CallbackService
             );
 
             try {
-                $fallbackSubscriptionId = $subscriptionService->startFreeTrial($businessId, $storeId);
+                $fallbackSubscriptionId = $subscriptionService->startFreeTrial($businessId, $storeId, 'free_trial', $trialExpiry);
                 $this->context->getLog()->info(
                     sprintf(
                         'Started local free trial %s for business %s store %s as a fallback.',
@@ -621,6 +753,78 @@ class CallbackService
         );
 
         return $created !== [];
+    }
+
+    private function resolvePlanIdFromSubscriptions(array $remoteSubscriptions, array $localSubscriptions): ?string
+    {
+        foreach ([$remoteSubscriptions, $localSubscriptions] as $collection) {
+            foreach ($collection as $subscription) {
+                if (!is_array($subscription)) {
+                    continue;
+                }
+
+                $planId = $subscription['planId'] ?? $subscription['plan_id'] ?? null;
+                if (is_string($planId) && trim($planId) !== '') {
+                    return $planId;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private function recordPlanDecision(
+        string $businessId,
+        ?string $storeId,
+        string $planId,
+        string $actor,
+        string $reason,
+        array $metadata = []
+    ): void {
+        try {
+            $this->context->getConn()->insert(
+                'subscription_plan_audit',
+                [
+                    'business_id' => $businessId,
+                    'store_id' => $storeId,
+                    'plan_id' => $planId,
+                    'decided_by' => $actor,
+                    'decision_reason' => $reason,
+                    'metadata' => Format::jsonObject($metadata),
+                ]
+            );
+        } catch (Throwable $e) {
+            $this->context->getLog()->warning(
+                sprintf(
+                    'Failed to record subscription decision for business %s store %s: %s',
+                    $businessId,
+                    $storeId ?? 'n/a',
+                    $e->getMessage()
+                )
+            );
+        }
+    }
+
+    private function normalizeTrialExpiry(mixed $value): ?DateTimeImmutable
+    {
+        if ($value instanceof DateTimeInterface) {
+            return DateTimeImmutable::createFromInterface($value);
+        }
+
+        if (is_string($value)) {
+            $trimmed = trim($value);
+            if ($trimmed === '') {
+                return null;
+            }
+
+            try {
+                return new DateTimeImmutable($trimmed);
+            } catch (Throwable) {
+                return null;
+            }
+        }
+
+        return null;
     }
 
     private function normalizePlanParameter(mixed $value): ?string

--- a/app/Services/SubscriptionService.php
+++ b/app/Services/SubscriptionService.php
@@ -11,6 +11,7 @@ use DateInterval;
 //use DateMalformedIntervalStringException;
 //use DateMalformedStringException;
 use DateTime;
+use DateTimeInterface;
 use DateTimeZone;
 use Exception;
 use InvalidArgumentException;
@@ -28,7 +29,7 @@ use function str_starts_with;
 class SubscriptionService
 {
     public const POYNT_BILLING_BASE = 'https://billing.poynt.net/organizations';
-    private const DEFAULT_TRIAL_DAYS = 14;
+    public const DEFAULT_TRIAL_DAYS = 14;
     private Context $context;
     private ClientInterface $http;
     private ?string $businessId = null;
@@ -297,13 +298,15 @@ class SubscriptionService
      * @param string $businessId Poynt business ID
      * @param string $storeId Poynt store ID
      * @param string $trialPlanId Your local “free trial” plan identifier (e.g. "free_trial")
+     * @param DateTimeInterface|null $trialEndsAt Optional trial end timestamp (UTC)
      *
      * @return string  The generated subscription_id (UUID)
      */
     public function startFreeTrial(
         string $businessId,
         string $storeId,
-        string $trialPlanId = 'free_trial'
+        string $trialPlanId = 'free_trial',
+        ?DateTimeInterface $trialEndsAt = null
     ): string {
         // 1) Generate a new UUID for subscription_id
         $subscriptionId = Uuid::uuid4()->toString();
@@ -311,7 +314,9 @@ class SubscriptionService
         // 2) Compute trial start/end timestamps (UTC)
         $trialDays = self::DEFAULT_TRIAL_DAYS;
         $now = new DateTime('now', new DateTimeZone('UTC'));
-        $trialEnd = (clone $now)->add(new DateInterval("P{$trialDays}D"));
+        $trialEnd = $trialEndsAt instanceof DateTimeInterface
+            ? new DateTime($trialEndsAt->format('Y-m-d H:i:sP'), new DateTimeZone('UTC'))
+            : (clone $now)->add(new DateInterval("P{$trialDays}D"));
 
         // 3) Insert into local subscription table as “trial”
         $sql = <<<SQL

--- a/database/migrations/20251210000000_alter_business_add_trial_fields.sql
+++ b/database/migrations/20251210000000_alter_business_add_trial_fields.sql
@@ -1,0 +1,21 @@
+-- Track business-level trials and plan decisions
+ALTER TABLE business
+    ADD COLUMN IF NOT EXISTS trial_eligible BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN IF NOT EXISTS trial_expires_at TIMESTAMPTZ;
+
+UPDATE business
+SET trial_eligible = COALESCE(trial_eligible, FALSE);
+
+CREATE TABLE IF NOT EXISTS subscription_plan_audit (
+    id SERIAL PRIMARY KEY,
+    business_id VARCHAR(255) NOT NULL,
+    store_id VARCHAR(255),
+    plan_id VARCHAR(255) NOT NULL,
+    decided_by VARCHAR(255) NOT NULL,
+    decision_reason TEXT NOT NULL,
+    decided_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    metadata JSONB NOT NULL DEFAULT '{}'::jsonb
+);
+
+CREATE INDEX IF NOT EXISTS idx_subscription_plan_audit_business ON subscription_plan_audit (business_id);
+CREATE INDEX IF NOT EXISTS idx_subscription_plan_audit_store ON subscription_plan_audit (store_id);


### PR DESCRIPTION
## Summary
- add business-level trial tracking columns and subscription decision audit table
- initialize business trial windows during onboarding and align store subscriptions with business trial state
- log plan choices for transparency and reuse shared trial duration in subscription handling

## Testing
- php -l app/Services/CallbackService.php
- php -l app/Services/BusinessService.php
- php -l app/Services/SubscriptionService.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69381040c05483299ef1d8040f126358)