### PR TITLE
Fix merchant token exchange JWT handling

### DIFF
--- a/app/Services/OAuthService.php
+++ b/app/Services/OAuthService.php
@@ -134,11 +134,12 @@ class OAuthService {
      */
     public function exchangeAuthCodeForMerchantToken(
         string $authCode,
-        string $redirectUri
+        string $redirectUri,
+        ?string $appAccessToken = null
     ): ?array {
         try {
             // 1. Self-signed JWT
-            $jwt = $this->generateSelfSignedJwt();
+            $jwt = $appAccessToken ?? $this->generateSelfSignedJwt();
 
             // 2. POST na /token s grant_type=authorization_code
             $response = $this->httpClient->post(self::POYNT_ENDPOINT_TOKEN, [
@@ -151,7 +152,7 @@ class OAuthService {
                 'form_params' => [
                     'grant_type'   => 'authorization_code',
                     'redirect_uri' => $redirectUri,
-                    'client_id'    => ConfigApp::$appId,
+                    'client_id'    => 'urn:aid:' . ConfigApp::$appId,
                     'code'         => $authCode,
                 ],
             ]);


### PR DESCRIPTION
## Summary
- allow passing an app access token when exchanging an auth code for a merchant token
- send the Poynt token exchange request with the expected urn:aid client identifier

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939a9c3fd0483298730ff47c54b40b3)