### PR TITLE
Use app JWT when exchanging authorization codes

### DIFF
--- a/app/Services/OAuthService.php
+++ b/app/Services/OAuthService.php
@@ -93,7 +93,7 @@ class OAuthService {
     /**
      * @param string $authCode
      * @param string $redirectUri
-     * @param string|null $appAccessToken
+     * @param string|null $appAccessToken Optional pre-fetched app token (retained for API compatibility).
      * @return mixed|void|null
      * @throws GuzzleException
      */
@@ -130,7 +130,11 @@ class OAuthService {
 
         // 3. Send POST request to exchange code for Merchant Access Token
         try {
-            $authorizationToken = $appAccessToken ?? $jwt;
+            // The authorization_code grant must be authorized by an application issuer.
+            // Using the self-signed JWT ensures the issuer is `urn:aid:<APP_ID>` instead
+            // of a previously issued token (issuer `https://services.poynt.net`) that
+            // would be rejected with INVALID_PARAMETER.
+            $authorizationToken = $jwt;
 
             $response = $this->httpClient->post(self::POYNT_ENDPOINT_TOKEN, [
                 'headers' => [


### PR DESCRIPTION
## Summary
- use the self-signed application JWT for authorization when exchanging codes for merchant tokens to avoid INVALID_PARAMETER issuer errors
- note optional app token parameter for compatibility

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69398da5a0fc8329a94fd51e22da96bf)