### PR TITLE
Ensure merchant token exchange uses application issuer

### DIFF
--- a/app/Services/OAuthService.php
+++ b/app/Services/OAuthService.php
@@ -138,8 +138,7 @@ class OAuthService {
         ?string $appAccessToken = null
     ): ?array {
         try {
-            // 1. Self-signed JWT
-            $jwt = $appAccessToken ?? $this->generateSelfSignedJwt();
+            $jwt = $this->resolveAuthorizationCodeToken($appAccessToken);
 
             // 2. POST na /token s grant_type=authorization_code
             $response = $this->httpClient->post(self::POYNT_ENDPOINT_TOKEN, [
@@ -281,6 +280,66 @@ class OAuthService {
         }
 
         return null;
+    }
+
+
+    private function resolveAuthorizationCodeToken(?string $appAccessToken): string
+    {
+        $expectedIssuer = 'urn:aid:' . ConfigApp::$appId;
+
+        if ($appAccessToken !== null) {
+            $issuer = $this->extractIssuerFromJwt($appAccessToken);
+
+            if ($issuer === $expectedIssuer) {
+                return $appAccessToken;
+            }
+
+            $logMessage = $issuer === null
+                ? 'Unable to determine issuer for provided app access token; using self-signed JWT for authorization_code grant.'
+                : sprintf(
+                    'Ignoring app access token issued by %s; using self-signed JWT for authorization_code grant.',
+                    $issuer
+                );
+
+            $this->context->getLog()->info($logMessage);
+        }
+
+        return $this->generateSelfSignedJwt();
+    }
+
+
+    private function extractIssuerFromJwt(string $jwt): ?string
+    {
+        $segments = explode('.', $jwt);
+
+        if (count($segments) < 2) {
+            return null;
+        }
+
+        $payload = $this->base64UrlDecode($segments[1]);
+        if ($payload === false) {
+            return null;
+        }
+
+        $claims = json_decode($payload, true);
+
+        if (!is_array($claims) || !isset($claims['iss'])) {
+            return null;
+        }
+
+        return (string) $claims['iss'];
+    }
+
+
+    private function base64UrlDecode(string $data): string|false
+    {
+        $padding = strlen($data) % 4;
+
+        if ($padding > 0) {
+            $data .= str_repeat('=', 4 - $padding);
+        }
+
+        return base64_decode(strtr($data, '-_', '+/'));
     }
 }
 


### PR DESCRIPTION
## Summary
- ensure authorization_code exchanges default to a self-signed application JWT
- log and ignore provided tokens whose issuer is not the application URN

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939ae440abc8329833e9544696816b0)