### PR TITLE
Use app access token for merchant token exchange

### DIFF
--- a/app/Modules/OAuth/PoyntOAuthHandler.php
+++ b/app/Modules/OAuth/PoyntOAuthHandler.php
@@ -74,7 +74,11 @@ class PoyntOAuthHandler implements OAuthHandlerInterface
         }
 
         try {
-            $merchantAccessToken = $oauthService->exchangeAuthCodeForMerchantToken($code, ConfigApp::$redirectUri);
+            $merchantAccessToken = $oauthService->exchangeAuthCodeForMerchantToken(
+                $code,
+                ConfigApp::$redirectUri,
+                is_array($appAccessToken) ? ($appAccessToken['accessToken'] ?? null) : null
+            );
         } catch (\Exception $e) {
             $this->context->getLog()->error("Error: " . $e->getMessage());
             return [
@@ -229,7 +233,13 @@ class PoyntOAuthHandler implements OAuthHandlerInterface
 
         try {
             $oauthService = new OAuthService($this->context);
-            $token = $oauthService->exchangeAuthCodeForMerchantToken($code, ConfigApp::$redirectUri);
+            $appAccessToken = $oauthService->exchangeJwtForToken();
+
+            $token = $oauthService->exchangeAuthCodeForMerchantToken(
+                $code,
+                ConfigApp::$redirectUri,
+                is_array($appAccessToken) ? ($appAccessToken['accessToken'] ?? null) : null
+            );
             return [
                 'success' => true,
                 'data' => $token,

--- a/app/Services/OAuthService.php
+++ b/app/Services/OAuthService.php
@@ -92,10 +92,11 @@ class OAuthService {
     /**
      * @param string $authCode
      * @param string $redirectUri
+     * @param string|null $appAccessToken
      * @return mixed|void|null
      * @throws GuzzleException
      */
-    public function exchangeAuthCodeForMerchantToken(string $authCode, string $redirectUri)
+    public function exchangeAuthCodeForMerchantToken(string $authCode, string $redirectUri, ?string $appAccessToken = null)
     {
         // 1. Load private key
         $basePath = dirname(__DIR__, 2);
@@ -128,11 +129,13 @@ class OAuthService {
 
         // 3. Send POST request to exchange code for Merchant Access Token
         try {
+            $authorizationToken = $appAccessToken ?? $jwt;
+
             $response = $this->httpClient->post(self::POYNT_ENDPOINT_TOKEN, [
                 'headers' => [
                     'Content-Type'  => 'application/x-www-form-urlencoded',
                     'api-version'   => '1.2',
-                    'Authorization' => 'Bearer ' . $jwt,
+                    'Authorization' => 'Bearer ' . $authorizationToken,
                 ],
                 'form_params' => [
                     'grant_type'   => 'authorization_code',


### PR DESCRIPTION
## Summary
- pass the app access token when exchanging the authorization code for a merchant token
- request a fresh app token in merchant token flows so the Authorization header is valid for Poynt

## Testing
- composer install --no-interaction *(fails: network restrictions when cloning GitHub dependencies)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69396c7db7bc83298e937c6af9cfa784)