### PR TITLE
Move subscription webhook registration to manual script

### DIFF
--- a/app/Modules/OAuth/PoyntOAuthHandler.php
+++ b/app/Modules/OAuth/PoyntOAuthHandler.php
@@ -122,41 +122,41 @@ class PoyntOAuthHandler implements OAuthHandlerInterface
         {
             $webhookService = new WebhookService($this->context, $this->businessId);
 
-            // 1) APPLICATION_SUBSCRIPTION_*
-            $webhookService->registerSubscriptionWebhooks($merchantToken);
+            // APPLICATION_SUBSCRIPTION_* hooks are registered separately via
+            // scripts/register_subscription_webhooks.php for production rollouts.
 
-            // 2) BUSINESS_USER_*
+            // BUSINESS_USER_*
             // TODO
             $webhookService->registerBusinessUserWebhooks($merchantToken);
 
-            // 3) CATALOG_*
+            // CATALOG_*
             $webhookService->registerCatalogWebhooks($merchantToken);
 
-            // 4) CATEGORY_*
+            // CATEGORY_*
             $webhookService->registerCategoryWebhooks($merchantToken);
 
-            // 5) INVENTORY_UPDATED (only one event under this prefix)
+            // INVENTORY_UPDATED (only one event under this prefix)
             $webhookService->registerInventoryWebhook($merchantToken);
 
-            // 6) ORDER_*
+            // ORDER_*
             $webhookService->registerOrderWebhooks($merchantToken);
 
-            // 7) ORDER_ITEM_*
+            // ORDER_ITEM_*
             $webhookService->registerOrderItemWebhooks($merchantToken);
 
-            // 8) PRODUCT_*
+            // PRODUCT_*
             $webhookService->registerProductWebhooks($merchantToken);
 
-            // 9) STORE_*
+            // STORE_*
             $webhookService->registerStoreWebhooks($merchantToken);
 
-            // 10) TAX_*
+            // TAX_*
             $webhookService->registerTaxWebhooks($merchantToken);
 
-            // 11) TRANSACTION_*
+            // TRANSACTION_*
             $webhookService->registerTransactionWebhooks($merchantToken);
 
-            // 12) USER_*
+            // USER_*
             // TODO
             $webhookService->registerUserWebhooks($merchantToken);
         }

--- a/scripts/register_subscription_webhooks.php
+++ b/scripts/register_subscription_webhooks.php
@@ -1,0 +1,81 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+use App\Config\ConfigApp;
+use App\Config\ConfigDatabase;
+use App\Core\Api;
+use App\Core\Context;
+use App\Http\GuzzleClientFactory;
+use App\Services\Support\LoggerFactory;
+use App\Services\TokenService;
+use App\Services\WebhookService;
+use Doctrine\DBAL\DriverManager;
+use Throwable;
+
+require_once __DIR__ . '/../public/bootstrap.php';
+
+$options = getopt('', ['business:']);
+
+if (!isset($options['business']) || $options['business'] === '') {
+    fwrite(STDERR, "Usage: php scripts/register_subscription_webhooks.php --business=<BUSINESS_ID>\n");
+
+    exit(1);
+}
+
+$businessId = $options['business'];
+
+$connectionParams = [
+    'driver' => 'pdo_pgsql',
+    'host' => ConfigDatabase::$host,
+    'port' => ConfigDatabase::$port,
+    'dbname' => ConfigDatabase::$database,
+    'user' => ConfigDatabase::$username,
+    'password' => ConfigDatabase::$password,
+    'charset' => ConfigDatabase::$charset,
+];
+
+$conn = DriverManager::getConnection($connectionParams);
+$conn->executeStatement("SET TIME ZONE '" . ConfigApp::$timezone . "'");
+
+$logConnection = DriverManager::getConnection($connectionParams);
+$logConnection->executeStatement("SET TIME ZONE '" . ConfigApp::$timezone . "'");
+
+[$log, $requestId] = LoggerFactory::create($conn, $logConnection);
+
+$api = new Api('', $log, $requestId);
+$httpClientFactory = new GuzzleClientFactory();
+$context = new Context($api, $conn, $log, $httpClientFactory);
+
+$tokenService = new TokenService($context);
+$merchantToken = null;
+
+try {
+    $merchantToken = $tokenService->getMerchantToken($businessId);
+} catch (Throwable $e) {
+    $log->error(
+        sprintf('Failed to retrieve merchant token for business %s: %s', $businessId, $e->getMessage()),
+        ['exception' => $e]
+    );
+}
+
+if (!is_string($merchantToken) || $merchantToken === '') {
+    fwrite(STDERR, sprintf("Missing merchant token for business %s.\n", $businessId));
+
+    exit(1);
+}
+
+$webhookService = new WebhookService($context, $businessId);
+
+try {
+    $webhookService->registerSubscriptionWebhooks($merchantToken);
+    fwrite(STDOUT, "Subscription webhooks registered.\n");
+} catch (Throwable $e) {
+    $log->error(
+        sprintf('Failed to register subscription webhooks for business %s: %s', $businessId, $e->getMessage()),
+        ['exception' => $e]
+    );
+
+    exit(1);
+}


### PR DESCRIPTION
## Summary
- stop registering APPLICATION_SUBSCRIPTION_* hooks during the default OAuth webhook setup
- add a standalone script to register subscription webhooks manually with an existing merchant token

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693897b557c0832988e495c6d7314c97)